### PR TITLE
fix issue #303 - integer overflow in DFA matching

### DIFF
--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -428,7 +428,7 @@ overflow. */
 
 else
   {
-  uint32_t newsize = (rws->size >= UINT32_MAX/2)? UINT32_MAX/2 : rws->size * 2;
+  uint32_t newsize = (rws->size >= UINT32_MAX/sizeof(int))? UINT32_MAX/sizeof(int) : rws->size * 2;
   uint32_t newsizeK = newsize/(1024/sizeof(int));
 
   if (newsizeK + mb->heap_used > mb->heap_limit)

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -428,7 +428,7 @@ overflow. */
 
 else
   {
-  uint32_t newsize = (rws->size >= UINT32_MAX/sizeof(int))? UINT32_MAX/sizeof(int) : rws->size * 2;
+  uint32_t newsize = (rws->size*2 >= UINT32_MAX/sizeof(int))? UINT32_MAX/sizeof(int) : rws->size * 2;
   uint32_t newsizeK = newsize/(1024/sizeof(int));
 
   if (newsizeK + mb->heap_used > mb->heap_limit)


### PR DESCRIPTION
Fix a potential integer overflow in DFA matching. More details can be found here:
https://github.com/PCRE2Project/pcre2/issues/303
