### PR TITLE
Add `pcre2_ucptables.c` to non-autotools build docs

### DIFF
--- a/NON-AUTOTOOLS-BUILD
+++ b/NON-AUTOTOOLS-BUILD
@@ -121,6 +121,7 @@ environment, for example.
        pcre2_substring.c
        pcre2_tables.c
        pcre2_ucd.c
+       pcre2_ucptables.c
        pcre2_valid_utf.c
        pcre2_xclass.c
 


### PR DESCRIPTION
This seems needed following https://github.com/PCRE2Project/pcre2/commit/4514ddd2a2a002214caf46c05326af3c1fe302af.