### PR TITLE
ci: avoid pulling 64bit libraries from strawberry perl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure
-        run: cmake -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -B build -A Win32
+        run: cmake -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DCMAKE_IGNORE_PREFIX_PATH=C:/Strawberry/c -B build -A Win32
 
       - name: Build
         run: cmake --build build


### PR DESCRIPTION
Workaround for Windows builds 20221120.1[1]

Regardless of cmake version there is no point pulling any extra libraries

[1] https://github.com/actions/runner-images/issues/6627