### PR TITLE
pcre2grep: document better possible multiline matching misses

### DIFF
--- a/doc/pcre2grep.1
+++ b/doc/pcre2grep.1
@@ -68,6 +68,9 @@ The block of memory that is actually used is three times the "buffer size", to
 allow for buffering "before" and "after" lines. If the buffer size is too
 small, fewer than requested "before" and "after" lines may be output.
 .P
+When matching with a multiline pattern, the size of the buffer must be at least
+half of the maximum match expected or the pattern might fail to match.
+.P
 Patterns can be no longer than 8KiB or BUFSIZ bytes, whichever is the greater.
 BUFSIZ is defined in \fB<stdio.h>\fP. When there is more than one pattern
 (specified by the use of \fB-e\fP and/or \fB-f\fP), each pattern is applied to
@@ -211,7 +214,7 @@ exactly the same as the number of lines that would have been output, but if the
 \fB-M\fP (multiline) option is used (without \fB-v\fP), there may be more
 suppressed lines than the count (that is, the number of matches).
 .sp
-If no lines are selected, the number zero is output. If several files are are
+If no lines are selected, the number zero is output. If several files are
 being scanned, a count is output for each of them and the \fB-t\fP option can
 be used to cause a total to be output at the end. However, if the
 \fB--files-with-matches\fP option is also used, only those files whose counts
@@ -506,8 +509,10 @@ well as possibly handling a two-character newline sequence.
 .sp
 There is a limit to the number of lines that can be matched, imposed by the way
 that \fBpcre2grep\fP buffers the input file as it scans it. With a sufficiently
-large processing buffer, this should not be a problem, but the \fB-M\fP option
-does not work when input is read line by line (see \fB--line-buffered\fP.)
+large processing buffer, this should not be a problem.
+.sp
+The \fB-M\fP option does not work when input is read line by line (see
+\fB--line-buffered\fP.)
 .TP
 \fB-m\fP \fInumber\fP, \fB--max-count\fP=\fInumber\fP
 Stop processing after finding \fInumber\fP matching lines, or non-matching

--- a/maint/ucptest.c
+++ b/maint/ucptest.c
@@ -76,7 +76,7 @@ Script Extensions and Boolean properties, there may be a mixture of positive
 and negative requirements. All must be satisfied.
 
 Sequences of two or more characters are shown as ranges, for example
-U+0041..U+004A. No more than 100 lines are are output. If there are more
+U+0041..U+004A. No more than 100 lines are output. If there are more
 characters, the list ends with ...
 
 The command "list" must be followed by one of property names script, bool,

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -5753,8 +5753,8 @@ for (;; pptr++)
 
     If the class contains characters outside the 0-255 range, a different
     opcode is compiled. It may optionally have a bit map for characters < 256,
-    but those above are are explicitly listed afterwards. A flag code unit
-    tells whether the bitmap is present, and whether this is a negated class or
+    but those above are explicitly listed afterwards. A flag code unit tells
+    whether the bitmap is present, and whether this is a negated class or
     not. */
 
     case META_CLASS_NOT:

--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -1856,7 +1856,7 @@ if (slen > 200)
 
 for (int i = 1; p != NULL; p = p->next, i++)
   {
-  int rc = pcre2_match(p->compiled, (PCRE2_SPTR)matchptr, (int)length,
+  int rc = pcre2_match(p->compiled, (PCRE2_SPTR)matchptr, length,
     startoffset, options, match_data, match_context);
   if (rc == PCRE2_ERROR_NOMATCH) continue;
 


### PR DESCRIPTION
Mostly an update of the documentation to make the failure more obvious

Fixes: #250