### PR TITLE
cmake: increase minimum to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,10 @@
 # 2023-06-03 Theodore used standard CMake constructs to export the library's targets.
 # 2023-08-06 PH added support for setting variable length lookbehind maximum
 
-# Increased minimum to 3.3 to support visibility.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.3)
-PROJECT(PCRE2 C)
+# Increased minimum to 3.5 to workaround deprecated backward compatibility
+# since 3.27.
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+project(PCRE2 C)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
 


### PR DESCRIPTION
Since 3.27 was released, the following warning is being triggered:

  CMake Deprecation Warning at CMakeLists.txt:108 (CMAKE_MINIMUM_REQUIRED):
    Compatibility with CMake < 3.5 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.

Update version and while at it, clean the code and make sure it errors out even when invoked with an ancient (<=2.4) version of cmake that would just warn otherwise.