### PR TITLE
pcre2test: print library bitwidth in banner for usability

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -77,6 +77,11 @@ even in UCP mode.
 
 18. Fix an invalid match of ascii word classes when invalid utf is enabled.
 
+19. Add a --posix-digit to pcre2grep for compatibility with GNU grep, and
+
+20. Report the bit width of the library in use by pcre2test for usability.
+other tools that prefer the POSIX compatible unicode definition for \d.
+
 
 Version 10.42 11-December-2022
 ------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ dnl be defined as -RC2, for example. For real releases, it should be empty.
 m4_define(pcre2_major, [10])
 m4_define(pcre2_minor, [43])
 m4_define(pcre2_prerelease, [-DEV])
-m4_define(pcre2_date, [2023-01-15])
+m4_define(pcre2_date, [2023-04-14])
 
 # Libtool shared library interface versions (current:revision:age)
 m4_define(libpcre2_8_version,     [11:2:11])

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -111,14 +111,14 @@ the default). If the 8-bit library has not been built, this option causes an
 error.
 .TP 10
 \fB-16\fP
-If the 16-bit library has been built, this option causes it to be used. If only
-the 16-bit library has been built, this is the default. If the 16-bit library
+If the 16-bit library has been built, this option causes it to be used. If the
+8-bit library has not been built, this is the default. If the 16-bit library
 has not been built, this option causes an error.
 .TP 10
 \fB-32\fP
-If the 32-bit library has been built, this option causes it to be used. If only
-the 32-bit library has been built, this is the default. If the 32-bit library
-has not been built, this option causes an error.
+If the 32-bit library has been built, this option causes it to be used. If no
+other library has been built, this is the default. If the 32-bit library has
+not been built, this option causes an error.
 .TP 10
 \fB-ac\fP
 Behave as if each pattern has the \fBauto_callout\fP modifier, that is, insert

--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -44,7 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define PCRE2_MAJOR           10
 #define PCRE2_MINOR           43
 #define PCRE2_PRERELEASE      -DEV
-#define PCRE2_DATE            2023-01-15
+#define PCRE2_DATE            2023-04-14
 
 /* When an application links to a PCRE DLL in Windows, the symbols that are
 imported have to be identified as such. When building PCRE2, the appropriate

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -8300,11 +8300,17 @@ return PR_OK;
 *************************************************/
 
 static void
-print_version(FILE *f)
+print_version(FILE *f, BOOL include_mode)
 {
+char buf[8];
 VERSION_TYPE *vp;
 fprintf(f, "PCRE2 version ");
 for (vp = version; *vp != 0; vp++) fprintf(f, "%c", *vp);
+if (include_mode)
+  {
+  sprintf(buf, "%d-bit", test_mode);
+  fprintf(f, " (%s)", buf);
+  }
 fprintf(f, "\n");
 }
 
@@ -8421,7 +8427,7 @@ printf("  -t [<n>]      time compilation and execution, repeating <n> times\n");
 printf("  -tm [<n>]     time execution (matching) only, repeating <n> times\n");
 printf("  -T            same as -t, but show total times at the end\n");
 printf("  -TM           same as -tm, but show total time at the end\n");
-printf("  -version      show PCRE2 version and exit\n");
+printf("  -v|--version  show PCRE2 version and exit\n");
 }
 
 
@@ -8522,7 +8528,7 @@ is contributed code which the PCRE2 developers have no means of testing. */
 
 /* No argument for -C: output all configuration information. */
 
-print_version(stdout);
+print_version(stdout, FALSE);
 printf("Compiled with\n");
 
 #ifdef EBCDIC
@@ -9163,10 +9169,10 @@ while (argc > 1 && argv[op][0] == '-' && argv[op][1] != 0)
 
   /* Show version */
 
-  else if (strcmp(arg, "-version") == 0 ||
+  else if (memcmp(arg, "-v", 2) == 0 ||
            strcmp(arg, "--version") == 0)
     {
-    print_version(stdout);
+    print_version(stdout, FALSE);
     goto EXIT;
     }
 
@@ -9407,7 +9413,7 @@ if (argc > 2)
 
 /* Output a heading line unless quiet, then process input lines. */
 
-if (!quiet) print_version(outfile);
+if (!quiet) print_version(outfile, TRUE);
 
 SET(compiled_code, NULL);
 


### PR DESCRIPTION
Mainly to easily document differences of behaviour between different flavors of the library

```
PCRE2 version 10.43-DEV 2023-04-14 (8-bit)
  re> /\x{df00}/
Failed: error 134 at offset 7: character code point value in \x{} or \o{} is too large
 
PCRE2 version 10.43-DEV 2023-04-14 (16-bit)
  re> /\x{df00}/
data> 
```