### PR TITLE
build: make the C99 requirement explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,14 @@
 # 2021-08-28 PH increased minimum version
 # 2021-08-28 PH added test for realpath()
 # 2022-12-10 PH added support for pcre2posix_test
+# 2023-01-15 Carlo added C99 as the minimum required
 
 # Increased minimum to 2.8.5 to support GNUInstallDirs.
 # Increased minimum to 3.1 to support imported targets.
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 PROJECT(PCRE2 C)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED TRUE)
 
 # Set policy CMP0026 to avoid warnings for the use of LOCATION in
 # GET_TARGET_PROPERTY. This should no longer be required.

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ m4_define(libpcre2_posix_version, [3:4:0])
 # NOTE: The CMakeLists.txt file searches for the above variables in the first
 # 50 lines of this file. Please update that if the variables above are moved.
 
-AC_PREREQ([2.60])
+AC_PREREQ([2.62])
 AC_INIT([PCRE2],pcre2_major.pcre2_minor[]pcre2_prerelease,[],[pcre2])
 AC_CONFIG_SRCDIR([src/pcre2.h.in])
 AM_INIT_AUTOMAKE([dist-bzip2 dist-zip])
@@ -42,7 +42,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 remember_set_CFLAGS="$CFLAGS"
 
-AC_PROG_CC
+m4_version_prereq(2.70, [AC_PROG_CC], [AC_PROG_CC_C99])
 AM_PROG_CC_C_O
 AC_USE_SYSTEM_EXTENSIONS
 


### PR DESCRIPTION
Fixes to bootstrapping with older tools that would result in broken builds.

The `configure.ac` uses additional syntax to keep using the original macro that is used in bootstrapping for releases and that works fine even with really old gcc (would test and try to enable up to C11) and could be dropped once the  `AC_PREREQ` is updated as originally intended.