### PR TITLE
Provide pcre2_match_data_create_with_frames() to avoid start stack frames.

### DIFF
--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -673,6 +673,8 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL pcre2_match_data PCRE2_CALL_CONVENTION \
   *pcre2_match_data_create(uint32_t, pcre2_general_context *); \
 PCRE2_EXP_DECL pcre2_match_data PCRE2_CALL_CONVENTION \
+  *pcre2_match_data_create_with_frames(uint32_t, pcre2_general_context *); \
+PCRE2_EXP_DECL pcre2_match_data PCRE2_CALL_CONVENTION \
   *pcre2_match_data_create_from_pattern(const pcre2_code *, \
     pcre2_general_context *); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
@@ -868,6 +870,7 @@ pcre2_compile are called by application code. */
 #define pcre2_match_context_create            PCRE2_SUFFIX(pcre2_match_context_create_)
 #define pcre2_match_context_free              PCRE2_SUFFIX(pcre2_match_context_free_)
 #define pcre2_match_data_create               PCRE2_SUFFIX(pcre2_match_data_create_)
+#define pcre2_match_data_create_with_frames   PCRE2_SUFFIX(pcre2_match_data_create_with_frames_)
 #define pcre2_match_data_create_from_pattern  PCRE2_SUFFIX(pcre2_match_data_create_from_pattern_)
 #define pcre2_match_data_free                 PCRE2_SUFFIX(pcre2_match_data_free_)
 #define pcre2_pattern_convert                 PCRE2_SUFFIX(pcre2_pattern_convert_)

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -673,6 +673,8 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL pcre2_match_data PCRE2_CALL_CONVENTION \
   *pcre2_match_data_create(uint32_t, pcre2_general_context *); \
 PCRE2_EXP_DECL pcre2_match_data PCRE2_CALL_CONVENTION \
+  *pcre2_match_data_create_with_frames(uint32_t, pcre2_general_context *); \
+PCRE2_EXP_DECL pcre2_match_data PCRE2_CALL_CONVENTION \
   *pcre2_match_data_create_from_pattern(const pcre2_code *, \
     pcre2_general_context *); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
@@ -868,6 +870,7 @@ pcre2_compile are called by application code. */
 #define pcre2_match_context_create            PCRE2_SUFFIX(pcre2_match_context_create_)
 #define pcre2_match_context_free              PCRE2_SUFFIX(pcre2_match_context_free_)
 #define pcre2_match_data_create               PCRE2_SUFFIX(pcre2_match_data_create_)
+#define pcre2_match_data_create_with_frames   PCRE2_SUFFIX(pcre2_match_data_create_with_frames_)
 #define pcre2_match_data_create_from_pattern  PCRE2_SUFFIX(pcre2_match_data_create_from_pattern_)
 #define pcre2_match_data_free                 PCRE2_SUFFIX(pcre2_match_data_free_)
 #define pcre2_pattern_convert                 PCRE2_SUFFIX(pcre2_pattern_convert_)

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -615,6 +615,8 @@ here.) */
 #undef  LOOKBEHIND_MAX
 #define LOOKBEHIND_MAX UINT16_MAX
 
