### PR TITLE
jit: fail early in ffcps_* if subject shorter than offs1

### DIFF
--- a/src/pcre2_jit_neon_inc.h
+++ b/src/pcre2_jit_neon_inc.h
@@ -183,6 +183,8 @@ restart:;
 #endif
 
 #if defined(FFCPS)
+if (str_ptr >= str_end)
+  return NULL;
 sljit_u8 *p1 = str_ptr - diff;
 #endif
 sljit_s32 align_offset = ((uint64_t)str_ptr & 0xf);


### PR DESCRIPTION
This is the minimal change required to solvce the reported crash and has been validated in production.

Fixes: #86