### PR TITLE
pcre2_compile: make errorcode parameter optional

### DIFF
--- a/doc/pcre2_compile.3
+++ b/doc/pcre2_compile.3
@@ -21,7 +21,7 @@ arguments are:
   \fIpattern\fP       A string containing expression to be compiled
   \fIlength\fP        The length of the string or PCRE2_ZERO_TERMINATED
   \fIoptions\fP       Option bits
-  \fIerrorcode\fP     Where to put an error code
+  \fIerrorcode\fP     Where to put an error code or NULL
   \fIerroffset\fP     Where to put an error offset
   \fIccontext\fP      Pointer to a compile context or NULL
 .sp

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -9812,17 +9812,17 @@ PCRE2_UCHAR *cworkspace = (PCRE2_UCHAR *)c16workspace;
 
 /* -------------- Check arguments and set up the pattern ----------------- */
 
-/* There must be error code and offset pointers. */
+/* There must be an error offset pointer. */
 
-if (errorptr == NULL || erroroffset == NULL) return NULL;
-*errorptr = ERR0;
+if (erroroffset == NULL) return NULL;
+if (errorptr) *errorptr = ERR0;
 *erroroffset = 0;
 
 /* There must be a pattern! */
 
 if (pattern == NULL)
   {
-  *errorptr = ERR16;
+  if (errorptr) *errorptr = ERR16;
   return NULL;
   }
 
@@ -9840,7 +9840,7 @@ if ((options & PCRE2_MATCH_INVALID_UTF) != 0) options |= PCRE2_UTF;
 if ((options & ~PUBLIC_COMPILE_OPTIONS) != 0 ||
     (ccontext->extra_options & ~PUBLIC_COMPILE_EXTRA_OPTIONS) != 0)
   {
-  *errorptr = ERR17;
+  if (errorptr) *errorptr = ERR17;
   return NULL;
   }
 
@@ -9848,7 +9848,7 @@ if ((options & PCRE2_LITERAL) != 0 &&
     ((options & ~PUBLIC_LITERAL_COMPILE_OPTIONS) != 0 ||
      (ccontext->extra_options & ~PUBLIC_LITERAL_COMPILE_EXTRA_OPTIONS) != 0))
   {
-  *errorptr = ERR92;
+  if (errorptr) *errorptr = ERR92;
   return NULL;
   }
 
@@ -9860,7 +9860,7 @@ if ((zero_terminated = (patlen == PCRE2_ZERO_TERMINATED)))
 
 if (patlen > ccontext->max_pattern_length)
   {
-  *errorptr = ERR88;
+  if (errorptr) *errorptr = ERR88;
   return NULL;
   }
 
@@ -10144,7 +10144,7 @@ if (parsed_size_needed >= PARSED_PATTERN_DEFAULT_SIZE)
     (parsed_size_needed + 1) * sizeof(uint32_t), ccontext->memctl.memory_data);
   if (heap_parsed_pattern == NULL)
     {
-    *errorptr = ERR21;
+    if (errorptr) *errorptr = ERR21;
     goto EXIT;
     }
   cb.parsed_pattern = heap_parsed_pattern;
@@ -10614,7 +10614,7 @@ HAD_EARLY_ERROR:
 *erroroffset = ptr - pattern;
 
 HAD_ERROR:
-*errorptr = errorcode;
+if (errorptr) *errorptr = errorcode;
 pcre2_code_free(re);
 re = NULL;
 goto EXIT;

--- a/src/pcre2_jit_test.c
+++ b/src/pcre2_jit_test.c
@@ -1998,7 +1998,7 @@ static int run_invalid_utf8_test(const struct invalid_utf8_regression_test_case 
 	int pattern_index, int i, pcre2_compile_context_8 *ccontext, pcre2_match_data_8 *mdata)
 {
 	pcre2_code_8 *code;
-	int result, errorcode;
+	int result;
 	PCRE2_SIZE length, erroroffset;
 	PCRE2_SIZE *ovector = pcre2_get_ovector_pointer_8(mdata);
 
@@ -2006,7 +2006,7 @@ static int run_invalid_utf8_test(const struct invalid_utf8_regression_test_case 
 		return 1;
 
 	code = pcre2_compile_8((PCRE2_UCHAR8*)current->pattern[i], PCRE2_ZERO_TERMINATED,
-		current->compile_options, &errorcode, &erroroffset, ccontext);
+		current->compile_options, NULL, &erroroffset, ccontext);
 
 	if (!code) {
 		printf("Pattern[%d:0] cannot be compiled. Error offset: %d\n", pattern_index, (int)erroroffset);
@@ -2207,7 +2207,7 @@ static int run_invalid_utf16_test(const struct invalid_utf16_regression_test_cas
 	int pattern_index, int i, pcre2_compile_context_16 *ccontext, pcre2_match_data_16 *mdata)
 {
 	pcre2_code_16 *code;
-	int result, errorcode;
+	int result;
 	PCRE2_SIZE length, erroroffset;
 	const PCRE2_UCHAR16 *input;
 	PCRE2_SIZE *ovector = pcre2_get_ovector_pointer_16(mdata);
@@ -2216,7 +2216,7 @@ static int run_invalid_utf16_test(const struct invalid_utf16_regression_test_cas
 		return 1;
 
 	code = pcre2_compile_16(current->pattern[i], PCRE2_ZERO_TERMINATED,
-		current->compile_options, &errorcode, &erroroffset, ccontext);
+		current->compile_options, NULL, &erroroffset, ccontext);
 
 	if (!code) {
 		printf("Pattern[%d:0] cannot be compiled. Error offset: %d\n", pattern_index, (int)erroroffset);
@@ -2394,7 +2394,7 @@ static int run_invalid_utf32_test(const struct invalid_utf32_regression_test_cas
 	int pattern_index, int i, pcre2_compile_context_32 *ccontext, pcre2_match_data_32 *mdata)
 {
 	pcre2_code_32 *code;
-	int result, errorcode;
+	int result;
 	PCRE2_SIZE length, erroroffset;
 	const PCRE2_UCHAR32 *input;
 	PCRE2_SIZE *ovector = pcre2_get_ovector_pointer_32(mdata);
@@ -2403,7 +2403,7 @@ static int run_invalid_utf32_test(const struct invalid_utf32_regression_test_cas
 		return 1;
 
 	code = pcre2_compile_32(current->pattern[i], PCRE2_ZERO_TERMINATED,
-		current->compile_options, &errorcode, &erroroffset, ccontext);
+		current->compile_options, NULL, &erroroffset, ccontext);
 
 	if (!code) {
 		printf("Pattern[%d:0] cannot be compiled. Error offset: %d\n", pattern_index, (int)erroroffset);


### PR DESCRIPTION
Not sure why the interface was designed this way, but it would seem that it was evolved from the one available in the original PCRE and that was using instead a text buffer to hold the error message directly.

While the use of both and error code and an error offset is useful and might be encouraged, shouldn't be required IMHO so this change tries to loosen that rule by allowing a NULL error, and showing how it will be used with some code from our own codebase.

With the risk of starting a bike shedding discussion, I would assume that making the offset ALSO optional might be useful, but had punted that change for the future once it would be discussed better.

There is also the posibility of an ABI breaking change that would either consolidate this 2 values (ex: using the offset with negative values of a ssize_t) for errors like is done in other functions, or creating an opaque parameter to replace this two but it is obviously not something to consider until pcre3