### PR TITLE
CMake: move `cmake_minimum_required()` before `project()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,10 @@
 # 2021-08-28 PH increased minimum version
 # 2021-08-28 PH added test for realpath()
 
-PROJECT(PCRE2 C)
-
 # Increased minimum to 2.8.5 to support GNUInstallDirs.
 # Increased minimum to 3.1 to support imported targets.
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
+PROJECT(PCRE2 C)
 
 # Set policy CMP0026 to avoid warnings for the use of LOCATION in
 # GET_TARGET_PROPERTY. This should no longer be required.


### PR DESCRIPTION
`cmake_minimum_required()` must be the first instruction of a top CMakeLists, otherwise side effects may occur.