### PR TITLE
add pcre2_match_data_reset()

### DIFF
--- a/doc/pcre2_match_data_reset.3
+++ b/doc/pcre2_match_data_reset.3
@@ -1,0 +1,34 @@
+.TH PCRE2_MATCH_DATA_FREE 3 "16 October 2018" "PCRE2 10.33"
+.SH NAME
+PCRE2 - Perl-compatible regular expressions (revised API)
+.SH SYNOPSIS
+.rs
+.sp
+.B #include <pcre2.h>
+.PP
+.nf
+.B void pcre2_match_data_reset(pcre2_match_data *\fImatch_data\fP);
+.fi
+.
+.SH DESCRIPTION
+.rs
+.sp
+\fImatch_data\fP must point to a match data block, which was created by
+\fIpcre2_match_data_create\fP or \Fipcre2_match_data_create_from_pattern\fP.
+.P
+This will free all heap frames that were previously allocated and used with
+this match data block.
+.P
+If the PCRE2_COPY_MATCHED_SUBJECT was used for a successful match using this
+match data block, the copy of the subject that was kept within the block is
+also freed.
+.P
+There is a complete description of the PCRE2 native API in the
+.\" HREF
+\fBpcre2api\fP
+.\"
+page and a description of the POSIX API in the
+.\" HREF
+\fBpcre2posix\fP
+.\"
+page.

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -682,6 +682,8 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_match(const pcre2_code *, PCRE2_SPTR, PCRE2_SIZE, PCRE2_SIZE, \
     uint32_t, pcre2_match_data *, pcre2_match_context *); \
 PCRE2_EXP_DECL void PCRE2_CALL_CONVENTION \
+  pcre2_match_data_reset(pcre2_match_data *); \
+PCRE2_EXP_DECL void PCRE2_CALL_CONVENTION \
   pcre2_match_data_free(pcre2_match_data *); \
 PCRE2_EXP_DECL PCRE2_SPTR PCRE2_CALL_CONVENTION \
   pcre2_get_mark(pcre2_match_data *); \
@@ -869,6 +871,7 @@ pcre2_compile are called by application code. */
 #define pcre2_match_context_free              PCRE2_SUFFIX(pcre2_match_context_free_)
 #define pcre2_match_data_create               PCRE2_SUFFIX(pcre2_match_data_create_)
 #define pcre2_match_data_create_from_pattern  PCRE2_SUFFIX(pcre2_match_data_create_from_pattern_)
+#define pcre2_match_data_reset                PCRE2_SUFFIX(pcre2_match_data_reset_)
 #define pcre2_match_data_free                 PCRE2_SUFFIX(pcre2_match_data_free_)
 #define pcre2_pattern_convert                 PCRE2_SUFFIX(pcre2_pattern_convert_)
 #define pcre2_pattern_info                    PCRE2_SUFFIX(pcre2_pattern_info_)

--- a/src/pcre2_match_data.c
+++ b/src/pcre2_match_data.c
@@ -91,6 +91,27 @@ return pcre2_match_data_create(((pcre2_real_code *)code)->top_bracket + 1,
 
 
 /*************************************************
+*           Reset a match data block             *
+*************************************************/
+
+PCRE2_EXP_DEFN void PCRE2_CALL_CONVENTION
+pcre2_match_data_reset(pcre2_match_data *match_data)
+{
+if (match_data->heapframes != NULL)
+  {
+  match_data->memctl.free(match_data->heapframes,
+    match_data->memctl.memory_data);
+  match_data->heapframes = NULL;
+  match_data->heapframes_size = 0;
+  }
+if ((match_data->flags & PCRE2_MD_COPIED_SUBJECT) != 0)
+  match_data->memctl.free((void *)match_data->subject,
+    match_data->memctl.memory_data);
+}
+
+
+
+/*************************************************
 *            Free a match data block             *
 *************************************************/
 
@@ -99,12 +120,7 @@ pcre2_match_data_free(pcre2_match_data *match_data)
 {
 if (match_data != NULL)
   {
-  if (match_data->heapframes != NULL)
-    match_data->memctl.free(match_data->heapframes,
-      match_data->memctl.memory_data);
-  if ((match_data->flags & PCRE2_MD_COPIED_SUBJECT) != 0)
-    match_data->memctl.free((void *)match_data->subject,
-      match_data->memctl.memory_data);
+  pcre2_match_data_reset(match_data);
   match_data->memctl.free(match_data, match_data->memctl.memory_data);
   }
 }

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -6058,32 +6058,17 @@ for (;;)
 
 #ifdef SUPPORT_PCRE2_8
     if (code_unit_size == 1)
-      {
-      match_data8->memctl.free(match_data8->heapframes,
-        match_data8->memctl.memory_data);
-      match_data8->heapframes = NULL;
-      match_data8->heapframes_size = 0;
-      }
+      pcre2_match_data_reset_8(match_data8);
 #endif
 
 #ifdef SUPPORT_PCRE2_16
     if (code_unit_size == 2)
-      {
-      match_data16->memctl.free(match_data16->heapframes,
-        match_data16->memctl.memory_data);
-      match_data16->heapframes = NULL;
-      match_data16->heapframes_size = 0;
-      }
+      pcre2_match_data_reset_16(match_data16);
 #endif
 
 #ifdef SUPPORT_PCRE2_32
     if (code_unit_size == 4)
-      {
-      match_data32->memctl.free(match_data32->heapframes,
-        match_data32->memctl.memory_data);
-      match_data32->heapframes = NULL;
-      match_data32->heapframes_size = 0;
-      }
+      pcre2_match_data_reset_32(match_data32);
 #endif
     }
 


### PR DESCRIPTION
This is just a mirror of `pcre2_match_data_free()` (and indeed changes its implementation to reuse the new code), but that would be useful when match_data is being reused (specially since 10.41, as it now contains the heapframes)

It adds a knob that could be useful when getting rid of the heapframes might be needed (ex: they'd grown abnormally large because of a bad regex) and plugs a possible leak when PCRE2_COPY_MATCHED_SUBJECT was set.

I'd seen also at least 1 case where an implementation was copying the match_data to a stack variable (for thread safety) and then would leak itself to dead as it was never calling `free` but that just happened to work before.