### PR TITLE
no partial match if trailing data is invalid utf

### DIFF
--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -7454,6 +7454,7 @@ if (utf && end_subject != true_end_subject &&
     if (start_match >= true_end_subject)
       {
       rc = MATCH_NOMATCH;  /* In case it was partial */
+      match_partial = NULL;
       break;
       }
 

--- a/testdata/testinput10
+++ b/testdata/testinput10
@@ -506,6 +506,25 @@
 \= Expect no match
     ab\x80cdef\=ph
 
+/.a/match_invalid_utf
+    ab\=ph
+    ab\=ps
+    b\xf0\x91\x88b\=ph
+    b\xf0\x91\x88b\=ps
+    b\xf0\x91\x88\xb4a
+\= Expect no match
+    b\x80\=ph
+    b\x80\=ps
+    b\xf0\x91\x88\=ph
+    b\xf0\x91\x88\=ps
+
+/.a$/match_invalid_utf
+    ab\=ph
+    ab\=ps
+\= Expect no match
+    b\xf0\x91\x98\=ph
+    b\xf0\x91\x98\=ps
+
 /ab$/match_invalid_utf
     ab\x80cdeab
 \= Expect no match

--- a/testdata/testinput12
+++ b/testdata/testinput12
@@ -413,6 +413,20 @@
 \= Expect no match
     ab\x{df00}cdef\=ph
 
+/.a/match_invalid_utf
+    ab\=ph
+    ab\=ps
+\= Expect no match
+    b\x{df00}\=ph
+    b\x{df00}\=ps
+
+/.a$/match_invalid_utf
+    ab\=ph
+    ab\=ps
+\= Expect no match
+    b\x{df00}\=ph
+    b\x{df00}\=ps
+
 /ab$/match_invalid_utf
     ab\x{df00}cdeab
 \= Expect no match

--- a/testdata/testoutput10
+++ b/testdata/testoutput10
@@ -1646,6 +1646,38 @@ Partial match: ab
     ab\x80cdef\=ph
 No match
 
+/.a/match_invalid_utf
+    ab\=ph
+Partial match: b
+    ab\=ps
+Partial match: b
+    b\xf0\x91\x88b\=ph
+Partial match: b
+    b\xf0\x91\x88b\=ps
+Partial match: b
+    b\xf0\x91\x88\xb4a
+ 0: \x{11234}a
+\= Expect no match
+    b\x80\=ph
+No match
+    b\x80\=ps
+No match
+    b\xf0\x91\x88\=ph
+No match
+    b\xf0\x91\x88\=ps
+No match
+
+/.a$/match_invalid_utf
+    ab\=ph
+Partial match: b
+    ab\=ps
+Partial match: b
+\= Expect no match
+    b\xf0\x91\x98\=ph
+No match
+    b\xf0\x91\x98\=ps
+No match
+
 /ab$/match_invalid_utf
     ab\x80cdeab
  0: ab

--- a/testdata/testoutput12-16
+++ b/testdata/testoutput12-16
@@ -1522,6 +1522,28 @@ Partial match: ab
     ab\x{df00}cdef\=ph
 No match
 
+/.a/match_invalid_utf
+    ab\=ph
+Partial match: b
+    ab\=ps
+Partial match: b
+\= Expect no match
+    b\x{df00}\=ph
+No match
+    b\x{df00}\=ps
+No match
+
+/.a$/match_invalid_utf
+    ab\=ph
+Partial match: b
+    ab\=ps
+Partial match: b
+\= Expect no match
+    b\x{df00}\=ph
+No match
+    b\x{df00}\=ps
+No match
+
 /ab$/match_invalid_utf
     ab\x{df00}cdeab
  0: ab

--- a/testdata/testoutput12-32
+++ b/testdata/testoutput12-32
@@ -1520,6 +1520,28 @@ Partial match: ab
     ab\x{df00}cdef\=ph
 No match
 
+/.a/match_invalid_utf
+    ab\=ph
+Partial match: b
+    ab\=ps
+Partial match: b
+\= Expect no match
+    b\x{df00}\=ph
+No match
+    b\x{df00}\=ps
+No match
+
+/.a$/match_invalid_utf
+    ab\=ph
+Partial match: b
+    ab\=ps
+Partial match: b
+\= Expect no match
+    b\x{df00}\=ph
+No match
+    b\x{df00}\=ps
+No match
+
 /ab$/match_invalid_utf
     ab\x{df00}cdeab
  0: ab


### PR DESCRIPTION
Addresses the inconsistency raised by the failing tests in #237 as shown by:

```
PCRE2 version 10.34 2019-11-21
  re> /.a/match_invalid_utf,allvector,jit
data> b\xb1\=ph,ovector=1
No match
 0: <unchanged>
data> b\xb1\=ph,ovector=1,no_jit
Partial match: b\x{b1}
** ovector[1] is not equal to the subject length: 1 != 2
 0: 0 1
```
   