+struct heapframe; /* see below */
+
 typedef struct pcre2_real_code {
   pcre2_memctl memctl;            /* Memory control fields */
   const uint8_t *tables;          /* The character tables */
@@ -661,6 +663,7 @@ typedef struct pcre2_real_match_data {
   uint8_t          flags;         /* Various flags */
   uint16_t         oveccount;     /* Number of pairs */
   int              rc;            /* The return code from the match */
+  struct heapframe *start_frames; /* Initial heap frames (NULL for stack) */
   PCRE2_SIZE       ovector[131072]; /* Must be last in the structure */
 } pcre2_real_match_data;
 

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -1248,6 +1248,14 @@ are supported. */
   else \
     G(a,32) = pcre2_match_data_create_32(b,c)
 
+#define PCRE2_MATCH_DATA_CREATE_WITH_FRAMES(a,b,c) \
+  if (test_mode == PCRE8_MODE) \
+    G(a,8) = pcre2_match_data_create_with_frames_8(b,c); \
+  else if (test_mode == PCRE16_MODE) \
+    G(a,16) = pcre2_match_data_create_with_frames_16(b,c); \
+  else \
+    G(a,32) = pcre2_match_data_create_with_frames_32(b,c)
+
 #define PCRE2_MATCH_DATA_CREATE_FROM_PATTERN(a,b,c) \
   if (test_mode == PCRE8_MODE) \
     G(a,8) = pcre2_match_data_create_from_pattern_8(G(b,8),c); \
@@ -1766,6 +1774,12 @@ the three different cases. */
   else \
     G(a,BITTWO) = G(pcre2_match_data_create_,BITTWO)(b,c)
 
+#define PCRE2_MATCH_DATA_CREATE_WITH_FRAMES(a,b,c) \
+  if (test_mode == G(G(PCRE,BITONE),_MODE)) \
+    G(a,BITONE) = G(pcre2_match_data_create_with_frames_,BITONE)(b,c); \
+  else \
+    G(a,BITTWO) = G(pcre2_match_data_create_with_frames_,BITTWO)(b,c)
+
 #define PCRE2_MATCH_DATA_CREATE_FROM_PATTERN(a,b,c) \
   if (test_mode == G(G(PCRE,BITONE),_MODE)) \
     G(a,BITONE) = G(pcre2_match_data_create_from_pattern_,BITONE)(G(b,BITONE),c); \
@@ -2071,6 +2085,8 @@ the three different cases. */
 #define PCRE2_MATCH(a,b,c,d,e,f,g,h) \
   a = pcre2_match_8(G(b,8),(PCRE2_SPTR8)c,d,e,f,G(g,8),h)
 #define PCRE2_MATCH_DATA_CREATE(a,b,c) G(a,8) = pcre2_match_data_create_8(b,c)
+#define PCRE2_MATCH_DATA_CREATE_WITH_FRAMES(a,b,c) \
+  G(a,8) = pcre2_match_data_create_with_frames_8(b,c)
 #define PCRE2_MATCH_DATA_CREATE_FROM_PATTERN(a,b,c) \
   G(a,8) = pcre2_match_data_create_from_pattern_8(G(b,8),c)
 #define PCRE2_MATCH_DATA_FREE(a) pcre2_match_data_free_8(G(a,8))
@@ -2178,6 +2194,8 @@ the three different cases. */
 #define PCRE2_MATCH(a,b,c,d,e,f,g,h) \
   a = pcre2_match_16(G(b,16),(PCRE2_SPTR16)c,d,e,f,G(g,16),h)
 #define PCRE2_MATCH_DATA_CREATE(a,b,c) G(a,16) = pcre2_match_data_create_16(b,c)
+#define PCRE2_MATCH_DATA_CREATE_WITH_FRAMES(a,b,c) \
+  G(a,16) = pcre2_match_data_create_with_frames_16(b,c)
 #define PCRE2_MATCH_DATA_CREATE_FROM_PATTERN(a,b,c) \
   G(a,16) = pcre2_match_data_create_from_pattern_16(G(b,16),c)
 #define PCRE2_MATCH_DATA_FREE(a) pcre2_match_data_free_16(G(a,16))
@@ -2285,6 +2303,8 @@ the three different cases. */
 #define PCRE2_MATCH(a,b,c,d,e,f,g,h) \
   a = pcre2_match_32(G(b,32),(PCRE2_SPTR32)c,d,e,f,G(g,32),h)
 #define PCRE2_MATCH_DATA_CREATE(a,b,c) G(a,32) = pcre2_match_data_create_32(b,c)
+#define PCRE2_MATCH_DATA_CREATE_WITH_FRAMES(a,b,c) \
+  G(a,32) = pcre2_match_data_create_with_frames_32(b,c)
 #define PCRE2_MATCH_DATA_CREATE_FROM_PATTERN(a,b,c) \
   G(a,32) = pcre2_match_data_create_from_pattern_32(G(b,32),c)
 #define PCRE2_MATCH_DATA_FREE(a) pcre2_match_data_free_32(G(a,32))
@@ -7287,7 +7307,7 @@ else
   {
   max_oveccount = dat_datctl.oveccount;
   PCRE2_MATCH_DATA_FREE(match_data);
-  PCRE2_MATCH_DATA_CREATE(match_data, max_oveccount, NULL);
+  PCRE2_MATCH_DATA_CREATE_WITH_FRAMES(match_data, max_oveccount, NULL);
   }
 
 if (CASTVAR(void *, match_data) == NULL)
@@ -9170,7 +9190,7 @@ max_oveccount = DEFAULT_OVECCOUNT;
   G(dat_context,BITS) = G(pcre2_match_context_copy_,BITS)(G(default_dat_context,BITS)); \
   G(default_con_context,BITS) = G(pcre2_convert_context_create_,BITS)(G(general_context,BITS)); \
   G(con_context,BITS) = G(pcre2_convert_context_copy_,BITS)(G(default_con_context,BITS)); \
-  G(match_data,BITS) = G(pcre2_match_data_create_,BITS)(max_oveccount, G(general_context,BITS))
+  G(match_data,BITS) = G(pcre2_match_data_create_with_frames_,BITS)(max_oveccount, G(general_context,BITS))
 
 #define CONTEXTTESTS \
   (void)G(pcre2_set_compile_extra_options_,BITS)(G(pat_context,BITS), 0); \


### PR DESCRIPTION
pcre2_match() uses START_FRAMES_SIZE (20KiB) of stack space for the start
(initial) frames, which may be too large for systems with small per-thread
stacks (e.g. 128KiB by default on Alpine Linux).

Provide pcre2_match_data_create_with_frames() to allow for the user to
create match_data containing context/heap allocated start frames, which
will be used by pcre2_match() if available instead of the stack frames.

* src/pcre2.h.generic, src/pcre2.h.in:
  Declare pcre2_match_data_create_with_frames().

* src/pcre2_intmodedep.h:
  Add a pointer to start_frames to struct pcre2_real_match_data, will be
  NULL if stack frames are to be used.

* src/pcre2_match_data.c:
  Provide a common match_data_create() helper to be called by all the
  pcre2_match_data_create*() functions without duplicating code.
  When called from pcre2_match_data_create_with_frames(), match_data_create()
  will allocate the start frames in (at the end of) the ovector and point
  match_data->start_frames to that.

* src/pcre2_match.c:
  Split pcre2_match() in two match_start() and match_start_on_stack()
  helpers, the former doing the usual work given some start frames, the
  latter calling the former with start frames reserved on the stack.
  pcre2_match can then call the one or the other depending on whether
  match_data->start_frames exist or not, playing some noinline/indirection
  games to do the stack allocation from match_start_on_stack() only.