### PR TITLE
Add a GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+
+name: Build
+on: [push, pull_request]
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: Autogen
+        run: ./autogen.sh
+        
+      - name: Configure
+        run: ./configure --enable-jit --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32
+        
+      - name: Build
+        run: make
+        
+      - name: Test
+        run: make check


### PR DESCRIPTION
Let's inaugurate the pull requests 🙂 

Here's a suggestion: you may use GitHub Actions for continuous integration. If you merge this, each time you push or receive a pull request, GitHub will build and test the code, then report success or failure with a ✔️ or ❌ sign on the commit or PR.

I wrote a very basic workflow (see the YAML file, it is pretty self-explanatory), but you may expand this to include more config options or combinations of options.

You can also see an [example of a run in my fork](https://github.com/ltrzesniewski/pcre2/runs/3644688236?check_suite_focus=true), or consult the [documentation](https://docs.github.com/en/actions).