### PR TITLE
Fix various typos in documentation

### DIFF
--- a/README
+++ b/README
@@ -391,7 +391,7 @@ library. They are also documented in the pcre2build man page.
   avoided by linking with libedit (which has a BSD licence) instead.
 
   Enabling libreadline causes the -lreadline option to be added to the
-  pcre2test build. In many operating environments with a sytem-installed
+  pcre2test build. In many operating environments with a system-installed
   readline library this is sufficient. However, in some environments (e.g. if
   an unmodified distribution version of readline is in use), it may be
   necessary to specify something like LIBS="-lncurses" as well. This is

--- a/doc/html/README.txt
+++ b/doc/html/README.txt
@@ -391,7 +391,7 @@ library. They are also documented in the pcre2build man page.
   avoided by linking with libedit (which has a BSD licence) instead.
 
   Enabling libreadline causes the -lreadline option to be added to the
-  pcre2test build. In many operating environments with a sytem-installed
+  pcre2test build. In many operating environments with a system-installed
   readline library this is sufficient. However, in some environments (e.g. if
   an unmodified distribution version of readline is in use), it may be
   necessary to specify something like LIBS="-lncurses" as well. This is

--- a/doc/html/pcre2api.html
+++ b/doc/html/pcre2api.html
@@ -3109,7 +3109,7 @@ Offset values that correspond to unused groups at the end of the expression are
 also set to PCRE2_UNSET. For example, if the string "abc" is matched against
 the pattern (abc)(x(yz)?)? groups 2 and 3 are not matched. The return from the
 function is 2, because the highest used capture group number is 1. The offsets
-for for the second and third capture groupss (assuming the vector is large
+for for the second and third capture groups (assuming the vector is large
 enough, of course) are set to PCRE2_UNSET.
 </P>
 <P>

--- a/doc/html/pcre2build.html
+++ b/doc/html/pcre2build.html
@@ -484,7 +484,7 @@ with <b>libedit</b>, which has a BSD licence.
 <P>
 Setting --enable-pcre2test-libreadline causes the <b>-lreadline</b> option to be
 added to the <b>pcre2test</b> build. In many operating environments with a
-sytem-installed readline library this is sufficient. However, in some
+system-installed readline library this is sufficient. However, in some
 environments (e.g. if an unmodified distribution version of readline is in
 use), some extra configuration may be necessary. The INSTALL file for
 <b>libreadline</b> says this:

--- a/doc/html/pcre2jit.html
+++ b/doc/html/pcre2jit.html
@@ -381,7 +381,7 @@ pattern causes stack overflow with a stack of 1MiB? Is that 1MiB kept until the
 stack is freed?
 <br>
 <br>
-Especially on embedded sytems, it might be a good idea to release memory
+Especially on embedded systems, it might be a good idea to release memory
 sometimes without freeing the stack. There is no API for this at the moment.
 Probably a function call which returns with the currently allocated memory for
 any stack and another which allows releasing memory (shrinking the stack) would

--- a/doc/html/pcre2pattern.html
+++ b/doc/html/pcre2pattern.html
@@ -1286,7 +1286,7 @@ above).
 Dot never matches a single line-ending character. When the two-character
 sequence CRLF is the only line ending, dot does not match CR if it is
 immediately followed by LF, but otherwise it matches all characters (including
-isolated CRs and LFs). When ANYCRLF is selected for line endings, no occurences
+isolated CRs and LFs). When ANYCRLF is selected for line endings, no occurrences
 of CR of LF match dot. When all Unicode line endings are being recognized, dot
 does not match CR or LF or any of the other line ending characters.
 </P>
@@ -2651,7 +2651,7 @@ The current matching point is then reset to the start of the subject, and the
 rest of the pattern match checks for two occurrences of the captured word,
 using an ungreedy .*? to scan from the left. If this succeeds, we are done, but
 if the last word in the string does not occur twice, this part of the pattern
