### PR TITLE
Revert "Correct spelling mistakes (#143)"

### DIFF
--- a/132html
+++ b/132html
@@ -94,7 +94,7 @@ while (<STDIN>)
       die "*** Processing abandoned\n";
       }
 
-    # Instead of .br, relevant "literal" sections are enclosed in .nf/.fi.
+    # Instead of .br, relevent "literal" sections are enclosed in .nf/.fi.
 
     elsif (/^\.nf/)
       {

--- a/HACKING
+++ b/HACKING
@@ -371,7 +371,7 @@ within the compiled pattern. LINK_SIZE always specifies a number of bytes. The
 default value for LINK_SIZE is 2, except for the 32-bit library, where it can
 only be 4. The 8-bit library can be compiled to used 3-byte or 4-byte values,
 and the 16-bit library can be compiled to use 4-byte values, though this
-impairs performance. Specifying a LINK_SIZE larger than 2 for these libraries is
+impairs performance. Specifing a LINK_SIZE larger than 2 for these libraries is
 necessary only when patterns whose compiled length is greater than 65535 code
 units are going to be processed. When a LINK_SIZE value uses more than one code
 unit, the most significant unit is first.

--- a/Makefile.am
+++ b/Makefile.am
@@ -739,7 +739,7 @@ CLEANFILES += \
 ## ------------ End of testing -------------
 
 
-# PCRE2 demonstration program. Not built automatically. The point is that the
+# PCRE2 demonstration program. Not built automatcally. The point is that the
 # users should build it themselves. So just distribute the source.
 
 EXTRA_DIST += src/pcre2demo.c

--- a/RunTest
+++ b/RunTest
@@ -656,7 +656,7 @@ for bmode in "$test8" "$test16" "$test32"; do
   # Test of internal offsets and code sizes. This test is run only when there
   # is UTF/UCP support. The actual tests are mostly the same as in some of the
   # above, but in this test we inspect some offsets and sizes. This is a
-  # doublecheck for the maintainer, just in case something changes unexpectedly.
+  # doublecheck for the maintainer, just in case something changes unexpectely.
   # The output from this test is different in 8-bit, 16-bit, and 32-bit modes
   # and for different link sizes, so there are different output files for each
   # mode and link size.

--- a/doc/pcre2_match_data_create_from_pattern.3
+++ b/doc/pcre2_match_data_create_from_pattern.3
@@ -21,7 +21,7 @@ offsets that are required in the match data block. These form the "output
 vector" (ovector) within the match data block, and are used to identify the
 matched string and any captured substrings when matching with
 \fBpcre2_match()\fP. If you are using \fBpcre2_dfa_match()\fP, which uses the
-output vector in a different way, you should use \fBpcre2_match_data_create()\fP
+outut vector in a different way, you should use \fBpcre2_match_data_create()\fP
 instead of this function.
 .P
 The second argument points to a general context, for custom memory management,

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -219,7 +219,7 @@ output, then exit with zero exit code. All other options are ignored. If both
 -C and any -Lx options are present, whichever is first is recognized.
 .TP 10
 \fB-LS\fP
-List scripts: write a list of recognized Unicode script names to the standard
+List scripts: write a list of recogized Unicode script names to the standard
 output, then exit with zero exit code. All other options are ignored. If both
 -C and any -Lx options are present, whichever is first is recognized.
 .TP 10
@@ -1334,7 +1334,7 @@ controlled by various modifiers listed above whose names begin with
 .\" </a>
 below.
 .\"
-Testing callouts from \fBpcre2_substitute()\fP is described separately in
+Testing callouts from \fBpcre2_substitute()\fP is decribed separately in
 "Testing the substitution function"
 .\" HTML <a href="#substitution">
 .\" </a>
@@ -2093,7 +2093,7 @@ reloads two patterns.
 If \fBjitverify\fP is used with #pop, it does not automatically imply
 \fBjit\fP, which is different behaviour from when it is used on a pattern.
 .P
-The #popcopy command is analogous to the \fBpushcopy\fP modifier in that it
+The #popcopy command is analagous to the \fBpushcopy\fP modifier in that it
 makes current a copy of the topmost stack pattern, leaving the original still
 on the stack.
 .

--- a/perltest.sh
+++ b/perltest.sh
@@ -218,7 +218,7 @@ for (;;)
 
   $showrest = ($mod =~ s/aftertext,?//);
 
-  # The "subject_literal" modifier disables escapes in subjects.
+  # The "subject_literal" modifer disables escapes in subjects.
 
   $subject_literal = ($mod =~ s/subject_literal,?//);
 


### PR DESCRIPTION
This reverts commit db53e4007db5e1fcfa144ddf10d0499a111a770b.