### PR TITLE
correctly set heap_limit in KiB

### DIFF
--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -6816,7 +6816,7 @@ frame_size = (offsetof(heapframe, ovector) +
 smaller. */
 
 mb->heap_limit = ((mcontext->heap_limit < re->limit_heap)?
-  mcontext->heap_limit : re->limit_heap) * 1024;
+  mcontext->heap_limit : re->limit_heap);
 
 mb->match_limit = (mcontext->match_limit < re->limit_match)?
   mcontext->match_limit : re->limit_match;


### PR DESCRIPTION
Noticed while doing sanitizer runs, as the multiplication will overflow an uint32_t, which for the default would result in an even larger value than expected.