### PR TITLE
fast_forward_first_n_chars should use while, not do-while

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -6247,13 +6247,12 @@ if (range_right >= 0)
 
     char_set = chars[range_right - i].chars;
     char_set_end = char_set + chars[range_right - i].count;
-    do
+    while (char_set < char_set_end)
       {
       if (update_table[(*char_set) & 0xff] > IN_UCHARS(i))
         update_table[(*char_set) & 0xff] = IN_UCHARS(i);
       char_set++;
       }
-    while (char_set < char_set_end);
     }
   }
 


### PR DESCRIPTION
This addresses a potential issue where `.count` (i.e. length) is 0 but the first index is accessed nonetheless.