### PR TITLE
Fix tests in out-of-source-tree CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1023,6 +1023,7 @@ MESSAGE(\" \")
   FILE(WRITE ${PROJECT_BINARY_DIR}/pcre2_test.sh
   "#! /bin/sh
 # This is a generated file.
+srcdir=${PROJECT_SOURCE_DIR}
 . ${PROJECT_SOURCE_DIR}/RunTest
 if test \"$?\" != \"0\"; then exit 1; fi
 # End
@@ -1036,6 +1037,7 @@ if test \"$?\" != \"0\"; then exit 1; fi
     FILE(WRITE ${PROJECT_BINARY_DIR}/pcre2_grep_test.sh
     "#! /bin/sh
 # This is a generated file.
+srcdir=${PROJECT_SOURCE_DIR}
 . ${PROJECT_SOURCE_DIR}/RunGrepTest
 if test \"$?\" != \"0\"; then exit 1; fi
 # End


### PR DESCRIPTION
I am building PCRE2 using CMake, with the build tree separate from the source. When I run the test suite, I encounter the following failures:
```
$ make test
Running tests...
When testing is complete, review test output in the
"/home/skunk/.conan2/p/b/pcre245455d9ceb200/b/build/Testing/Temporary" folder.
 
Test project /home/skunk/.conan2/p/b/pcre245455d9ceb200/b/build
    Start 1: pcre2_test
1/4 Test #1: pcre2_test .......................***Failed    0.01 sec
    Start 2: pcre2_grep_test
2/4 Test #2: pcre2_grep_test ..................***Failed    0.01 sec
    Start 3: pcre2_jit_test
3/4 Test #3: pcre2_jit_test ...................   Passed   12.55 sec
...
```

If I run the test scripts directly (in the build tree), I see the following:
```
$ sh ./pcre2_test.sh 
Cannot find the testdata directory

$ sh ./pcre2_grep_test.sh 
Testing pcre2grep version 10.42 2022-12-11
Cannot find the testdata directory
```

This PR sets `srcdir` inside the generated wrapper scripts so that the tests can find their test data. After this change, the tests run without issue in the same scenario.