### PR TITLE
Fix integer promotion causing a warning in MSVC

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -5886,7 +5886,7 @@ static BOOL check_fast_forward_char_pair_simd(compiler_common *common, fast_forw
       while (j < i)
         {
         b_pri = chars[j].last_count;
-        if (b_pri > 2 && a_pri + b_pri >= max_pri)
+        if (b_pri > 2 && (sljit_u32)a_pri + (sljit_u32)b_pri >= max_pri)
           {
           b1 = chars[j].chars[0];
           b2 = chars[j].chars[1];


### PR DESCRIPTION
This continues the discussion from #105.

When compiled on x86, MSVC generates the following warning (which becomes an error when the _Treat Warnings As Errors_ option is used):

> pcre2_jit_compile.c(5889,40): warning C4018: '>=': signed/unsigned mismatch

on the following line:

https://github.com/PCRE2Project/pcre2/blob/b52d055d1b8feb6e56804c2062de65d50a5601e2/src/pcre2_jit_compile.c#L5889

This warning seems wrong at first, as `a_pri` and `b_pri` are of type `PCRE2_UCHAR`, while `max_pri` is of type `sljit_u32`, so both operands are supposed to be unsigned.

Turns out, [implicit conversion rules](https://en.cppreference.com/w/c/language/conversion) in C are... complicated. The way I understand them, the `a_pri + b_pri` expression is promoted to type `int`, which causes the signed/unsigned mismatch on `>=`.

Here are the relevant quotes from the _Integer promotions_ section:

> Integer promotion is the implicit conversion of a value of any integer type with _rank_ less or equal to rank of `int` or of a [bit field](https://en.cppreference.com/w/c/language/bit_field) of type \_Bool, int, signed int, unsigned int, to the value of type `int` or `unsigned int`
> 
> If `int` can represent the entire range of values of the original type (or the range of values of the original bit field), the value is converted to type `int`. Otherwise the value is converted to `unsigned int`.

> Note: integer promotions are applied only:  
> [...]
> to the operand of the unary arithmetic operators + and -  
> [...]

When applied to the `a_pri + b_pri` expression:

- In the 8-bit and 16-bit versions of the library, the _rank_ of `PCRE2_UCHAR` is less than the _rank_ of `int` (see the definition of _rank_ in the linked article), and equal in the 32-bit version, therefore the integer promotion rules apply.

- In the 8-bit and 16-bit versions, `int` can represent the entire range of values of `PCRE2_UCHAR`, therefore the expression type gets promoted to type `int` and the warning is raised.

- In the 32-bit version, `int` cannot represent the entire range of values of `PCRE2_UCHAR`, therefore `unsigned int` is used and no warning is raised.

I'm not sure why the warning is not raised on x64 though. Since Windows uses the LLP64 data model, I believe it should have raised the same warning as on x86, but I didn't dig deeper.

This PR casts `a_pri` to `sljit_u32`, which forces the expression to an unsigned type. Note that this is the type of `max_pri`, to which the addition is assigned later on.
