### PR TITLE
bugfixes for UTF support (WIP)

### DIFF
--- a/doc/pcre2_set_compile_extra_options.3
+++ b/doc/pcre2_set_compile_extra_options.3
@@ -20,7 +20,7 @@ options are:
 .sp
   PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK     Allow \eK in lookarounds
 .\" JOIN
-  PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES  Allow \ex{d800} to \ex{dfff}
+  PCRE2_EXTRA_ALLOW_SURROGATES         Allow \ex{d800} to \ex{dfff}
                                          in UTF-8 and UTF-32 modes
 .\" JOIN
   PCRE2_EXTRA_ALT_BSUX                 Extended alternate \eu, \eU, and

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -1824,8 +1824,8 @@ Note also that setting PCRE2_NO_UTF_CHECK at compile time does not disable the
 error that is given if an escape sequence for an invalid Unicode code point is
 encountered in the pattern. In particular, the so-called "surrogate" code
 points (0xd800 to 0xdfff) are invalid. If you want to allow escape sequences
-such as \ex{d800} you can set the PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES extra
-option, as described in the section entitled "Extra compile options"
+such as \ex{d800} you can set the PCRE2_EXTRA_ALLOW_SURROGATES extra option,
+as described in the section entitled "Extra compile options"
 .\" HTML <a href="#extracompileoptions">
 .\" </a>
 below.
@@ -1907,7 +1907,7 @@ assertions, following Perl's lead. This option is provided to re-enable the
 previous behaviour (act in positive lookarounds, ignore in negative ones) in
 case anybody is relying on it.
 .sp
-  PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES
+  PCRE2_EXTRA_ALLOW_SURROGATES
 .sp
 This option applies when compiling a pattern in UTF-8 or UTF-32 mode. It is
 forbidden in UTF-16 mode, and ignored in non-UTF modes. Unicode "surrogate"
@@ -1924,10 +1924,16 @@ for the surrogates using escape sequences. The PCRE2_NO_UTF_CHECK option does
 not disable the error that occurs, because it applies only to the testing of
 input strings for UTF validity.
 .P
-If the extra option PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is set, surrogate code
-point values in UTF-8 and UTF-32 patterns no longer provoke errors and are
+If the extra option PCRE2_EXTRA_ALLOW_SURROGATES is set, surrogate code point
+values in UTF-8 and UTF-32 patterns no longer provoke errors and are
 incorporated in the compiled pattern. However, they can only match subject
 characters if the matching function is called with PCRE2_NO_UTF_CHECK set.
+.P
+Before 10.43 this option was known as PCRE2_EXTRA_ALLOW_SURROGATES and that
+is still available for backward compatibility, but the new name should be used
+in new code to better reflect that it also applies to characters in that range
+in UTF-32 as part ot the pattern or subject, including characters encoded in
+UTF-8 if found in the subject.
 .sp
   PCRE2_EXTRA_ALT_BSUX
 .sp

--- a/doc/pcre2pattern.3
+++ b/doc/pcre2pattern.3
@@ -538,8 +538,8 @@ limited to certain values, as follows:
 Invalid Unicode code points are all those in the range 0xd800 to 0xdfff (the
 so-called "surrogate" code points). The check for these can be disabled by the
 caller of \fBpcre2_compile()\fP by setting the option
-PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES. However, this is possible only in UTF-8
-and UTF-32 modes, because these values are not representable in UTF-16.
+PCRE2_EXTRA_ALLOW_SURROGATES. However, this is possible only in UTF-8 and
+UTF-32 modes, because these values are not representable in UTF-16.
 .
 .
 .SS "Escape sequences in character classes"
@@ -1436,8 +1436,8 @@ inclusive. They can also be used for code points specified numerically, for
 example [\e000-\e037]. Ranges can include any characters that are valid for the
 current mode. In any UTF mode, the so-called "surrogate" characters (those
 whose code points lie between 0xd800 and 0xdfff inclusive) may not be specified
-explicitly by default (the PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES option disables
-this check). However, ranges such as [\ex{d7ff}-\ex{e000}], which include the
+explicitly by default (the PCRE2_EXTRA_ALLOW_SURROGATES option disables the
+check). However, ranges such as [\ex{d7ff}-\ex{e000}], which include the
 surrogates, are always permitted.
 .P
 There is a special case in EBCDIC environments for ranges whose end points are

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -577,7 +577,7 @@ for a description of the effects of these options.
 .sp
       allow_empty_class         set PCRE2_ALLOW_EMPTY_CLASS
       allow_lookaround_bsk      set PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK
