### PR TITLE
Fixed race condition that occurs when initializing the executable_allocator_is_working variable in the pcre2_jit_compile function

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -14384,7 +14384,7 @@ pcre2_jit_compile(pcre2_code *code, uint32_t options)
 pcre2_real_code *re = (pcre2_real_code *)code;
 #ifdef SUPPORT_JIT
 executable_functions *functions;
-static int executable_allocator_is_working = 0;
+static int executable_allocator_is_working = -1;
 #endif
 
 if (code == NULL)
@@ -14447,23 +14447,21 @@ return PCRE2_ERROR_JIT_BADOPTION;
 
 if ((re->flags & PCRE2_NOJIT) != 0) return 0;
 
-if (executable_allocator_is_working == 0)
+if (executable_allocator_is_working == -1)
   {
   /* Checks whether the executable allocator is working. This check
      might run multiple times in multi-threaded environments, but the
      result should not be affected by it. */
   void *ptr = SLJIT_MALLOC_EXEC(32, NULL);
-
-  executable_allocator_is_working = -1;
-
   if (ptr != NULL)
     {
     SLJIT_FREE_EXEC(((sljit_u8*)(ptr)) + SLJIT_EXEC_OFFSET(ptr), NULL);
     executable_allocator_is_working = 1;
     }
+  else executable_allocator_is_working = 0;
   }
 
-if (executable_allocator_is_working < 0)
+if (!executable_allocator_is_working)
   return PCRE2_ERROR_NOMEMORY;
 
 if ((re->overall_options & PCRE2_MATCH_INVALID_UTF) != 0)


### PR DESCRIPTION
### The error fixed by this PR

If `pcre2_jit_compiler` is called simultaneously for the first time from 2 (or more) threads, then one of the calls may fail with the `PCRE2_ERROR_NOMEMORY` error.
