### PR TITLE
Silence warnings about uninitialized min/max_repeat variables.

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -2689,7 +2689,7 @@ if ((options & PCRE2_EXTENDED_MORE) != 0) options |= PCRE2_EXTENDED;
 while (ptr < ptrend)
   {
   int prev_expect_cond_assert;
-  uint32_t min_repeat, max_repeat;
+  uint32_t min_repeat = 0, max_repeat = 0;
   uint32_t set, unset, *optset;
   uint32_t terminator;
   uint32_t prev_meta_quantifier;


### PR DESCRIPTION
When using Clang-11 on Ubuntu 18+ we get these warnings:
```
pcre2_compile.c:3306:27: warning: variable 'min_repeat' may be uninitialized when 
used here [-Wconditional-uninitialized]

pcre2_compile.c:2690:22: note: initialize the variable 'min_repeat' to silence this warning

pcre2_compile.c:3307:27: warning: variable 'max_repeat' may be uninitialized when 
used here [-Wconditional-uninitialized]

pcre2_compile.c:2690:34: note: initialize the variable 'max_repeat' to silence this warning
```
