### PR TITLE
improve __buitin_mul_overflow() checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ set(ORIG_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Werror")
 
 CHECK_C_SOURCE_COMPILES(
-  "#include <sys/types.h>
+  "#include <stddef.h>
    int main() { int a,b; size_t m; __builtin_mul_overflow(a,b,&m); return 0; }"
   HAVE_BUILTIN_MUL_OVERFLOW
 )

--- a/configure.ac
+++ b/configure.ac
@@ -77,15 +77,12 @@ PCRE2_VISIBILITY
 
 AC_MSG_CHECKING([for __builtin_mul_overflow()])
 AC_LANG_PUSH([C])
-tmp_CFLAGS=$CFLAGS
-CFLAGS="$CFLAGS -Werror"
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 		#ifdef HAVE_SYS_TYPES_H
 		#include <sys/types.h>
 		#endif
-		#ifdef HAVE_STDLIB_H
-		#include <stdlib.h>
-		#endif
+		#include <stddef.h>
+
 		int a, b;
 		size_t m;
 	]], [[__builtin_mul_overflow(a, b, &m)]])],
@@ -96,7 +93,6 @@ if test "$pcre2_cc_cv_builtin_mul_overflow" = yes; then
 	AC_DEFINE([HAVE_BUILTIN_MUL_OVERFLOW], 1,
 		[Define this if your compiler provides __builtin_mul_overflow()])
 fi
-CFLAGS=$tmp_CFLAGS
 AC_LANG_POP([C])
 
 # Check for Clang __attribute__((uninitialized)) feature


### PR DESCRIPTION
Improve the checks introduced with 4678857 (add a C23 inspired checked integer multiplication helper (#198), 2023-02-03) and that could result in build failures at least in AIX with xlc