### PR TITLE
Enable LFS on 32-bit platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,8 @@ AC_PROG_INSTALL
 LT_INIT([win32-dll])
 AC_PROG_LN_S
 
+AC_SYS_LARGEFILE
+
 # Check for GCC visibility feature
 
 PCRE2_VISIBILITY

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -428,6 +428,12 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Version number of package */
 #undef VERSION
 
+/* Number of bits in a file offset, on hosts where this is settable. */
+#undef _FILE_OFFSET_BITS
+
+/* Define for large files, on AIX-style hosts. */
+#undef _LARGE_FILES
+
 /* Define to empty if `const' does not conform to ANSI C. */
 #undef const
 


### PR DESCRIPTION
* required to support 64-bit filesystems (inodes) on 32-bit platforms: https://flameeyes.blog/2010/12/15/another-good-reason-to-use-64-bit-installations-large-file-support-headaches/

Bug: https://bugs.gentoo.org/878475