### PR TITLE
Remove pcre2_ucptables.c from sources in build doc

### DIFF
--- a/NON-AUTOTOOLS-BUILD
+++ b/NON-AUTOTOOLS-BUILD
@@ -121,7 +121,6 @@ environment, for example.
        pcre2_substring.c
        pcre2_tables.c
        pcre2_ucd.c
-       pcre2_ucptables.c
        pcre2_valid_utf.c
        pcre2_xclass.c
 

--- a/doc/html/NON-AUTOTOOLS-BUILD.txt
+++ b/doc/html/NON-AUTOTOOLS-BUILD.txt
@@ -121,7 +121,6 @@ environment, for example.
        pcre2_substring.c
        pcre2_tables.c
        pcre2_ucd.c
-       pcre2_ucptables.c
        pcre2_valid_utf.c
        pcre2_xclass.c
 


### PR DESCRIPTION
This file is included by pcre2_tables.c, so it should not be built manually, otherwise it causes loads of errors like this:
```
pcre2-10.42/src/pcre2_ucptables.c:1517:3: warning: braces around scalar initializer
 1517 |   { 3563, PT_SC, ucp_Unknown }
      |   ^
pcre2-10.42/src/pcre2_ucptables.c:1517:3: note: (near initialization for ‘PRIV’)
pcre2-10.42/src/pcre2_ucptables.c:1517:5: error: invalid initializer
 1517 |   { 3563, PT_SC, ucp_Unknown }
      |     ^~~~
pcre2-10.42/src/pcre2_ucptables.c:1517:5: note: (near initialization for ‘PRIV’)
pcre2-10.42/src/pcre2_ucptables.c:1517:11: warning: excess elements in scalar initializer
 1517 |   { 3563, PT_SC, ucp_Unknown }
      |           ^~~~~
pcre2-10.42/src/pcre2_ucptables.c:1517:11: note: (near initialization for ‘PRIV’)
pcre2-10.42/src/pcre2_ucptables.c:1517:18: warning: excess elements in scalar initializer
 1517 |   { 3563, PT_SC, ucp_Unknown }
      |                  ^~~~~~~~~~~
pcre2-10.42/src/pcre2_ucptables.c:1517:18: note: (near initialization for ‘PRIV’)
pcre2-10.42/src/pcre2_ucptables.c:1517:3: warning: excess elements in scalar initializer
 1517 |   { 3563, PT_SC, ucp_Unknown }
      |   ^
pcre2-10.42/src/pcre2_ucptables.c:1517:3: note: (near initialization for ‘PRIV’)
pcre2-10.42/src/pcre2_ucptables.c:1520:7: error: unknown type name ‘size_t’
 1520 | const size_t PRIV(utt_size) = sizeof(PRIV(utt)) / sizeof(ucp_type_table);
      |       ^~~~~~
pcre2-10.42/src/pcre2_ucptables.c:1520:1: warning: parameter names (without types) in function declaration
 1520 | const size_t PRIV(utt_size) = sizeof(PRIV(utt)) / sizeof(ucp_type_table);
      | ^~~~~
pcre2-10.42/src/pcre2_ucptables.c:1520:1: error: function ‘PRIV’ is initialized like a variable
pcre2-10.42/src/pcre2_ucptables.c:1520:43: error: ‘utt’ undeclared here (not in a function)
 1520 | const size_t PRIV(utt_size) = sizeof(PRIV(utt)) / sizeof(ucp_type_table);
      |                                           ^~~
pcre2-10.42/src/pcre2_ucptables.c:1520:58: error: ‘ucp_type_table’ undeclared here (not in a function)
 1520 | const size_t PRIV(utt_size) = sizeof(PRIV(utt)) / sizeof(ucp_type_table);
      |
```

See: https://github.com/PCRE2Project/pcre2/blob/6277357eff44c887100ec19b2127bbb03118f725/src/pcre2_tables.c#L230

The makefile already acknowledges this: https://github.com/PCRE2Project/pcre2/blob/6277357eff44c887100ec19b2127bbb03118f725/Makefile.am#L388

Perhaps it should also be removed from [BUILD.bazel](https://github.com/PCRE2Project/pcre2/blob/6277357eff44c887100ec19b2127bbb03118f725/BUILD.bazel#L49) and [build.zig](https://github.com/PCRE2Project/pcre2/blob/6277357eff44c887100ec19b2127bbb03118f725/build.zig#L42). I'm not sure how these have been added since it seems like they shouldn't compile.
