### PR TITLE
Fixed edge case where entrysize == 0 for which the code is not well d…

### DIFF
--- a/src/pcre2_substring.c
+++ b/src/pcre2_substring.c
@@ -488,6 +488,8 @@ uint16_t top = code->name_count;
 uint16_t entrysize = code->name_entry_size;
 PCRE2_SPTR nametable = (PCRE2_SPTR)((char *)code + sizeof(pcre2_real_code));
 
+ if (entrysize == 0)
+   return PCRE2_ERROR_NOSUBSTRING;
 while (top > bot)
   {
   uint16_t mid = (top + bot) / 2;


### PR DESCRIPTION
…efined

Consequence of missing check could be an infinite loop execution due to doing -= 0 on line 506 and += 0 n line 511 following incorrect arithmetic on line 501

The fix is a simple two-liner change to filter erroneous edge case, cutting off execution before getting into anything problematic.

API and data structure look exposed via external API call: pcre2_substring_copy_byname