### PR TITLE
Add missing include of config.h

### DIFF
--- a/src/pcre2posix_test.c
+++ b/src/pcre2posix_test.c
@@ -22,6 +22,10 @@ zero. If any test fails there is output to stderr, and the return code is 1.
 For testing purposes, the "-v" option causes verification output to be written
 to stdout. */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <pcre2posix.h>


### PR DESCRIPTION
Without this, linking fails on mingw when configured with --disable-shared because PCRE2_STATIC doesn't get defined, leading to pcre2posix.h incorrectly enabling use of __declspec(dllimport). The errors look like:

c:/mingw/bin/../lib/gcc/mingw32/9.2.0/../../../../mingw32/bin/ld.exe: src/pcre2posix_test-pcre2posix_test.o:pcre2posix_test.c:(.text.startup+0x6f): undefined reference to `_imp__pcre2_regcomp'