### PR TITLE
maketables: avoid misleading values in case flipping table

### DIFF
--- a/src/pcre2_maketables.c
+++ b/src/pcre2_maketables.c
@@ -52,8 +52,6 @@ PCRE2_DFTABLES is defined. */
 #  include "pcre2_internal.h"
 #endif
 
-
-
 /*************************************************
 *           Create PCRE2 character tables        *
 *************************************************/
@@ -98,7 +96,11 @@ for (i = 0; i < 256; i++) *p++ = tolower(i);
 
 /* Next the case-flipping table */
 
-for (i = 0; i < 256; i++) *p++ = islower(i)? toupper(i) : tolower(i);
+for (i = 0; i < 256; i++)
+  {
+  int c = islower(i)? toupper(i) : tolower(i);
+  *p++ = (c < 256)? c : i;
+  }
 
 /* Then the character class tables. Don't try to be clever and save effort on
 exclusive ones - in some locales things may be different.

--- a/testdata/testinput3
+++ b/testdata/testinput3
@@ -75,6 +75,11 @@
 \= Expect no match
     école
 
+/\xb5/i
+    µ
+\= Expect no match
+    \x9c
+
 /\W+/
     >>>\xaa<<<
     >>>\xba<<< 

--- a/testdata/testoutput3
+++ b/testdata/testoutput3
@@ -108,6 +108,13 @@ Subject length lower bound = 1
     école
 No match
 
+/\xb5/i
+    µ
+ 0: µ
+\= Expect no match
+    \x9c
+No match
+
 /\W+/
     >>>\xaa<<<
  0: >>>

--- a/testdata/testoutput3A
+++ b/testdata/testoutput3A
@@ -108,6 +108,13 @@ Subject length lower bound = 1
     école
 No match
 
+/\xb5/i
+    µ
+ 0: µ
+\= Expect no match
+    \x9c
+No match
+
 /\W+/
     >>>\xaa<<<
  0: >>>

--- a/testdata/testoutput3B
+++ b/testdata/testoutput3B
@@ -108,6 +108,13 @@ Subject length lower bound = 1
     école
 No match
 
+/\xb5/i
+    µ
+ 0: µ
+\= Expect no match
+    \x9c
+No match
+
 /\W+/
     >>>\xaa<<<
  0: >>>


### PR DESCRIPTION
Fixes an issue observed at least in macOS, where the locale uses an UTF-8 charmap by default and at least toupper() uses an UTF-8 equivalent character for codepoint 181[1] and returns a higher than 255 result.

[1] https://en.wikipedia.org/wiki/Mu_(letter)