-      allow_surrogate_escapes   set PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES
+      allow_surrogates          set PCRE2_EXTRA_ALLOW_SURROGATES
       alt_bsux                  set PCRE2_ALT_BSUX
       alt_circumflex            set PCRE2_ALT_CIRCUMFLEX
       alt_verbnames             set PCRE2_ALT_VERBNAMES

--- a/doc/pcre2unicode.3
+++ b/doc/pcre2unicode.3
@@ -309,7 +309,7 @@ UTF-32.)
 Setting PCRE2_NO_UTF_CHECK at compile time does not disable the error that is
 given if an escape sequence for an invalid Unicode code point is encountered in
 the pattern. If you want to allow escape sequences such as \ex{d800} (a
-surrogate code point) you can set the PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES extra
+surrogate code point) you can set the PCRE2_EXTRA_ALLOW_SURROGATES extra
 option. However, this is possible only in UTF-8 and UTF-32 modes, because these
 values are not representable in UTF-16.
 .

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -146,7 +146,7 @@ D   is inspected during pcre2_dfa_match() execution
 
 /* An additional compile options word is available in the compile context. */
 
-#define PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES  0x00000001u  /* C */
+#define PCRE2_EXTRA_ALLOW_SURROGATES         0x00000001u  /* C */
 #define PCRE2_EXTRA_BAD_ESCAPE_IS_LITERAL    0x00000002u  /* C */
 #define PCRE2_EXTRA_MATCH_WORD               0x00000004u  /* C */
 #define PCRE2_EXTRA_MATCH_LINE               0x00000008u  /* C */
@@ -159,6 +159,9 @@ D   is inspected during pcre2_dfa_match() execution
 #define PCRE2_EXTRA_ASCII_BSW                0x00000400u  /* C */
 #define PCRE2_EXTRA_ASCII_POSIX              0x00000800u  /* C */
 #define PCRE2_EXTRA_ASCII_DIGIT              0x00001000u  /* C */
+
+/* Backward compatibility */
+#define PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES  PCRE2_EXTRA_ALLOW_SURROGATES
 
 /* These are for pcre2_jit_compile(). */
 

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -783,7 +783,7 @@ are allowed. */
 
 #define PUBLIC_COMPILE_EXTRA_OPTIONS \
    (PUBLIC_LITERAL_COMPILE_EXTRA_OPTIONS| \
-    PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES|PCRE2_EXTRA_BAD_ESCAPE_IS_LITERAL| \
+    PCRE2_EXTRA_ALLOW_SURROGATES|PCRE2_EXTRA_BAD_ESCAPE_IS_LITERAL| \
     PCRE2_EXTRA_ESCAPED_CR_IS_LF|PCRE2_EXTRA_ALT_BSUX| \
     PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK|PCRE2_EXTRA_ASCII_BSD| \
     PCRE2_EXTRA_ASCII_BSS|PCRE2_EXTRA_ASCII_BSW|PCRE2_EXTRA_ASCII_POSIX| \
@@ -1691,7 +1691,7 @@ else
         if (c > 0x10ffffU) *errorcodeptr = ERR77;
         else
           if (c >= 0xd800 && c <= 0xdfff &&
-              (xoptions & PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES) == 0)
+              (xoptions & PCRE2_EXTRA_ALLOW_SURROGATES) == 0)
                 *errorcodeptr = ERR73;
         }
       else if (c > MAX_NON_UTF_CHAR) *errorcodeptr = ERR77;
