### PR TITLE
pcre2test: print max stack size in the right units

### DIFF
--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -9004,7 +9004,7 @@ while (argc > 1 && argv[op][0] == '-' && argv[op][1] != 0)
       fprintf(stderr,
         "pcre2test: requested stack size %luMiB is greater than hard limit "
           "%luMiB\n", (unsigned long int)stack_size,
-          (unsigned long int)(rlim.rlim_max));
+          (unsigned long int)(rlim.rlim_max / (1024 * 1024)));
       exit(1);
       }
     rc = setrlimit(RLIMIT_STACK, &rlim);


### PR DESCRIPTION
on a side note; do we really need to test with 64MB of stack nowadays? if I recall correctly the limit might had been increased because of some platforms that couldn't run without it (maybe Linux/m68k) but that was before 10.30 where the possibility of stack overflows was more likely.

AFAIK macOS uses 8M by default and was failing the -S call because the maximum allowed is a little less than 64M and therefore has been running fine with only that much (even before the latest improvements in 10.41)

if anything, and considering the trend to have multiple threads I would expect we should be instead looking at restricting the stack size (less than 1MB per thread stack size is IMHO common).