### PR TITLE
add pcre2_get_match_data_heapframes_size()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,14 +5,18 @@ Change Log for PCRE2 - see also the Git log
 Version 10.43 xx-xxx-202x
 -------------------------
 
-1. The test program added by change 2 of 10.42 didn't work when the default 
-newline setting didn't include \n as a newline. One test needed (*LF) to ensure 
+1. The test program added by change 2 of 10.42 didn't work when the default
+newline setting didn't include \n as a newline. One test needed (*LF) to ensure
 that it worked.
 
-2. Added the new freestanding POSIX test program to the ManyConfigTests script 
-in the maint directory (overlooked in 2 below). Also improved the selection 
-facilities in that script, and added a test with JIT in a non-source directory, 
+2. Added the new freestanding POSIX test program to the ManyConfigTests script
+in the maint directory (overlooked in 2 below). Also improved the selection
+facilities in that script, and added a test with JIT in a non-source directory,
 fixing an oversight that would have made such a test fail before.
+
+3. Added pcre2_get_match_data_heapframes_size() and related pcre2test flags
+to allow for finer control of the heap used when pcre2_match() without JIT is
+used and the match_data might be reused.
 
 
 Version 10.42 11-December-2022

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ dist_html_DATA = \
   doc/html/pcre2_general_context_free.html \
   doc/html/pcre2_get_error_message.html \
   doc/html/pcre2_get_mark.html \
+  doc/html/pcre2_get_match_data_heapframes_size.html \
   doc/html/pcre2_get_match_data_size.html \
   doc/html/pcre2_get_ovector_count.html \
   doc/html/pcre2_get_ovector_pointer.html \
@@ -142,6 +143,7 @@ dist_man_MANS = \
   doc/pcre2_general_context_free.3 \
   doc/pcre2_get_error_message.3 \
   doc/pcre2_get_mark.3 \
+  doc/pcre2_get_match_data_heapframes_size.3 \
   doc/pcre2_get_match_data_size.3 \
   doc/pcre2_get_ovector_count.3 \
   doc/pcre2_get_ovector_pointer.3 \

--- a/doc/html/pcre2_get_match_data_heapframes_size.html
+++ b/doc/html/pcre2_get_match_data_heapframes_size.html
@@ -1,9 +1,9 @@
 <html>
 <head>
-<title>pcre2_match_data_free specification</title>
+<title>pcre2_get_match_data_heapframes_size specification</title>
 </head>
 <body bgcolor="#FFFFFF" text="#00005A" link="#0066FF" alink="#3399FF" vlink="#2222BB">
-<h1>pcre2_match_data_free man page</h1>
+<h1>pcre2_get_match_data_heapframes_size man page</h1>
 <p>
 Return to the <a href="index.html">PCRE2 index page</a>.
 </p>
@@ -19,21 +19,14 @@ SYNOPSIS
 <b>#include &#60;pcre2.h&#62;</b>
 </P>
 <P>
-<b>void pcre2_match_data_free(pcre2_match_data *<i>match_data</i>);</b>
+<b>PCRE2_SIZE pcre2_get_match_data_heapframes_size(pcre2_match_data *<i>match_data</i>);</b>
 </P>
 <br><b>
 DESCRIPTION
 </b><br>
 <P>
-If <i>match_data</i> is NULL, this function does nothing. Otherwise,
-<i>match_data</i> must point to a match data block, which this function frees,
-using the memory freeing function from the general context or compiled pattern
-with which it was created, or <b>free()</b> if that was not set.
-</P>
-<P>
-If the PCRE2_COPY_MATCHED_SUBJECT was used for a successful match using this
-match data block, the copy of the subject that was referencedd within the block is
-also freed.
+This function returns the size, in bytes, of the heapframes data block that is owned
+by its argument.
 </P>
 <P>
 There is a complete description of the PCRE2 native API in the

--- a/doc/html/pcre2test.html
+++ b/doc/html/pcre2test.html
@@ -686,6 +686,7 @@ heavily used in the test files.
       fullbincode               show binary code with lengths
   /I  info                      show info about compiled pattern
       hex                       unquoted characters are hexadecimal
