### PR TITLE
ci: add dev job using clang

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   canary:
-    name: basic
+    name: gcc
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,7 +17,35 @@ jobs:
         run: ./autogen.sh
 
       - name: Configure
-        run: ./configure CC='gcc -fsanitize=undefined,address' CPPFLAGS='-Wall -Wextra -Werror -Wno-error=unused-but-set-parameter' --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --with-link-size=4
+        run: ./configure CC='gcc -fsanitize=undefined,address -fsanitize-undefined-trap-on-error' CPPFLAGS='-Wall -Wextra -Werror -Wno-error=unused-but-set-parameter' --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --with-link-size=4
+
+      - name: Build
+        run: make -j3
+
+      - name: Test (main test script)
+        run: ./RunTest
+
+      - name: Test (JIT test program)
+        run: ./pcre2_jit_test
+
+      - name: Test (pcre2grep test script)
+        run: ./RunGrepTest
+
+      - name: Test (pcre2posix program)
+        run: ./pcre2posix_test -v
+
+  dragon:
+    name: clang
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare
+        run: ./autogen.sh
+
+      - name: Configure
+        run: ./configure CC='clang -fsanitize=undefined,address,integer -fno-sanitize=unsigned-integer-overflow' CPPFLAGS='-Wall -Wextra -Werror -Wno-error=unused-but-set-parameter -Wno-error=deprecated-declarations -Wno-error=incompatible-library-redeclaration' --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --with-link-size=3
 
       - name: Build
         run: make -j3
@@ -37,7 +65,6 @@ jobs:
   bigbird:
     name: manyconfig
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/maint/ManyConfigTests
+++ b/maint/ManyConfigTests
@@ -289,9 +289,7 @@ fi
 # throw up warnings that are not detected with -O0. Then run a second test with
 # -fsanitize=address, which also may throw up new warnings as well as checking
 # things at runtime. Finally, run another test using -fsanitize=undefined
-# -std-gnu99 to check for runtime actions that are not well defined. However,
-# we also use -fno-sanitize=shift to avoid warnings for shifts of negative
-# numbers, which occur in src/pcre2_jit_compile.c.
+# -std-gnu99 to check for runtime actions that are not well defined.
 
 if [ $ISGCC -ne 0 -a $usemain -ne 0 ]; then
   echo "---------- Maximally configured test with -O2 ----------"
@@ -311,8 +309,8 @@ if [ $ISGCC -ne 0 -a $usemain -ne 0 ]; then
   fi
 # This also seems to be the case for sanitize undefined.
   if [ $useusan -ne 0 ]; then
-    echo "------- Maximally configured test with -fsanitize=undefined -fno-sanitize=shift -fno-sanitize=alignment -std=gnu99 -------"
-    CFLAGS="$OFLAGS $SAVECFLAGS -no-pie -fno-PIE -fsanitize=undefined -fno-sanitize=shift -fno-sanitize=alignment -std=gnu99"
+    echo "------- Maximally configured test with -fsanitize=undefined -fno-sanitize=alignment -std=gnu99 -------"
+    CFLAGS="$OFLAGS $SAVECFLAGS -no-pie -fno-PIE -fsanitize=undefined -fno-sanitize=alignment -std=gnu99"
     echo "CFLAGS=$CFLAGS"
     opts="--disable-shared $enable_jit --enable-pcre2-16 --enable-pcre2-32"
     runtest

--- a/maint/README
+++ b/maint/README
@@ -448,6 +448,14 @@ years.
   gigabyte memory, but perhaps another implementation might be considered.
   Needs coordination between the interpreters and JIT.
 
+. The POSIX interface is no longer POSIX compatible, because regoff_t is still
+  defined as an int.
+
+. The POSIX interface is not thread safe because it modifies a pcre2_match
+  inside its regex_t while doing matching. A thread safe version that uses
+  a thread local object has been proposed but it will require that the code
+  requires at least C11 compatibility.
+
 . See also any suggestions in the GitHub issues.
 
 Philip Hazel

--- a/src/pcre2_jit_misc.c
+++ b/src/pcre2_jit_misc.c
@@ -141,8 +141,8 @@ if (startsize == 0 || maxsize == 0 || maxsize > SIZE_MAX - STACK_GROWTH_RATE)
   return NULL;
 if (startsize > maxsize)
   startsize = maxsize;
-startsize = (startsize + STACK_GROWTH_RATE - 1) & ~(STACK_GROWTH_RATE - 1);
-maxsize = (maxsize + STACK_GROWTH_RATE - 1) & ~(STACK_GROWTH_RATE - 1);
+startsize = (startsize + STACK_GROWTH_RATE - 1) & (size_t)(~(STACK_GROWTH_RATE - 1));
+maxsize = (maxsize + STACK_GROWTH_RATE - 1) & (size_t)(~(STACK_GROWTH_RATE - 1));
 
 jit_stack = PRIV(memctl_malloc)(sizeof(pcre2_real_jit_stack), (pcre2_memctl *)gcontext);
 if (jit_stack == NULL) return NULL;

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -2176,7 +2176,7 @@ struct sljit_label *restart;
 struct sljit_jump *jump[2];
 
 SLJIT_ASSERT(common->mode == PCRE2_JIT_COMPLETE && offs1 > offs2);
