### PR TITLE
pcre2posix_test: fix build when using a static library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -566,6 +566,7 @@ endif # WITH_PCRE2_8
 ## If the 8-bit library is enabled, build the POSIX wrapper test program and
 ## arrange for it to run.
 
+if WITH_DLL
 if WITH_PCRE2_8
 TESTS += pcre2posix_test
 noinst_PROGRAMS += pcre2posix_test
@@ -573,6 +574,7 @@ pcre2posix_test_SOURCES = src/pcre2posix_test.c
 pcre2posix_test_CFLAGS = $(AM_CFLAGS)
 pcre2posix_test_LDADD = libpcre2-posix.la libpcre2-8.la
 endif # WITH_PCRE2_8
+endif # WITH_DLL
 
 ## If JIT support is enabled, arrange for the JIT test program to run.
 

--- a/configure.ac
+++ b/configure.ac
@@ -523,6 +523,7 @@ AM_CONDITIONAL(WITH_JIT, test "x$enable_jit" = "xyes")
 AM_CONDITIONAL(WITH_UNICODE, test "x$enable_unicode" = "xyes")
 AM_CONDITIONAL(WITH_VALGRIND, test "x$enable_valgrind" = "xyes")
 AM_CONDITIONAL(WITH_FUZZ_SUPPORT, test "x$enable_fuzz_support" = "xyes")
+AM_CONDITIONAL(WITH_DLL, test "x$enable_shared" = "xyes")
 
 if test "$enable_fuzz_support" = "yes" -a "$enable_pcre2_8" = "no"; then
   echo "** ERROR: Fuzzer support requires the 8-bit library"


### PR DESCRIPTION
Only relevant for Windows builds, where the lack of a PCRE2_STATIC definition implies the use of a DLL

Fixes: #243 