+      heapframes_size           show match data heapframes size
       jit[=&#60;number&#62;]            use JIT
       jitfast                   use JIT fast path
       jitverify                 verify JIT use
@@ -776,6 +777,12 @@ when it can never be used.
 The <b>framesize</b> modifier shows the size, in bytes, of the storage frames
 used by <b>pcre2_match()</b> for handling backtracking. The size depends on the
 number of capturing parentheses in the pattern.
+</P>
+<P>
+The <b>heapframes_size</b> modifier shows the size, in bytes, of the allocated
+heapframes used by <b>pcre2_match()</b> and associated with the match_data.
+The vector is reused by all matching patterns that use that `pcre2_match_data`
+and will be expanded as needed.
 </P>
 <P>
 The <b>callout_info</b> modifier requests information about all the callouts in

--- a/doc/pcre2_get_match_data_heapframes_size.3
+++ b/doc/pcre2_get_match_data_heapframes_size.3
@@ -1,0 +1,27 @@
+.TH PCRE2_GET_MATCH_DATA_HEAPFRAMES_SIZE 3 "13 January 2023" "PCRE2 10.43"
+.SH NAME
+PCRE2 - Perl-compatible regular expressions (revised API)
+.SH SYNOPSIS
+.rs
+.sp
+.B #include <pcre2.h>
+.PP
+.nf
+.B PCRE2_SIZE pcre2_get_match_data_heapframes_size(pcre2_match_data *\fImatch_data\fP);
+.fi
+.
+.SH DESCRIPTION
+.rs
+.sp
+This function returns the size, in bytes, of the heapframes data block that is owned
+by its argument.
+.P
+There is a complete description of the PCRE2 native API in the
+.\" HREF
+\fBpcre2api\fP
+.\"
+page and a description of the POSIX API in the
+.\" HREF
+\fBpcre2posix\fP
+.\"
+page.

--- a/doc/pcre2_match_data_free.3
+++ b/doc/pcre2_match_data_free.3
@@ -19,7 +19,7 @@ using the memory freeing function from the general context or compiled pattern
 with which it was created, or \fBfree()\fP if that was not set.
 .P
 If the PCRE2_COPY_MATCHED_SUBJECT was used for a successful match using this
-match data block, the copy of the subject that was remembered with the block is
+match data block, the copy of the subject that was referencedd within the block is
 also freed.
 .P
 There is a complete description of the PCRE2 native API in the

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -642,6 +642,7 @@ heavily used in the test files.
       fullbincode               show binary code with lengths
   /I  info                      show info about compiled pattern
       hex                       unquoted characters are hexadecimal
+      heapframes_size           show match data heapframes size
       jit[=<number>]            use JIT
       jitfast                   use JIT fast path
       jitverify                 verify JIT use
@@ -727,6 +728,11 @@ when it can never be used.
 The \fBframesize\fP modifier shows the size, in bytes, of the storage frames
 used by \fBpcre2_match()\fP for handling backtracking. The size depends on the
 number of capturing parentheses in the pattern.
+.P
+The \fBheapframes_size\fP modifier shows the size, in bytes, of the allocated
+heapframes used by \fBpcre2_match()\fP and associated with the match_data.
+The vector is reused by all matching patterns that use that `pcre2_match_data`
+and will be expanded as needed.
 .P
 The \fBcallout_info\fP modifier requests information about all the callouts in
 the pattern. A list of them is output at the end of any other information that

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -687,6 +687,8 @@ PCRE2_EXP_DECL PCRE2_SPTR PCRE2_CALL_CONVENTION \
   pcre2_get_mark(pcre2_match_data *); \
 PCRE2_EXP_DECL PCRE2_SIZE PCRE2_CALL_CONVENTION \
   pcre2_get_match_data_size(pcre2_match_data *); \
+PCRE2_EXP_DECL PCRE2_SIZE PCRE2_CALL_CONVENTION \
+  pcre2_get_match_data_heapframes_size(pcre2_match_data *); \
 PCRE2_EXP_DECL uint32_t PCRE2_CALL_CONVENTION \
   pcre2_get_ovector_count(pcre2_match_data *); \
 PCRE2_EXP_DECL PCRE2_SIZE *PCRE2_CALL_CONVENTION \
@@ -851,6 +853,7 @@ pcre2_compile are called by application code. */
 #define pcre2_general_context_free            PCRE2_SUFFIX(pcre2_general_context_free_)
 #define pcre2_get_error_message               PCRE2_SUFFIX(pcre2_get_error_message_)
 #define pcre2_get_mark                        PCRE2_SUFFIX(pcre2_get_mark_)
+#define pcre2_get_match_data_heapframes_size  PCRE2_SUFFIX(pcre2_get_match_data_heapframes_size_)
 #define pcre2_get_match_data_size             PCRE2_SUFFIX(pcre2_get_match_data_size_)
 #define pcre2_get_ovector_pointer             PCRE2_SUFFIX(pcre2_get_ovector_pointer_)
 #define pcre2_get_ovector_count               PCRE2_SUFFIX(pcre2_get_ovector_count_)

--- a/src/pcre2_match_data.c
+++ b/src/pcre2_match_data.c
@@ -170,4 +170,16 @@ return offsetof(pcre2_match_data, ovector) +
   2 * (match_data->oveccount) * sizeof(PCRE2_SIZE);
 }
 
+
+
+/*************************************************
+*             Get heapframes size                *
+*************************************************/
+
+PCRE2_EXP_DEFN PCRE2_SIZE PCRE2_CALL_CONVENTION
+pcre2_get_match_data_heapframes_size(pcre2_match_data *match_data)
+{
+return match_data->heapframes_size;
+}
+
 /* End of pcre2_match_data.c */


### PR DESCRIPTION
The proposed code, allows for an external application to implement logic similar to:
```
PCRE2 version 10.42 2022-12-11
  re> /\[(a)]{1000}/expand,framesize
Frame size for pcre2_match(): 16128
data> \[a]{1000}\=ovector=1
Matched, but too many substrings
 0: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
data> 
  re> /a/memory,heapframes_size
Memory allocation (code space): 9
Heapframes size for pcre2_match(): 20643840
data> a\=ovector=0
 0: a
data> 
  re> /a/heapframes_size
Heapframes size for pcre2_match(): 20480
```
So that the system could recover from memory pressure in cases were match_data is being reused.