### PR TITLE
Fix integer overflow undefined behaviour

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -7117,10 +7117,8 @@ for (;; pptr++)
 
         if (lengthptr != NULL)
           {
-          PCRE2_SIZE delta = replicate*(1 + LINK_SIZE);
-          if ((INT64_OR_DOUBLE)replicate*
-                (INT64_OR_DOUBLE)(1 + LINK_SIZE) >
-                  (INT64_OR_DOUBLE)INT_MAX ||
+          INT64_OR_DOUBLE delta = (INT64_OR_DOUBLE)replicate*(INT64_OR_DOUBLE)(1 + LINK_SIZE);
+          if (delta > (INT64_OR_DOUBLE)INT_MAX ||
               OFLOW_MAX - *lengthptr < delta)
             {
             *errorcodeptr = ERR20;


### PR DESCRIPTION
Even though delta's type is PCRE2_SIZE, the computation for delta uses all integers at the right hand side.
This means that there is a potential integer overflow. The if below then checks whether a computation equivalent to delta is larger than INT_MAX: the overflow check.
However, since integer overflow is undefined behaviour, the compiler may assume it never happens. Therefore, the overflow check can be assumed to always be false even though there is casting because according to the compiler if an overflow doesn't happen for ints, it surely does not happen for INT64_OR_DOUBLE...

I found this issue using the stack static analysis tool. I verified that the compiler actually optimizes away the check by looking at the IR.

Fix it by computing delta with the casts first, and use that same delta in the if.