@@ -1886,7 +1886,7 @@ else
       else if (ptr < ptrend && *ptr++ == CHAR_RIGHT_CURLY_BRACKET)
         {
         if (utf && c >= 0xd800 && c <= 0xdfff &&
-            (xoptions & PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES) == 0)
+            (xoptions & PCRE2_EXTRA_ALLOW_SURROGATES) == 0)
           {
           ptr--;
           *errorcodeptr = ERR73;
@@ -1959,7 +1959,7 @@ else
         else if (ptr < ptrend && *ptr++ == CHAR_RIGHT_CURLY_BRACKET)
           {
           if (utf && c >= 0xd800 && c <= 0xdfff &&
-              (xoptions & PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES) == 0)
+              (xoptions & PCRE2_EXTRA_ALLOW_SURROGATES) == 0)
             {
             ptr--;
             *errorcodeptr = ERR73;
@@ -10177,23 +10177,29 @@ if ((cb.external_options & (PCRE2_UTF|PCRE2_UCP)) != 0)
 
 /* Check UTF. We have the original options in 'options', with that value as
 modified by (*UTF) etc in cb->external_options. The extra option
-PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is not permitted in UTF-16 mode because the
+PCRE2_EXTRA_ALLOW_SURROGATES is not permitted in UTF-16 mode because the
 surrogate code points cannot be represented in UTF-16. */
 
 utf = (cb.external_options & PCRE2_UTF) != 0;
 if (utf)
   {
+  BOOL strict = TRUE;
+
+#if PCRE2_CODE_UNIT_WIDTH != 16
+  strict = (ccontext->extra_options & PCRE2_EXTRA_ALLOW_SURROGATES) == 0;
+#endif
+
   if ((options & PCRE2_NEVER_UTF) != 0)
     {
     errorcode = ERR74;
     goto HAD_EARLY_ERROR;
     }
   if ((options & PCRE2_NO_UTF_CHECK) == 0 &&
-       (errorcode = PRIV(valid_utf)(pattern, patlen, erroroffset)) != 0)
+       (errorcode = PRIV(valid_utf)(pattern, patlen, erroroffset, strict)) != 0)
     goto HAD_ERROR;  /* Offset was set by valid_utf() */
 
 #if PCRE2_CODE_UNIT_WIDTH == 16
-  if ((ccontext->extra_options & PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES) != 0)
+  if ((ccontext->extra_options & PCRE2_EXTRA_ALLOW_SURROGATES) != 0)
     {
     errorcode = ERR91;
     goto HAD_EARLY_ERROR;

--- a/src/pcre2_convert.c
+++ b/src/pcre2_convert.c
@@ -1090,7 +1090,7 @@ if (utf)
 if (utf && (options & PCRE2_CONVERT_NO_UTF_CHECK) == 0)
   {
   PCRE2_SIZE erroroffset;
-  rc = PRIV(valid_utf)(pattern, plength, &erroroffset);
+  rc = PRIV(valid_utf)(pattern, plength, &erroroffset, TRUE);
   if (rc != 0)
     {
     *bufflenptr = erroroffset;

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -3575,7 +3575,8 @@ if (utf && (options & PCRE2_NO_UTF_CHECK) == 0)
   offset to be an absolute offset in the whole string. */
 
   match_data->rc = PRIV(valid_utf)(check_subject,
-    length - (PCRE2_SIZE)(check_subject - subject), &(match_data->startchar));
+                          length - (PCRE2_SIZE)(check_subject - subject),
+                          &(match_data->startchar), TRUE);
   if (match_data->rc != 0)
     {
     match_data->startchar += (PCRE2_SIZE)(check_subject - subject);

--- a/src/pcre2_error.c
+++ b/src/pcre2_error.c
@@ -177,7 +177,7 @@ static const unsigned char compile_error_texts[] =
   "internal error: unknown code in parsed pattern\0"
   /* 90 */
   "internal error: bad code value in parsed_skip()\0"
-  "PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is not allowed in UTF-16 mode\0"
+  "PCRE2_EXTRA_ALLOW_SURROGATES is not allowed in UTF-16 mode\0"
   "invalid option bits with PCRE2_LITERAL\0"
   "\\N{U+dddd} is supported only in Unicode (UTF) mode\0"
   "invalid hyphen in option setting\0"

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -206,7 +206,7 @@ Unicode doesn't go beyond 0x0010ffff. */
 
 /* This is the largest valid UTF/Unicode code point. */
 
-#define MAX_UTF_CODE_POINT 0x10ffff
+#define MAX_UTF_CODE_POINT 0x10ffffu
 
 /* Compile-time positive error numbers (all except UTF errors, which are
 negative) start at this value. It should probably never be changed, in case
@@ -2036,7 +2036,8 @@ extern PCRE2_SIZE   _pcre2_strlen(PCRE2_SPTR);
 extern int          _pcre2_strncmp(PCRE2_SPTR, PCRE2_SPTR, size_t);
 extern int          _pcre2_strncmp_c8(PCRE2_SPTR, const char *, size_t);
 extern int          _pcre2_study(pcre2_real_code *);
-extern int          _pcre2_valid_utf(PCRE2_SPTR, PCRE2_SIZE, PCRE2_SIZE *);
+extern int          _pcre2_valid_utf(PCRE2_SPTR, PCRE2_SIZE, PCRE2_SIZE *,
+                      BOOL);
 extern BOOL         _pcre2_was_newline(PCRE2_SPTR, uint32_t, PCRE2_SPTR,
                       uint32_t *, BOOL);
 extern BOOL         _pcre2_xclass(uint32_t, PCRE2_SPTR, BOOL);

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -471,7 +471,7 @@ code. */
 /* These are trivial for the 32-bit library, since all UTF-32 characters fit
 into one PCRE2_UCHAR unit. */
 
-#define MAX_UTF_SINGLE_CU (0x10ffffu)
+#define MAX_UTF_SINGLE_CU 0x10ffffu
 #define HAS_EXTRALEN(c) (0)
 #define GET_EXTRALEN(c) (0)
 #define NOT_FIRSTCU(c) (0)

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -345,7 +345,7 @@ if (length == PCRE2_ZERO_TERMINATED)
 #ifdef SUPPORT_UNICODE
 if (utf && (options & PCRE2_NO_UTF_CHECK) == 0)
   {
-  rc = PRIV(valid_utf)(replacement, rlength, &(match_data->startchar));
+  rc = PRIV(valid_utf)(replacement, rlength, &(match_data->startchar), TRUE);
   if (rc != 0)
     {
     match_data->leftchar = 0;

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -343,7 +343,7 @@ widths are actually available, because the input to pcre2test is always in
 8-bit code units. So we include the UTF validity checking function for 8-bit
 code units. */
 
-extern int valid_utf(PCRE2_SPTR8, PCRE2_SIZE, PCRE2_SIZE *);
+extern int valid_utf(PCRE2_SPTR8, PCRE2_SIZE, PCRE2_SIZE *, BOOL);
 
 #define  PCRE2_CODE_UNIT_WIDTH 8
 #undef   PCRE2_SPTR
@@ -639,7 +639,7 @@ static modstruct modlist[] = {
   { "allcaptures",                 MOD_PND,  MOD_CTL, CTL_ALLCAPTURES,            PO(control) },
   { "allow_empty_class",           MOD_PAT,  MOD_OPT, PCRE2_ALLOW_EMPTY_CLASS,    PO(options) },
   { "allow_lookaround_bsk",        MOD_CTC,  MOD_OPT, PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK, CO(extra_options) },
-  { "allow_surrogate_escapes",     MOD_CTC,  MOD_OPT, PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES, CO(extra_options) },
+  { "allow_surrogates",            MOD_CTC,  MOD_OPT, PCRE2_EXTRA_ALLOW_SURROGATES, CO(extra_options) },
   { "allusedtext",                 MOD_PNDP, MOD_CTL, CTL_ALLUSEDTEXT,            PO(control) },
   { "allvector",                   MOD_PND,  MOD_CTL, CTL2_ALLVECTOR,             PO(control2) },
   { "alt_bsux",                    MOD_PAT,  MOD_OPT, PCRE2_ALT_BSUX,             PO(options) },
@@ -4297,7 +4297,7 @@ show_compile_extra_options(uint32_t options, const char *before,
 if (options == 0) fprintf(outfile, "%s <none>%s", before, after);
 else fprintf(outfile, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
   before,
-  ((options & PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES) != 0)? " allow_surrogate_escapes" : "",
+  ((options & PCRE2_EXTRA_ALLOW_SURROGATES) != 0)? " allow_surrogates" : "",
   ((options & PCRE2_EXTRA_ALT_BSUX) != 0)? " alt_bsux" : "",
   ((options & PCRE2_EXTRA_ASCII_BSD) != 0)? " ascii_bsd" : "",
   ((options & PCRE2_EXTRA_ASCII_BSS) != 0)? " ascii_bss" : "",
@@ -7548,7 +7548,7 @@ if (dat_datctl.replacement[0] != 0)
   is detected. Otherwise, UTF-8 can be used to include wide characters in a
   replacement. */
 
-  if (utf) badutf = valid_utf(pr, strlen((const char *)pr), &erroroffset);
+  if (utf) badutf = valid_utf(pr, strlen((const char *)pr), &erroroffset, TRUE);
 
   /* Not UTF or invalid UTF-8: just copy the code units. */
 

--- a/testdata/testinput10
+++ b/testdata/testinput10
@@ -294,6 +294,16 @@
 \= Expect no match
     a\x{123}aa\=offset=5
 
+/a+/match_invalid_utf
+    a\x{123}aa\=offset=1
+    a\x{123}aa\=offset=2
+    a\x{123}aa\=offset=3
+    a\x{123}aa\=offset=4
+\= Expect bad offset value
+    a\x{123}aa\=offset=6
+\= Expect no match
+    a\x{123}aa\=offset=5
+
 /\x{1234}+/Ii,utf
 
 /\x{1234}+?/Ii,utf
@@ -463,12 +473,18 @@
 # A special extra option allows excaped surrogate code points in 8-bit mode,
 # but subjects containing them must not be UTF-checked.
 
-/\x{d800}/I,utf,allow_surrogate_escapes
+/\x{d800}/I,utf,allow_surrogates
     \x{d800}\=no_utf_check
 
-/\udfff\o{157401}/utf,alt_bsux,allow_surrogate_escapes
+/\x{d800}/I,match_invalid_utf,allow_surrogates
+    \x{d800}\=no_utf_check
+
+/\udfff\o{157401}/utf,alt_bsux,allow_surrogates
     \x{dfff}\x{df01}\=no_utf_check
-    
+
+/\udfff\o{157401}/match_invalid_utf,alt_bsux,allow_surrogates
+    \x{dfff}\x{df01}\=no_utf_check
+
 # This has different starting code units in 8-bit mode. 
 
 /^[^ab]/IB,utf

--- a/testdata/testinput12
+++ b/testdata/testinput12
@@ -367,10 +367,10 @@
 # but subjects containing them must not be UTF-checked. These patterns give
 # errors in 16-bit mode.
 
-/\x{d800}/I,utf,allow_surrogate_escapes
+/\x{d800}/I,utf,allow_surrogates
     \x{d800}\=no_utf_check
 
-/\udfff\o{157401}/utf,alt_bsux,allow_surrogate_escapes
+/\udfff\o{157401}/utf,alt_bsux,allow_surrogates
     \x{dfff}\x{df01}\=no_utf_check
 
 # This has different starting code units in 8-bit mode. 
@@ -394,7 +394,7 @@
     \x{30a1}\x{3041}\x{3007}\x{3007}   Katakana Hiragana Han Han
     \x{1100}\x{2e80}\x{2e80}\x{1101}   Hangul Han Han Hangul
  
-/^(*sr:.*)/utf,allow_surrogate_escapes
+/^(*sr:.*)/utf,allow_surrogates
     \x{2e80}\x{3105}\x{2e80}\x{30a1}   Han Bopomofo Han Katakana
     \x{d800}\x{dfff}                   Surrogates (Unknown) \=no_utf_check
 

--- a/testdata/testinput18
+++ b/testdata/testinput18
@@ -17,7 +17,7 @@
   
 /a(())bc/parens_nest_limit=1
 
-/abc/allow_surrogate_escapes,max_pattern_length=2
+/abc/allow_surrogates,max_pattern_length=2
 
 # Real tests
 

--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -912,6 +912,16 @@
 \= Expect no match
     \x{09f}
 
+/^\p{Cs}/match_invalid_utf
+\= Expect no match
+    \x{dfff}\=no_utf_check
+    \x{09f}
+
+/^\p{Cs}/match_invalid_utf,allow_surrogates
+    \x{dfff}\=no_utf_check
+\= Expect no match
+    \x{09f}
+
 /^\p{Mn}/utf
     \x{1a1b}
 

--- a/testdata/testoutput10
+++ b/testdata/testoutput10
@@ -885,6 +885,22 @@ Error -36 (bad UTF-8 offset)
     a\x{123}aa\=offset=5
 No match
 
+/a+/match_invalid_utf
+    a\x{123}aa\=offset=1
+ 0: aa
+    a\x{123}aa\=offset=2
+ 0: aa
+    a\x{123}aa\=offset=3
+ 0: aa
+    a\x{123}aa\=offset=4
+ 0: a
+\= Expect bad offset value
+    a\x{123}aa\=offset=6
+Failed: error -33: bad offset value
+\= Expect no match
+    a\x{123}aa\=offset=5
+No match
+
 /\x{1234}+/Ii,utf
 Capture group count = 0
 Options: caseless utf
@@ -1553,20 +1569,34 @@ Failed: error 176 at offset 259: name is too long in (*MARK), (*PRUNE), (*SKIP),
 # A special extra option allows excaped surrogate code points in 8-bit mode,
 # but subjects containing them must not be UTF-checked.
 
-/\x{d800}/I,utf,allow_surrogate_escapes
+/\x{d800}/I,utf,allow_surrogates
 Capture group count = 0
 Options: utf
-Extra options: allow_surrogate_escapes
+Extra options: allow_surrogates
 First code unit = \xed
 Last code unit = \x80
 Subject length lower bound = 1
     \x{d800}\=no_utf_check
  0: \x{d800}
 
-/\udfff\o{157401}/utf,alt_bsux,allow_surrogate_escapes
+/\x{d800}/I,match_invalid_utf,allow_surrogates
+Capture group count = 0
+Options: match_invalid_utf utf
+Extra options: allow_surrogates
+First code unit = \xed
+Last code unit = \x80
+Subject length lower bound = 1
+    \x{d800}\=no_utf_check
+ 0: \x{d800}
+
+/\udfff\o{157401}/utf,alt_bsux,allow_surrogates
     \x{dfff}\x{df01}\=no_utf_check
  0: \x{dfff}\x{df01}
-    
+
+/\udfff\o{157401}/match_invalid_utf,alt_bsux,allow_surrogates
+    \x{dfff}\x{df01}\=no_utf_check
+ 0: \x{dfff}\x{df01}
+
 # This has different starting code units in 8-bit mode. 
 
 /^[^ab]/IB,utf

--- a/testdata/testoutput12-16
+++ b/testdata/testoutput12-16
@@ -1425,12 +1425,12 @@ No match
 # but subjects containing them must not be UTF-checked. These patterns give
 # errors in 16-bit mode.
 
-/\x{d800}/I,utf,allow_surrogate_escapes
-Failed: error 191 at offset 0: PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is not allowed in UTF-16 mode
+/\x{d800}/I,utf,allow_surrogates
+Failed: error 191 at offset 0: PCRE2_EXTRA_ALLOW_SURROGATES is not allowed in UTF-16 mode
     \x{d800}\=no_utf_check
 
-/\udfff\o{157401}/utf,alt_bsux,allow_surrogate_escapes
-Failed: error 191 at offset 0: PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is not allowed in UTF-16 mode
+/\udfff\o{157401}/utf,alt_bsux,allow_surrogates
+Failed: error 191 at offset 0: PCRE2_EXTRA_ALLOW_SURROGATES is not allowed in UTF-16 mode
     \x{dfff}\x{df01}\=no_utf_check
 
 # This has different starting code units in 8-bit mode. 
@@ -1491,8 +1491,8 @@ No match
     \x{1100}\x{2e80}\x{2e80}\x{1101}   Hangul Han Han Hangul
  0: \x{1100}\x{2e80}\x{2e80}\x{1101}
  
-/^(*sr:.*)/utf,allow_surrogate_escapes
-Failed: error 191 at offset 0: PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is not allowed in UTF-16 mode
+/^(*sr:.*)/utf,allow_surrogates
+Failed: error 191 at offset 0: PCRE2_EXTRA_ALLOW_SURROGATES is not allowed in UTF-16 mode
     \x{2e80}\x{3105}\x{2e80}\x{30a1}   Han Bopomofo Han Katakana
     \x{d800}\x{dfff}                   Surrogates (Unknown) \=no_utf_check
 

--- a/testdata/testoutput12-32
+++ b/testdata/testoutput12-32
@@ -1417,16 +1417,16 @@ No match
 # but subjects containing them must not be UTF-checked. These patterns give
 # errors in 16-bit mode.
 
-/\x{d800}/I,utf,allow_surrogate_escapes
+/\x{d800}/I,utf,allow_surrogates
 Capture group count = 0
 Options: utf
-Extra options: allow_surrogate_escapes
+Extra options: allow_surrogates
 First code unit = \x{d800}
 Subject length lower bound = 1
     \x{d800}\=no_utf_check
  0: \x{d800}
 
-/\udfff\o{157401}/utf,alt_bsux,allow_surrogate_escapes
+/\udfff\o{157401}/utf,alt_bsux,allow_surrogates
     \x{dfff}\x{df01}\=no_utf_check
  0: \x{dfff}\x{df01}
 
@@ -1488,7 +1488,7 @@ No match
     \x{1100}\x{2e80}\x{2e80}\x{1101}   Hangul Han Han Hangul
  0: \x{1100}\x{2e80}\x{2e80}\x{1101}
  
-/^(*sr:.*)/utf,allow_surrogate_escapes
+/^(*sr:.*)/utf,allow_surrogates
     \x{2e80}\x{3105}\x{2e80}\x{30a1}   Han Bopomofo Han Katakana
  0: \x{2e80}\x{3105}\x{2e80}
     \x{d800}\x{dfff}                   Surrogates (Unknown) \=no_utf_check

--- a/testdata/testoutput18
+++ b/testdata/testoutput18
@@ -23,8 +23,8 @@
 /a(())bc/parens_nest_limit=1
 ** Ignored with POSIX interface: parens_nest_limit
 
-/abc/allow_surrogate_escapes,max_pattern_length=2
-** Ignored with POSIX interface: allow_surrogate_escapes max_pattern_length
+/abc/allow_surrogates,max_pattern_length=2
+** Ignored with POSIX interface: allow_surrogates max_pattern_length
 
 # Real tests
 

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -17764,5 +17764,5 @@ Error -1: no match
 Error 0: PCRE2_ERROR_BADDATA (unknown error number)
 Error 100: no error
 Error 101: \ at end of pattern
-Error 191: PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is not allowed in UTF-16 mode
+Error 191: PCRE2_EXTRA_ALLOW_SURROGATES is not allowed in UTF-16 mode
 Error 200: PCRE2_ERROR_BADDATA (unknown error number)

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -1972,6 +1972,20 @@ No match
     \x{09f}
 No match
 
+/^\p{Cs}/match_invalid_utf
+\= Expect no match
+    \x{dfff}\=no_utf_check
+No match
+    \x{09f}
+No match
+
+/^\p{Cs}/match_invalid_utf,allow_surrogates
+    \x{dfff}\=no_utf_check
+ 0: \x{dfff}
+\= Expect no match
+    \x{09f}
+No match
+
 /^\p{Mn}/utf
     \x{1a1b}
  0: \x{1a1b}


### PR DESCRIPTION
Rename PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES to PCRE2_EXTRA_ALLOW_SURROGATES so it can be used when characters with those codes are used even when not escaped.  This also resolves the ambuiguity that allowed the following:

  PCRE2 version 10.34 2019-11-21
    re> /\p{Cs}/match_invalid_utf
  data> \x{dfff}\=no_utf_check
  No match

Several interrelated bug fixes:

* An UTF-8 or UTF-32 encoded character with a surrogate codepoint should be allowed with PCRE2_EXTRA_ALLOW_SURROGATES.  Before this change non UTF-16 will not allow surrogates if encoded in the pattern directly.
* In ALT_BSUX mode, any escaped character should represent itself if not "special", but that was not the case for not ASCII characters.
* When match_invalid_utf is enabled a surrogate character in the subject was being skipped, even if no_utf_check was used together with allow_surrogates

Issues that would be addressed with a new version

* the documentation around \o and \x, specially when bigger than 255 needs reviewing for clarification.
* pcre2test support for testing escaped UTF characters is suboptimal, so most testing was done with custom code that should be integrated instead.
* JIT is broken when match_invalid_utf and allow_surrogate.

Issues that are still open and had been punted from this version:

* ALT_BSUX allows escape characters up to \x{ffff} even without PCRE2_UTF.
* PCRE2_ALT_BSUX might assume only UTF-16. It is not clear what 0xf1 might mean (\u00F1, assume binary matching like it seems to do with surrogates and match with an extended  0xf1 PCRE2_UCHAR, or error), if the later is something like PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES needed?.
* PCRE2_ALT_BSUX match shouldn't really do UTF matching when using surrogates.
* PCRE2_EXTRA_ALT_BSUX should restrict the use of \, so for example non ASCII or \U throw an error.  It probably need to break with PCRE2_ALT_SUX.
* Behaviour is different between UTF-16 and UTF-32 but tests are still unified so tests are missing.