### PR TITLE
Bazel and bazel central registry support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+common --experimental_enable_bzlmod
+build --incompatible_enable_cc_toolchain_resolution
+build --incompatible_strict_action_env

--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,6 @@ src/pcre2.h
 src/pcre2_chartables.c
 src/stamp-h1
 
+/bazel-*
+
 # End

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,72 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
+copy_file(
+    name = "config_h_generic",
+    src = "src/config.h.generic",
+    out = "src/config.h",
+)
+
+copy_file(
+    name = "pcre2_h_generic",
+    src = "src/pcre2.h.generic",
+    out = "src/pcre2.h",
+)
+
+copy_file(
+    name = "pcre2_chartables_c",
+    src = "src/pcre2_chartables.c.dist",
+    out = "src/pcre2_chartables.c",
+)
+
+cc_library(
+    name = "pcre2",
+    srcs = [
+        "src/pcre2_auto_possess.c",
+        "src/pcre2_compile.c",
+        "src/pcre2_config.c",
+        "src/pcre2_context.c",
+        "src/pcre2_convert.c",
+        "src/pcre2_dfa_match.c",
+        "src/pcre2_error.c",
+        "src/pcre2_extuni.c",
+        "src/pcre2_find_bracket.c",
+        "src/pcre2_maketables.c",
+        "src/pcre2_match.c",
+        "src/pcre2_match_data.c",
+        "src/pcre2_newline.c",
+        "src/pcre2_ord2utf.c",
+        "src/pcre2_pattern_info.c",
+        "src/pcre2_script_run.c",
+        "src/pcre2_serialize.c",
+        "src/pcre2_string_utils.c",
+        "src/pcre2_study.c",
+        "src/pcre2_substitute.c",
+        "src/pcre2_substring.c",
+        "src/pcre2_tables.c",
+        "src/pcre2_ucd.c",
+        "src/pcre2_ucptables.c",
+        "src/pcre2_valid_utf.c",
+        "src/pcre2_xclass.c",
+        ":pcre2_chartables_c",
+    ],
+    hdrs = glob(["src/*.h"]) + [
+        ":config_h_generic",
+        ":pcre2_h_generic",
+    ],
+    defines = [
+        "HAVE_CONFIG_H",
+        "PCRE2_CODE_UNIT_WIDTH=8",
+        "PCRE2_STATIC",
+    ],
+    includes = ["src"],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "pcre2demo",
+    srcs = ["src/pcre2demo.c"],
+    visibility = ["//visibility:public"],
+    deps = [":pcre2"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "pcre2",
+    version = "10.40",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.1")
+bazel_dep(name = "bazel_skylib", version = "1.2.1")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,1 @@
+# See MODULE.bazel


### PR DESCRIPTION
I mainly use [bazel](https://bazel.build/) as my build system and I was wondering if pcre2 would be willing to accept these files upstream to add pcre2 to the [bazel central registry](https://github.com/bazelbuild/bazel-central-registry). I _can_ write patches for the repository and submit it that way, but it is preferred to have them in the repository.

At the moment this is a minimal configuration that successfully runs the `pcre2demo`. e.g.

```sh
bazel run //:pcre2demo -- -g "\\w+" "hello world"
```
```
Match succeeded at offset 0
 0: hello
No named substrings

Match succeeded again at offset 6
 0: world
No named substrings
```

If this was accepted and submited to the bazel central registry then bazel users would only have to add the following to their `MODULE.bazel`.

```python
bazel_dep(name = "pcre2", version = "10.40")
```

And then any target that uses pcre2 would simply be added to their `deps` list.

```python
cc_library(
    name = "my_cool_library_that_uses_pcre2",
    # ...
    deps = [
        # ...
        "@pcre2",
    ],
)
```

I'm happy to add tests that cover bazel and make any other modifications you require.