-fails. If a traditional atomic lookhead (?= or (*pla: had been used, the
+fails. If a traditional atomic lookahead (?= or (*pla: had been used, the
 assertion could not be re-entered, and the whole match would fail. The pattern
 would succeed only if the very last word in the subject was found twice.
 </P>

--- a/doc/html/pcre2posix.html
+++ b/doc/html/pcre2posix.html
@@ -189,7 +189,7 @@ caution in software intended to be portable to other systems.
 </pre>
 The PCRE2_UCP option is set when the regular expression is passed for
 compilation to the native function. This causes PCRE2 to use Unicode properties
-when matchine \d, \w, etc., instead of just recognizing ASCII values. Note
+when matching \d, \w, etc., instead of just recognizing ASCII values. Note
 that REG_UCP is not part of the POSIX standard.
 <pre>
   REG_UNGREEDY

--- a/doc/html/pcre2serialize.html
+++ b/doc/html/pcre2serialize.html
@@ -88,7 +88,7 @@ being a pointer to a vector of pointers to compiled patterns, and the length of
 the vector. The third and fourth arguments point to variables which are set to
 point to the created byte stream and its length, respectively. The final
 argument is a pointer to a general context, which can be used to specify custom
-memory mangagement functions. If this argument is NULL, <b>malloc()</b> is used
+memory management functions. If this argument is NULL, <b>malloc()</b> is used
 to obtain memory for the byte stream. The yield of the function is the number
 of serialized patterns, or one of the following negative error codes:
 <pre>
@@ -150,7 +150,7 @@ the compiled patterns in new memory blocks, setting pointers to them in a
 vector. The first two arguments are a pointer to a suitable vector and its
 length, and the third argument points to a byte stream. The final argument is a
 pointer to a general context, which can be used to specify custom memory
-mangagement functions for the decoded patterns. If this argument is NULL,
+management functions for the decoded patterns. If this argument is NULL,
 <b>malloc()</b> and <b>free()</b> are used. After deserialization, the byte
 stream is no longer needed and can be discarded.
 <pre>

--- a/doc/html/pcre2syntax.html
+++ b/doc/html/pcre2syntax.html
@@ -213,7 +213,7 @@ matching" rules.
   Xan        Alphanumeric: union of properties L and N
   Xps        POSIX space: property Z or tab, NL, VT, FF, CR
   Xsp        Perl space: property Z or tab, NL, VT, FF, CR
-  Xuc        Univerally-named character: one that can be
+  Xuc        Universally-named character: one that can be
                represented by a Universal Character Name
   Xwd        Perl word: property Xan or underscore
 </pre>

--- a/doc/pcre2.txt
+++ b/doc/pcre2.txt
@@ -3016,7 +3016,7 @@ HOW PCRE2_MATCH() RETURNS A STRING AND CAPTURED SUBSTRINGS
        is matched against the pattern (abc)(x(yz)?)? groups 2 and  3  are  not
        matched.  The  return  from the function is 2, because the highest used
        capture group number is 1. The offsets for for  the  second  and  third
-       capture  groupss  (assuming  the vector is large enough, of course) are
+       capture  groups  (assuming  the vector is large enough, of course) are
        set to PCRE2_UNSET.
 
        Elements in the ovector that do not correspond to capturing parentheses
@@ -4441,7 +4441,7 @@ PCRE2TEST OPTION FOR LIBREADLINE SUPPORT
 
        Setting --enable-pcre2test-libreadline causes the -lreadline option  to
        be  added to the pcre2test build. In many operating environments with a
-       sytem-installed readline library this is sufficient. However,  in  some
+       system-installed readline library this is sufficient. However,  in  some
        environments (e.g. if an unmodified distribution version of readline is
        in  use),  some  extra configuration may be necessary. The INSTALL file
        for libreadline says this:
@@ -5615,7 +5615,7 @@ JIT STACK FAQ
        if a pattern causes stack overflow with a stack of 1MiB? Is  that  1MiB
        kept until the stack is freed?
 
-       Especially  on embedded sytems, it might be a good idea to release mem-
+       Especially  on embedded systems, it might be a good idea to release mem-
        ory sometimes without freeing the stack. There is no API  for  this  at
        the  moment.  Probably a function call which returns with the currently
        allocated memory for any stack and another which allows releasing  mem-
@@ -7568,7 +7568,7 @@ FULL STOP (PERIOD, DOT) AND \N
        ter sequence CRLF is the only line ending, dot does not match CR if  it
        is  immediately followed by LF, but otherwise it matches all characters
        (including isolated CRs and LFs). When ANYCRLF  is  selected  for  line
-       endings,  no  occurences  of  CR of LF match dot. When all Unicode line
+       endings,  no  occurrences  of  CR of LF match dot. When all Unicode line
        endings are being recognized, dot does not match CR or LF or any of the
        other line ending characters.
 
@@ -8864,7 +8864,7 @@ NON-ATOMIC ASSERTIONS
        captured  word,  using  an  ungreedy .*? to scan from the left. If this
        succeeds, we are done, but if the last word in the string does not  oc-
        cur  twice,  this  part  of  the pattern fails. If a traditional atomic
-       lookhead (?= or (*pla: had been used, the assertion could not be re-en-
+       lookahead (?= or (*pla: had been used, the assertion could not be re-en-
        tered, and the whole match would fail. The pattern would  succeed  only
        if the very last word in the subject was found twice.
 
@@ -10415,7 +10415,7 @@ COMPILING A PATTERN
 
        The PCRE2_UCP option is set when the regular expression is  passed  for
        compilation  to  the  native function. This causes PCRE2 to use Unicode
-       properties when matchine \d, \w,  etc.,  instead  of  just  recognizing
+       properties when matching \d, \w,  etc.,  instead  of  just  recognizing
        ASCII values. Note that REG_UCP is not part of the POSIX standard.
 
          REG_UNGREEDY
@@ -10766,7 +10766,7 @@ SAVING COMPILED PATTERNS
        the length of the vector. The third and fourth arguments point to vari-
        ables which are set to point to the created byte stream and its length,
        respectively. The final argument is a pointer  to  a  general  context,
-       which  can  be  used to specify custom memory mangagement functions. If
+       which  can  be  used to specify custom memory management functions. If
        this argument is NULL, malloc() is used to obtain memory for  the  byte
        stream. The yield of the function is the number of serialized patterns,
        or one of the following negative error codes:
@@ -10830,7 +10830,7 @@ RE-USING PRECOMPILED PATTERNS
        a  vector.  The  first two arguments are a pointer to a suitable vector
        and its length, and the third argument points to a byte stream. The fi-
        nal argument is a pointer to a general context, which can  be  used  to
-       specify  custom  memory mangagement functions for the decoded patterns.
+       specify  custom  memory management functions for the decoded patterns.
        If this argument is NULL, malloc() and free() are used. After deserial-
        ization, the byte stream is no longer needed and can be discarded.
 
@@ -11060,7 +11060,7 @@ PCRE2 SPECIAL CATEGORY PROPERTIES FOR \p and \P
          Xan        Alphanumeric: union of properties L and N
          Xps        POSIX space: property Z or tab, NL, VT, FF, CR
          Xsp        Perl space: property Z or tab, NL, VT, FF, CR
-         Xuc        Univerally-named character: one that can be
+         Xuc        Universally-named character: one that can be
                       represented by a Universal Character Name
          Xwd        Perl word: property Xan or underscore
 

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -3111,8 +3111,8 @@ Offset values that correspond to unused groups at the end of the expression are
 also set to PCRE2_UNSET. For example, if the string "abc" is matched against
 the pattern (abc)(x(yz)?)? groups 2 and 3 are not matched. The return from the
 function is 2, because the highest used capture group number is 1. The offsets
-for for the second and third capture groupss (assuming the vector is large
-enough, of course) are set to PCRE2_UNSET.
+for the second and third capture groups (assuming the vector is large enough,
+of course) are set to PCRE2_UNSET.
 .P
 Elements in the ovector that do not correspond to capturing parentheses in the
 pattern are never changed. That is, if a pattern contains \fIn\fP capturing
@@ -3283,7 +3283,7 @@ The backtracking match limit was reached.
 .sp
   PCRE2_ERROR_NOMEMORY
 .sp
-Heap memory is used to remember backgracking points. This error is given when
+Heap memory is used to remember backtracking points. This error is given when
 the memory allocation function (default or custom) fails. Note that a different
 error, PCRE2_ERROR_HEAPLIMIT, is given if the amount of memory needed exceeds
 the heap limit. PCRE2_ERROR_NOMEMORY is also returned if

--- a/doc/pcre2build.3
+++ b/doc/pcre2build.3
@@ -487,7 +487,7 @@ with \fBlibedit\fP, which has a BSD licence.
 .P
 Setting --enable-pcre2test-libreadline causes the \fB-lreadline\fP option to be
 added to the \fBpcre2test\fP build. In many operating environments with a
-sytem-installed readline library this is sufficient. However, in some
+system-installed readline library this is sufficient. However, in some
 environments (e.g. if an unmodified distribution version of readline is in
 use), some extra configuration may be necessary. The INSTALL file for
 \fBlibreadline\fP says this:

--- a/doc/pcre2jit.3
+++ b/doc/pcre2jit.3
@@ -362,7 +362,7 @@ list of patterns.
 pattern causes stack overflow with a stack of 1MiB? Is that 1MiB kept until the
 stack is freed?
 .sp
-Especially on embedded sytems, it might be a good idea to release memory
+Especially on embedded systems, it might be a good idea to release memory
 sometimes without freeing the stack. There is no API for this at the moment.
 Probably a function call which returns with the currently allocated memory for
 any stack and another which allows releasing memory (shrinking the stack) would

--- a/doc/pcre2pattern.3
+++ b/doc/pcre2pattern.3
@@ -1285,7 +1285,7 @@ above).
 Dot never matches a single line-ending character. When the two-character
 sequence CRLF is the only line ending, dot does not match CR if it is
 immediately followed by LF, but otherwise it matches all characters (including
-isolated CRs and LFs). When ANYCRLF is selected for line endings, no occurences
+isolated CRs and LFs). When ANYCRLF is selected for line endings, no occurrences
 of CR of LF match dot. When all Unicode line endings are being recognized, dot
 does not match CR or LF or any of the other line ending characters.
 .P
@@ -2668,7 +2668,7 @@ The current matching point is then reset to the start of the subject, and the
 rest of the pattern match checks for two occurrences of the captured word,
 using an ungreedy .*? to scan from the left. If this succeeds, we are done, but
 if the last word in the string does not occur twice, this part of the pattern
-fails. If a traditional atomic lookhead (?= or (*pla: had been used, the
+fails. If a traditional atomic lookahead (?= or (*pla: had been used, the
 assertion could not be re-entered, and the whole match would fail. The pattern
 would succeed only if the very last word in the subject was found twice.
 .P

--- a/doc/pcre2posix.3
+++ b/doc/pcre2posix.3
@@ -161,7 +161,7 @@ caution in software intended to be portable to other systems.
 .sp
 The PCRE2_UCP option is set when the regular expression is passed for
 compilation to the native function. This causes PCRE2 to use Unicode properties
-when matchine \ed, \ew, etc., instead of just recognizing ASCII values. Note
+when matching \ed, \ew, etc., instead of just recognizing ASCII values. Note
 that REG_UCP is not part of the POSIX standard.
 .sp
   REG_UNGREEDY

--- a/doc/pcre2serialize.3
+++ b/doc/pcre2serialize.3
@@ -75,7 +75,7 @@ being a pointer to a vector of pointers to compiled patterns, and the length of
 the vector. The third and fourth arguments point to variables which are set to
 point to the created byte stream and its length, respectively. The final
 argument is a pointer to a general context, which can be used to specify custom
-memory mangagement functions. If this argument is NULL, \fBmalloc()\fP is used
+memory management functions. If this argument is NULL, \fBmalloc()\fP is used
 to obtain memory for the byte stream. The yield of the function is the number
 of serialized patterns, or one of the following negative error codes:
 .sp
@@ -137,7 +137,7 @@ the compiled patterns in new memory blocks, setting pointers to them in a
 vector. The first two arguments are a pointer to a suitable vector and its
 length, and the third argument points to a byte stream. The final argument is a
 pointer to a general context, which can be used to specify custom memory
-mangagement functions for the decoded patterns. If this argument is NULL,
+management functions for the decoded patterns. If this argument is NULL,
 \fBmalloc()\fP and \fBfree()\fP are used. After deserialization, the byte
 stream is no longer needed and can be discarded.
 .sp

--- a/doc/pcre2syntax.3
+++ b/doc/pcre2syntax.3
@@ -180,7 +180,7 @@ matching" rules.
   Xan        Alphanumeric: union of properties L and N
   Xps        POSIX space: property Z or tab, NL, VT, FF, CR
   Xsp        Perl space: property Z or tab, NL, VT, FF, CR
-  Xuc        Univerally-named character: one that can be
+  Xuc        Universally-named character: one that can be
                represented by a Universal Character Name
   Xwd        Perl word: property Xan or underscore
 .sp


### PR DESCRIPTION
Most of these typos were found with the following command:

    find doc -type f -exec aspell -c {} \;
