### PR TITLE
Add some test cases

### DIFF
--- a/testdata/testinput10
+++ b/testdata/testinput10
@@ -636,4 +636,8 @@
     qchq\=ph
     qchq\=ps
 
+/line1\nbreak/firstline,utf,match_invalid_utf
+    line1\nbreak
+    line0\nline1\nbreak
+
 # End of testinput10

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -5940,4 +5940,11 @@ a)"xI
 /abcd/
     abcd\=ovector=65536
 
+# Use recurse to test \K and Mark in atomic scope.
+/(?>this line\s*((?R)|)\K)/
+    this line this line this line
+
+/(?>this line\s*((?R)|)(*MARK:A))/
+    this line this line this line
+
 # End of testinput2

--- a/testdata/testoutput10
+++ b/testdata/testoutput10
@@ -1913,4 +1913,10 @@ Partial match:
     qchq\=ps
 Partial match: 
 
+/line1\nbreak/firstline,utf,match_invalid_utf
+    line1\nbreak
+ 0: line1\x{0a}break
+    line0\nline1\nbreak
+No match
+
 # End of testinput10

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -17756,6 +17756,17 @@ Subject length lower bound = 2
     abcd\=ovector=65536
  0: abcd
 
+# Use recurse to test \K and Mark in atomic scope.
+/(?>this line\s*((?R)|)\K)/
+    this line this line this line
+ 0: 
+ 1: this line this line
+
+/(?>this line\s*((?R)|)(*MARK:A))/
+    this line this line this line
+ 0: this line this line this line
+ 1: this line this line
+
 # End of testinput2
 Error -70: PCRE2_ERROR_BADDATA (unknown error number)
 Error -62: bad serialized data


### PR DESCRIPTION
"Add tests which use recurse to test \K and Mark in atomic scope" is used to override two branches of the init_frame function, as follows:
https://github.com/PCRE2Project/pcre2/blob/1bc34ffa64c33381d793fb5cdddf3f484e603d23/src/pcre2_jit_compile.c#L2188
https://github.com/PCRE2Project/pcre2/blob/1bc34ffa64c33381d793fb5cdddf3f484e603d23/src/pcre2_jit_compile.c#L2197

"Add the test which use firstline,utf,match_invalid_utf together" is used to overwrite a branch of do_utfreadnewline_invalid:
https://github.com/PCRE2Project/pcre2/blob/1bc34ffa64c33381d793fb5cdddf3f484e603d23/src/pcre2_jit_compile.c#L4657
