### PR TITLE
Ignore build subdirectory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Public .gitignore file for PCRE2
 
+build/
+
 *.a
 *.gcda
 *.gcno


### PR DESCRIPTION
It is a common practice to create a build subdirectory and run cmake from there.