### PR TITLE
pcre2posix: additional updates for recent changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -142,15 +142,18 @@ above because \b and \B are defined in terms of \w.
 option, and (?aP) also sets (?aT) so that (?-aP) disables all ASCII
 restrictions on POSIX classes.
 
-37. If PCRE2_FIRSTLINE was set on an anchored pattern, pcre2_match() and 
-pcre2_dfa_match() misbehaved. PCRE2_FIRSTLINE is now ignored for anchored 
+37. If PCRE2_FIRSTLINE was set on an anchored pattern, pcre2_match() and
+pcre2_dfa_match() misbehaved. PCRE2_FIRSTLINE is now ignored for anchored
 patterns.
 
-38. Add a test for ridiculous ovector offset values to the substring extraction 
+38. Add a test for ridiculous ovector offset values to the substring extraction
 functions.
 
-39. Make OP_REVERSE use IMM2_SIZE for its data instead of LINK_SIZE, for 
+39. Make OP_REVERSE use IMM2_SIZE for its data instead of LINK_SIZE, for
 consistency with OP_VREVERSE.
+
+40. In some legacy environments with a pre C99 snprintf, pcre2_regerror could
+return an incorrect value when the provided buffer was too small.
 
 
 Version 10.42 11-December-2022

--- a/HACKING
+++ b/HACKING
@@ -742,7 +742,7 @@ different (but fixed) length.
 Variable-length backward assertions whose maximum matching length is limited
 are also supported. For such assertions, the first opcode inside each branch is
 OP_VREVERSE, followed by the minimum and maximum lengths for that branch,
-unless these happen to be equal, in which case OP_REVERSE is used. These 
+unless these happen to be equal, in which case OP_REVERSE is used. These
 IMM2_SIZE values occupy two code units each in 8-bit mode, and 1 code unit in
 16/32 bit modes.
 

--- a/doc/pcre2posix.3
+++ b/doc/pcre2posix.3
@@ -32,7 +32,8 @@ documentation for a description of PCRE2's native API, which contains much
 additional functionality.
 .P
 \fBIMPORTANT NOTE\fP: The functions described here are NOT thread-safe, and
-should not be used in multi-threaded applications. Use the native API instead.
+should not be used in multi-threaded applications. They are also limited to
+processing subjects that are not bigger than 2GB. Use the native API instead.
 .P
 These functions are wrapper functions that ultimately call the PCRE2 native
 API. Their prototypes are defined in the \fBpcre2posix.h\fP header file, and
@@ -74,7 +75,7 @@ captured substrings. It also defines some constants whose names start with
 .sp
 Note that these functions are just POSIX-style wrappers for PCRE2's native API.
 They do not give POSIX regular expression behaviour, and they are not
-thread-safe.
+thread-safe or even POSIX compatible.
 .P
 Those POSIX option bits that can reasonably be mapped to PCRE2 native options
 have been implemented. In addition, the option REG_EXTENDED is defined with the
@@ -297,6 +298,10 @@ of each substring, respectively. The 0th element of the vector relates to the
 entire portion of \fIstring\fP that was matched; subsequent elements relate to
 the capturing subpatterns of the regular expression. Unused entries in the
 array have both structure members set to -1.
+.P
+\fIregmatch_t\fP as well as the \fIregoff_t\fP typedef it uses are defined in
+\fBpcre2posix.h\fP and are not warranted to have the same size or layout as other
+similarly named types from other libraries that provide POSIX-style matching.
 .P
 A successful match yields a zero return; various error codes are defined in the
 header file, of which REG_NOMATCH is the "expected" failure code.

--- a/src/pcre2posix.c
+++ b/src/pcre2posix.c
@@ -199,8 +199,11 @@ if (preg != NULL && (int)preg->re_erroffset != -1)
 else
   {
   len = strlen(message);
-  strncpy(errbuf, message, errbuf_size);
-  if (errbuf_size <= len) errbuf[errbuf_size - 1] = '\0';
+  if (errbuf_size != 0)
+    {
+    strncpy(errbuf, message, errbuf_size);
+    if (errbuf_size <= len) errbuf[errbuf_size - 1] = '\0';
+    }
   ret = (int)len;
   }
 

--- a/src/pcre2posix.c
+++ b/src/pcre2posix.c
@@ -168,7 +168,7 @@ static int message_len(const char *message, int offset)
 char buf[12];
 
 /* 11 magic number comes from the format below */
-return strlen(message) + 11 + snprintf(buf, sizeof(buf), "%d", offset);
+return (int)strlen(message) + 11 + snprintf(buf, sizeof(buf), "%d", offset);
 }
 
 /*************************************************
@@ -198,9 +198,10 @@ if (preg != NULL && (int)preg->re_erroffset != -1)
   }
 else
   {
-  ret = len = strlen(message);
+  len = strlen(message);
   strncpy(errbuf, message, errbuf_size);
   if (errbuf_size <= len) errbuf[errbuf_size - 1] = '\0';
+  ret = (int)len;
   }
 
 do {


### PR DESCRIPTION
This was originally meant as a "fixup" for the changes introduced in #333, but includes additional changes that are shown independently in case they need to be dropped, albet it includes a critical brown bag patch that fixes a crash on the original code.

- The first patch is mostly code that I somehow didn't include in my last push as intended.
- The second patch fixes a crash when `pcre2_regerror(.., .., NULL, 0)` or equivalent is used.
- The third patch is documentation updates that might be relevant in addition.

There is actually a fourth patch that actually tightens the issues raised about overlong buffers, but it is not included in this series but kept on its own [branch](https://github.com/carenas/pcre2/tree/noposixlfs), let me know if you would rather had everything squashed there and in a different PR instead, I will squash them as you prefer, but will suggest getting the first two ASAP otherwise.