### PR TITLE
Allow restricting [:xdigit:] to ASCII for POSIX compatibility

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -119,7 +119,7 @@ does the same, except for \u{...}, which is recognized only when
 PCRE2_EXTRA_ALT_BSUX is set. This an ECMAScript, non-Perl compatible,
 extension, so PCRE2 follows ECMAScript rather than Perl.
 
-31. Applied pull request #300 bu Carlo, which fixes #261. The bug was that
+31. Applied pull request #300 by Carlo, which fixes #261. The bug was that
 pcre2_match() was not fully resetting all captures that had been set within a
 (possibly recursive) subroutine call such as (?3).
 
@@ -128,8 +128,9 @@ now matches characters whose general categories are L or N or whose particular
 categories are Mn (non-spacing mark) or Pc (combining puntuation). The latter
 includes underscore.
 
-33. Changed the meaning of [:digit:] in UCP mode to match Perl. It now also
-matches the "fullwidth" versions of the hex digits.
+33. Changed the meaning of [:xdigit:] in UCP mode to match Perl. It now also
+matches the "fullwidth" versions of the hex digits. Just like it is done for
+[:digit:], PCRE2_EXTRA_ASCII_DIGIT can be used to keep this class ASCII only.
 
 
 Version 10.42 11-December-2022

--- a/doc/pcre2_set_compile_extra_options.3
+++ b/doc/pcre2_set_compile_extra_options.3
@@ -29,8 +29,8 @@ options are:
   PCRE2_EXTRA_ASCII_BSS                \es remains ASCII in UCP mode
   PCRE2_EXTRA_ASCII_BSW                \ew remains ASCII in UCP mode
 .\" JOIN
-  PCRE2_EXTRA_ASCII_DIGIT              [:digit:] POSIX class remains ASCII
-                                         in UCP mode
+  PCRE2_EXTRA_ASCII_DIGIT              [:digit:] and [:xdigit:] POSIX classes
+                                         remain ASCII in UCP mode
 .\" JOIN
   PCRE2_EXTRA_ASCII_POSIX              POSIX classes remain ASCII in
                                          UCP mode

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -1971,8 +1971,8 @@ setting.
 .sp
   PCRE2_EXTRA_ASCII_DIGIT
 .sp
-This option forces the POSIX character class [:digit:] to match only ASCII
-digits, even when PCRE2_UCP is set.
+This option forces the POSIX character classes [:digit:] and [:xdigit:] to
+match only ASCII digits, even when PCRE2_UCP is set.
 .sp
   PCRE2_EXTRA_ASCII_POSIX
 .sp

--- a/doc/pcre2pattern.3
+++ b/doc/pcre2pattern.3
@@ -1569,14 +1569,16 @@ plus those characters with code points less than 256 that have the S (Symbol)
 property.
 .TP 10
 [:xdigit:]
-In addition to the ASCII hexadecimal digits, this also matches the "fullwidth" 
-versions of those characters, whose Unicode code points start at U+FF10. This 
-is a change that was made in PCRE release 10.43 for Perl compatibility.
+In addition to the ASCII hexadecimal digits, this also matches the "fullwidth"
+versions of those characters, whose Unicode code points start at U+FF10. The
+effect of PCRE2_UCP can be negated by setting the PCRE2_EXTRA_ASCII_DIGIT
+option, just like it does for [:digit]. This is a change that was made in
+PCRE release 10.43 for Perl compatibility.
 .P
 The other POSIX classes are unchanged by PCRE2_UCP, and match only characters
-with code points less than 256. The effect of PCRE2_UCP on POSIX classes can be
-negated by setting the PCRE2_EXTRA_ASCII_POSIX option, either when calling
-\fBpcre2_compile()\fP or internally within the pattern.
+with code points less than 256. The effect of PCRE2_UCP on all POSIX classes
+can be negated by setting the PCRE2_EXTRA_ASCII_POSIX option, either when
+calling \fBpcre2_compile()\fP or internally within the pattern.
 .
 .
 .SH "COMPATIBILITY FEATURE FOR WORD BOUNDARIES"

--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -1234,6 +1234,8 @@
 
 /[[:xdigit:]]/B,ucp
 
+/[[:xdigit:]]/B,ucp,ascii_digit
+
 # Unicode properties for \b and \B
 
 /\b...\B/utf,ucp
@@ -2444,6 +2446,22 @@
 
 /[[:digit:]]+/utf,ucp,ascii_posix
     123\x{660}456
+
+/^[[:xdigit:]]+$/utf,ucp
+    f0
+    1A
+    d\x{ff10}
+    \x{ff26}8
+\= Expect no match
+    8g\=no_jit
+
+/^[[:xdigit:]]+$/utf,ucp,ascii_digit
+    f0
+    1A
+\= Expect no match
+    d\x{ff10}
+    \x{ff26}8
+    8g
 
 />[[:space:]]+</utf,ucp
     >\x{a0} \x{a0}<

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -2583,6 +2583,14 @@ No match
         End
 ------------------------------------------------------------------
 
+/[[:xdigit:]]/B,ucp,ascii_digit
+------------------------------------------------------------------
+        Bra
+        [0-9A-Fa-f]
+        Ket
+        End
+------------------------------------------------------------------
+
 # Unicode properties for \b and \B
 
 /\b...\B/utf,ucp
@@ -5383,6 +5391,32 @@ No match
 /[[:digit:]]+/utf,ucp,ascii_posix
     123\x{660}456
  0: 123
+
+/^[[:xdigit:]]+$/utf,ucp
+    f0
+ 0: f0
+    1A
+ 0: 1A
+    d\x{ff10}
+ 0: d\x{ff10}
+    \x{ff26}8
+ 0: \x{ff26}8
+\= Expect no match
+    8g\=no_jit
+No match
+
+/^[[:xdigit:]]+$/utf,ucp,ascii_digit
+    f0
+ 0: f0
+    1A
+ 0: 1A
+\= Expect no match
+    d\x{ff10}
+No match
+    \x{ff26}8
+No match
+    8g
+No match
 
 />[[:space:]]+</utf,ucp
     >\x{a0} \x{a0}<


### PR DESCRIPTION
Just like in the case of [:digit:], and as suggested in [UTS#18](https://unicode.org/reports/tr18/#Compatibility_Properties)