### PR TITLE
jit: add support for partial matches to arm64 simd helper

### DIFF
--- a/src/pcre2_jit_neon_inc.h
+++ b/src/pcre2_jit_neon_inc.h
@@ -82,7 +82,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #  endif
 # endif
 
-static sljit_u8* SLJIT_FUNC FF_FUN(sljit_u8 *str_end, sljit_u8 *str_ptr, sljit_uw offs1, sljit_uw offs2, sljit_uw chars)
+static sljit_u8* SLJIT_FUNC FF_FUN(sljit_u8 *str_end, sljit_u8 **str_ptr, sljit_uw offs1, sljit_uw offs2, sljit_uw chars)
 #undef FF_FUN
 {
 quad_word qw;
@@ -171,7 +171,7 @@ else
   }
 # endif
 
-str_ptr += IN_UCHARS(offs1);
+*str_ptr += IN_UCHARS(offs1);
 #endif
 
 #if PCRE2_CODE_UNIT_WIDTH != 8
@@ -183,13 +183,13 @@ restart:;
 #endif
 
 #if defined(FFCPS)
-if (str_ptr >= str_end)
+if (*str_ptr >= str_end)
   return NULL;
-sljit_u8 *p1 = str_ptr - diff;
+sljit_u8 *p1 = *str_ptr - diff;
 #endif
-sljit_s32 align_offset = ((uint64_t)str_ptr & 0xf);
-str_ptr = (sljit_u8 *) ((uint64_t)str_ptr & ~0xf);
-vect_t data = VLD1Q(str_ptr);
+sljit_s32 align_offset = ((uint64_t)*str_ptr & 0xf);
+*str_ptr = (sljit_u8 *) ((uint64_t)*str_ptr & ~0xf);
+vect_t data = VLD1Q(*str_ptr);
 #if PCRE2_CODE_UNIT_WIDTH != 8
 data = VANDQ(data, char_mask);
 #endif
@@ -212,9 +212,9 @@ vect_t prev_data = data;
 # endif
 
 vect_t data2;
-if (p1 < str_ptr)
+if (p1 < *str_ptr)
   {
-  data2 = VLD1Q(str_ptr - diff);
+  data2 = VLD1Q(*str_ptr - diff);
 #if PCRE2_CODE_UNIT_WIDTH != 8
   data2 = VANDQ(data2, char_mask);
 #endif
@@ -242,12 +242,12 @@ if (align_offset < 8)
   qw.dw[0] >>= align_offset * 8;
   if (qw.dw[0])
     {
-    str_ptr += align_offset + __builtin_ctzll(qw.dw[0]) / 8;
+    *str_ptr += align_offset + __builtin_ctzll(qw.dw[0]) / 8;
     goto match;
     }
   if (qw.dw[1])
     {
-    str_ptr += 8 + __builtin_ctzll(qw.dw[1]) / 8;
+    *str_ptr += 8 + __builtin_ctzll(qw.dw[1]) / 8;
     goto match;
     }
   }
@@ -256,15 +256,15 @@ else
   qw.dw[1] >>= (align_offset - 8) * 8;
   if (qw.dw[1])
     {
-    str_ptr += align_offset + __builtin_ctzll(qw.dw[1]) / 8;
+    *str_ptr += align_offset + __builtin_ctzll(qw.dw[1]) / 8;
     goto match;
     }
   }
-str_ptr += 16;
+*str_ptr += 16;
 
-while (str_ptr < str_end)
+while (*str_ptr < str_end)
   {
-  vect_t orig_data = VLD1Q(str_ptr);
+  vect_t orig_data = VLD1Q(*str_ptr);
 #if PCRE2_CODE_UNIT_WIDTH != 8
   orig_data = VANDQ(orig_data, char_mask);
 #endif
@@ -287,7 +287,7 @@ while (str_ptr < str_end)
 # if defined (FFCPS_DIFF1)
   data2 = VEXTQ(prev_data, data, VECTOR_FACTOR - 1);
 # else
-  data2 = VLD1Q(str_ptr - diff);
+  data2 = VLD1Q(*str_ptr - diff);
 #  if PCRE2_CODE_UNIT_WIDTH != 8
   data2 = VANDQ(data2, char_mask);
 #  endif
@@ -312,11 +312,11 @@ while (str_ptr < str_end)
 
   VST1Q(qw.mem, eq);
   if (qw.dw[0])
-    str_ptr += __builtin_ctzll(qw.dw[0]) / 8;
+    *str_ptr += __builtin_ctzll(qw.dw[0]) / 8;
   else if (qw.dw[1])
-    str_ptr += 8 + __builtin_ctzll(qw.dw[1]) / 8;
+    *str_ptr += 8 + __builtin_ctzll(qw.dw[1]) / 8;
   else {
-    str_ptr += 16;
+    *str_ptr += 16;
 #if defined (FFCPS_DIFF1)
     prev_data = orig_data;
 #endif
@@ -324,24 +324,24 @@ while (str_ptr < str_end)
   }
 
 match:;
-  if (str_ptr >= str_end)
+  if (*str_ptr >= str_end)
     /* Failed match. */
     return NULL;
 
 #if defined(FF_UTF)
-  if (utf_continue((PCRE2_SPTR)str_ptr - offs1))
+  if (utf_continue((PCRE2_SPTR)*str_ptr - offs1))
     {
     /* Not a match. */
-    str_ptr += IN_UCHARS(1);
+    *str_ptr += IN_UCHARS(1);
     goto restart;
     }
 #endif
 
   /* Match. */
 #if defined (FFCPS)
-  str_ptr -= IN_UCHARS(offs1);
+  *str_ptr -= IN_UCHARS(offs1);
 #endif
-  return str_ptr;
+  return *str_ptr;
   }
 
 /* Failed match. */


### PR DESCRIPTION
Do the minimal change required to address the underlying issue (not a hang, but very degraded performance, with the possibility of corruption that could result in an infinite loop by accidentally decrementing `str_ptr`) that was reported.

Fixes: #257