### PR TITLE
jit: fix pcre2_jit_free_unused_memory() if sljit not using allocator

### DIFF
--- a/src/pcre2_jit_misc.c
+++ b/src/pcre2_jit_misc.c
@@ -110,8 +110,10 @@ pcre2_jit_free_unused_memory(pcre2_general_context *gcontext)
 (void)gcontext;     /* Suppress warning */
 #else  /* SUPPORT_JIT */
 SLJIT_UNUSED_ARG(gcontext);
+#if (defined SLJIT_EXECUTABLE_ALLOCATOR && SLJIT_EXECUTABLE_ALLOCATOR)
 sljit_free_unused_memory_exec();
-#endif  /* SUPPORT_JIT */
+#endif /* SLJIT_EXECUTABLE_ALLOCATOR */
+#endif /* SUPPORT_JIT */
 }
 
 


### PR DESCRIPTION
sljit allows building without an internal allocator, but instead using an external one.

make sure to only invoke the corresponding sljit call if an internal allocator is in use (the default and as coded in pcre integration) to avoid problems if the code is changed to use an external allocator instead.