### PR TITLE
pcre2grep: documentation updates

### DIFF
--- a/doc/html/pcre2grep.html
+++ b/doc/html/pcre2grep.html
@@ -675,7 +675,7 @@ number. This option is forced if <b>--line-offsets</b> is used.
 If the PCRE2 library is built with support for just-in-time compiling (which
 speeds up matching), <b>pcre2grep</b> automatically makes use of this, unless it
 was explicitly disabled at build time. This option can be used to disable the
-use of JIT at run time. It is provided for testing and working round problems.
+use of JIT at run time. It is provided for testing and working around problems.
 It should never be needed in normal use.
 </P>
 <P>
@@ -923,9 +923,9 @@ capturing parentheses number.
 Although most of the common options work the same way, a few are different in
 <b>pcre2grep</b>. For example, the <b>--include</b> option's argument is a glob
 for GNU <b>grep</b>, but in <b>pcre2grep</b> it is a regular expression to which
-the \i option applies. If both the <b>-c</b> and <b>-l</b> options are given,
-GNU grep lists only file names, without counts, but <b>pcre2grep</b> gives the
-counts as well.
+the <b>-i</b> option applies. If both the <b>-c</b> and <b>-l</b> options are
+given, GNU grep lists only file names, without counts, but <b>pcre2grep</b>
+gives the counts as well.
 </P>
 <br><a name="SEC10" href="#TOC1">OPTIONS WITH DATA</a><br>
 <P>

--- a/doc/pcre2grep.1
+++ b/doc/pcre2grep.1
@@ -589,7 +589,7 @@ number. This option is forced if \fB--line-offsets\fP is used.
 If the PCRE2 library is built with support for just-in-time compiling (which
 speeds up matching), \fBpcre2grep\fP automatically makes use of this, unless it
 was explicitly disabled at build time. This option can be used to disable the
-use of JIT at run time. It is provided for testing and working round problems.
+use of JIT at run time. It is provided for testing and working around problems.
 It should never be needed in normal use.
 .TP
 \fB-O\fP \fItext\fP, \fB--output\fP=\fItext\fP
@@ -816,9 +816,9 @@ capturing parentheses number.
 Although most of the common options work the same way, a few are different in
 \fBpcre2grep\fP. For example, the \fB--include\fP option's argument is a glob
 for GNU \fBgrep\fP, but in \fBpcre2grep\fP it is a regular expression to which
-the \ei option applies. If both the \fB-c\fP and \fB-l\fP options are given,
-GNU grep lists only file names, without counts, but \fBpcre2grep\fP gives the
-counts as well.
+the \fB-i\fP option applies. If both the \fB-c\fP and \fB-l\fP options are
+given, GNU grep lists only file names, without counts, but \fBpcre2grep\fP
+gives the counts as well.
 .
 .
 .SH "OPTIONS WITH DATA"


### PR DESCRIPTION
using -E without -i doesn't make sense, but it could give confusing results otherwise