### PR TITLE
Spaces are not allowed within \u{} in BSUX mode

### DIFF
--- a/doc/pcre2pattern.3
+++ b/doc/pcre2pattern.3
@@ -425,8 +425,9 @@ interpreted as a literal "u" character.
 .P
 PCRE2_EXTRA_ALT_BSUX has the same effect as PCRE2_ALT_BSUX and, in addition,
 \eu{hhh..} is recognized as the character specified by hexadecimal code point.
-There may be any number of hexadecimal digits. This syntax is from ECMAScript
-6.
+There may be any number of hexadecimal digits, but unlike other places that
+also use brackets, spaces are not allowed and would result in the string being
+interpreted as a literal. This syntax is from ECMAScript 6.
 .P
 The \eN{U+hhh..} escape sequence is recognized only when PCRE2 is operating in
 UTF mode. Perl also uses \eN{name} to specify characters by Unicode name; PCRE2

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -1692,15 +1692,7 @@ else
           (xoptions & PCRE2_EXTRA_ALT_BSUX) != 0)
         {
         PCRE2_SPTR hptr = ptr + 1;
-        PCRE2_SPTR ohptr;
 
-        /* Perl ignores spaces and tabs after {, and though this isn't Perl-
-        compatible code, we do so here as well for uniformity. */
-
-        while (hptr < ptrend && (*hptr == CHAR_SPACE || *hptr == CHAR_HT))
-          hptr++;
-
-        ohptr = hptr;
         cc = 0;
         while (hptr < ptrend && (xc = XDIGIT(*hptr)) != 0xff)
           {
@@ -1714,11 +1706,8 @@ else
           hptr++;
           }
 
-        if (hptr == ohptr) break;  /* No hex digits, escape not recognized */
-
-        while (hptr < ptrend && (*hptr == CHAR_SPACE || *hptr == CHAR_HT))
-          hptr++;
-        if (hptr >= ptrend ||    /* Hit end of input */
+        if (hptr == ptr + 1 ||   /* No hex digits */
+            hptr >= ptrend ||    /* Hit end of input */
             *hptr != CHAR_RIGHT_CURLY_BRACKET)  /* No } terminator */
           break;         /* Hex escape not recognized */
 

--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -817,6 +817,14 @@
 /^\u{0000000000010ffff}/utf,extra_alt_bsux
     \x{10ffff}
 
+/\u{ 1bb1}/utf,extra_alt_bsux
+    u{ 1bb1}
+\= Expect no match
+    \x{1bb1}
+
+/\u{}/extra_alt_bsux
+    u{}
+
 /\u/utf,alt_bsux
     \\u
 

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -1737,6 +1737,17 @@ Failed: error 173 at offset 6: disallowed Unicode code point (>= 0xd800 && <= 0x
     \x{10ffff}
  0: \x{10ffff}
 
+/\u{ 1bb1}/utf,extra_alt_bsux
+    u{ 1bb1}
+ 0: u{ 1bb1}
+\= Expect no match
+    \x{1bb1}
+No match
+
+/\u{}/extra_alt_bsux
+    u{}
+ 0: u{}
+
 /\u/utf,alt_bsux
     \\u
  0: u


### PR DESCRIPTION
Avoid regressions by matching the observed behaviour of Javascript when the PCRE2_EXTENDED_ALT_BSUX option is in effect, and make sure to document the exception.