-SLJIT_ASSERT(diff <= IN_UCHARS(max_fast_forward_char_pair_offset()));
+SLJIT_ASSERT(diff <= (unsigned)IN_UCHARS(max_fast_forward_char_pair_offset()));
 
 /* Initialize. */
 if (common->match_end_ptr != 0)

--- a/src/pcre2_jit_test.c
+++ b/src/pcre2_jit_test.c
@@ -148,7 +148,7 @@ int main(void)
 #define F_PROPERTY	0x200000
 
 struct regression_test_case {
-	int compile_options;
+	uint32_t compile_options;
 	int newline;
 	int match_options;
 	int start_offset;
@@ -1172,7 +1172,7 @@ static int regression_tests(void)
 	int counter = 0;
 	int jit_compile_mode;
 	int utf = 0;
-	int disabled_options = 0;
+	uint32_t disabled_options = 0;
 	int i;
 #ifdef SUPPORT_PCRE2_8
 	pcre2_code_8 *re8;
@@ -1377,9 +1377,9 @@ static int regression_tests(void)
 			ovector8_1 = pcre2_get_ovector_pointer_8(mdata8_1);
 			ovector8_2 = pcre2_get_ovector_pointer_8(mdata8_2);
 			for (i = 0; i < OVECTOR_SIZE * 2; ++i)
-				ovector8_1[i] = -2;
+				ovector8_1[i] = (PCRE2_SIZE)(-2);
 			for (i = 0; i < OVECTOR_SIZE * 2; ++i)
-				ovector8_2[i] = -2;
+				ovector8_2[i] = (PCRE2_SIZE)(-2);
 			pcre2_set_match_limit_8(mcontext8, 10000000);
 		}
 		if (re8) {
@@ -1417,9 +1417,9 @@ static int regression_tests(void)
 			ovector16_1 = pcre2_get_ovector_pointer_16(mdata16_1);
 			ovector16_2 = pcre2_get_ovector_pointer_16(mdata16_2);
 			for (i = 0; i < OVECTOR_SIZE * 2; ++i)
-				ovector16_1[i] = -2;
+				ovector16_1[i] = (PCRE2_SIZE)(-2);
 			for (i = 0; i < OVECTOR_SIZE * 2; ++i)
-				ovector16_2[i] = -2;
+				ovector16_2[i] = (PCRE2_SIZE)(-2);
 			pcre2_set_match_limit_16(mcontext16, 10000000);
 		}
 		if (re16) {
@@ -1462,9 +1462,9 @@ static int regression_tests(void)
 			ovector32_1 = pcre2_get_ovector_pointer_32(mdata32_1);
 			ovector32_2 = pcre2_get_ovector_pointer_32(mdata32_2);
 			for (i = 0; i < OVECTOR_SIZE * 2; ++i)
-				ovector32_1[i] = -2;
+				ovector32_1[i] = (PCRE2_SIZE)(-2);
 			for (i = 0; i < OVECTOR_SIZE * 2; ++i)
-				ovector32_2[i] = -2;
+				ovector32_2[i] = (PCRE2_SIZE)(-2);
 			pcre2_set_match_limit_32(mcontext32, 10000000);
 		}
 		if (re32) {
@@ -1844,7 +1844,7 @@ static int check_invalid_utf_result(int pattern_index, const char *type, int res
 #define CPI (PCRE2_JIT_COMPLETE | PCRE2_JIT_PARTIAL_SOFT | PCRE2_JIT_INVALID_UTF)
 
 struct invalid_utf8_regression_test_case {
-	int compile_options;
+	uint32_t compile_options;
 	int jit_compile_options;
 	int start_offset;
 	int skip_left;
@@ -2135,7 +2135,7 @@ static int invalid_utf8_regression_tests(void)
 #define CPI (PCRE2_JIT_COMPLETE | PCRE2_JIT_PARTIAL_SOFT | PCRE2_JIT_INVALID_UTF)
 
 struct invalid_utf16_regression_test_case {
-	int compile_options;
+	uint32_t compile_options;
 	int jit_compile_options;
 	int start_offset;
 	int skip_left;
@@ -2343,7 +2343,7 @@ static int invalid_utf16_regression_tests(void)
 #define CPI (PCRE2_JIT_COMPLETE | PCRE2_JIT_PARTIAL_SOFT | PCRE2_JIT_INVALID_UTF)
 
 struct invalid_utf32_regression_test_case {
-	int compile_options;
+	uint32_t compile_options;
 	int jit_compile_options;
 	int start_offset;
 	int skip_left;


### PR DESCRIPTION
A similar job to the one that was added originally and that used `gcc`.

The "fix" for the "Undefined Behaviour while shifting framesize" is a little more involved that I would like, but done this way to keep mostly the same logic.