### PR TITLE
Add AVX2 simd support on x86

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -5945,6 +5945,7 @@ static BOOL check_fast_forward_char_pair_simd(compiler_common *common, fast_forw
 {
   sljit_s32 i, j, max_i = 0, max_j = 0;
   sljit_u32 max_pri = 0;
+  sljit_s32 max_offset = max_fast_forward_char_pair_offset();
   PCRE2_UCHAR a1, a2, a_pri, b1, b2, b_pri;
 
   for (i = max - 1; i >= 1; i--)
@@ -5955,7 +5956,7 @@ static BOOL check_fast_forward_char_pair_simd(compiler_common *common, fast_forw
       a2 = chars[i].chars[1];
       a_pri = chars[i].last_count;
 
-      j = i - max_fast_forward_char_pair_offset();
+      j = i - max_offset;
       if (j < 0)
         j = 0;
 
@@ -14183,7 +14184,7 @@ common->compiler = compiler;
 
 /* Main pcre2_jit_exec entry. */
 SLJIT_ASSERT((private_data_size & (sizeof(sljit_sw) - 1)) == 0);
-sljit_emit_enter(compiler, 0, SLJIT_ARGS1(W, W), 5, 5, 0, 0, private_data_size);
+sljit_emit_enter(compiler, 0, SLJIT_ARGS1(W, W), 5, 5, SLJIT_NUMBER_OF_SCRATCH_FLOAT_REGISTERS, 0, private_data_size);
 
 /* Register init. */
 reset_ovector(common, (re->top_bracket + 1) * 2);

--- a/src/pcre2_jit_test.c
+++ b/src/pcre2_jit_test.c
@@ -198,6 +198,8 @@ static struct regression_test_case regression_test_cases[] = {
 	{ M, A, 0, 0, "[3-57-9]", "5" },
 	{ PCRE2_AUTO_CALLOUT, A, 0, 0, "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
 		"12345678901234567890123456789012345678901234567890123456789012345678901234567890" },
+	{ 0, A, 0, 0, "..a.......b", "bbbbbbbbbbbbbbbbbbbbbabbbbbbbb" },
+	{ 0, A, 0, 0, "..a.....b", "bbbbbbbbbbbbbbbbbbbbbabbbbbbbb" },
 
 	/* Assertions. */
 	{ MU, A, 0, 0, "\\b[^A]", "A_B#" },


### PR DESCRIPTION
The downside is SSE4.1 is the minimum for simd support. I don't see much perf difference with AVX2, but maybe it is just my machine.