### PR TITLE
match: avoid signed/unsigned mismatch

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -298,8 +298,8 @@ META_LOOKBEHIND_NA    (*naplb:  start of non-atomic lookbehind
 META_LOOKBEHINDNOT    (?<!      start of negative lookbehind
 
 The following are followed by two elements, the minimum and maximum. The
-maximum value is limited to 65535 (MAX_REPEAT). A maximum value of "unlimited"
-is represented by REPEAT_UNLIMITED, which is bigger than MAX_REPEAT:
+maximum value is limited to 65535 (MAX_REPEAT_COUNT). A maximum value of
+"unlimited" is represented by REPEAT_UNLIMITED, which is bigger than it:
 
 META_MINMAX           {n,m}  repeat
 META_MINMAX_PLUS      {n,m}+ repeat

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -5767,7 +5767,7 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
           break;
           }
         Feptr--;
-        if (utf) { BACKCHAR(Feptr); }
+        BACKCHAR(Feptr);
         }
       }
     else
@@ -5776,7 +5776,8 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
     /* No UTF support or not in UTF mode */
 
       {
-      ptrdiff_t available = Feptr - mb->start_subject;
+      ptrdiff_t diff = Feptr - mb->start_subject;
+      uint32_t available = (diff > 65535)? 65535 : ((diff > 0)? diff : 0);
       if (Lmin > available) RRETURN(MATCH_NOMATCH);
       if (Lmax > available) Lmax = available;
       Feptr -= Lmax;


### PR DESCRIPTION
Since 1e78b77 (Code for variable-length lookbehinds, 2023-08-06) the Windows CI job (doing 32bit) is showing:

```
  pcre2_match.c(5780,16): warning C4018: '>': signed/unsigned mismatch [pcre2-8-static.vcxproj]
  pcre2_match.c(5781,16): warning C4018: '>': signed/unsigned mismatch [pcre2-8-static.vcxproj]
```

Restrict the ptrdiff to the valid range and while at it remove an unnecessary conditional from the UTF section an update related documentation as well.