### PR TITLE
jit: correctly implement utf_continue() for utf16

### DIFF
--- a/src/pcre2_jit_neon_inc.h
+++ b/src/pcre2_jit_neon_inc.h
@@ -327,7 +327,7 @@ match:;
     return NULL;
 
 #if defined(FF_UTF)
-  if (utf_continue(str_ptr + IN_UCHARS(-offs1)))
+  if (utf_continue((PCRE2_SPTR)str_ptr - offs1))
     {
     /* Not a match. */
     str_ptr += IN_UCHARS(1);

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -776,7 +776,7 @@ typedef union {
 } int_char;
 
 #if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
-static SLJIT_INLINE int utf_continue(sljit_u8 *s)
+static SLJIT_INLINE int utf_continue(PCRE2_SPTR s)
 {
 #if PCRE2_CODE_UNIT_WIDTH == 8
 return (*s & 0xc0) == 0x80;


### PR DESCRIPTION
Resulting in a constant false result in aarch64 when using SIMD