### PR TITLE
test: avoid Undefined Behaviour because of NULL pointer arithmetic in test17

### DIFF
--- a/testdata/testinput17
+++ b/testdata/testinput17
@@ -304,7 +304,7 @@
 /[aCz]/mg,firstline,newline=lf
     match\nmatch
 
-//jitfast
+//jit
     \=null_subject
 
 # End of testinput17

--- a/testdata/testoutput17
+++ b/testdata/testoutput17
@@ -550,7 +550,7 @@ Failed: error -47: match limit exceeded
     match\nmatch
  0: a (JIT)
 
-//jitfast
+//jit
     \=null_subject
  0:  (JIT)
 


### PR DESCRIPTION
Not a regression, as it seems to be included with the 10.40 release.

Resolves the following error when building with [UBSAN](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) in a recent compiler:

```
Test 17: JIT-specific features when JIT is available
src/pcre2_jit_match.c:124:25: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/pcre2_jit_match.c:124:25 in 
src/pcre2_jit_match.c:126:25: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/pcre2_jit_match.c:126:25 in 
```