### PR TITLE
Backport locking fix in sljit allocator

### DIFF
--- a/src/sljit/allocator_src/sljitExecAllocatorCore.c
+++ b/src/sljit/allocator_src/sljitExecAllocatorCore.c
@@ -237,12 +237,12 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 		header->size = chunk_size;
 		next_header = AS_BLOCK_HEADER(header, chunk_size);
 	}
-	SLJIT_ALLOCATOR_UNLOCK();
 	next_header->size = 1;
 	next_header->prev_size = chunk_size;
 #ifdef SLJIT_HAS_EXECUTABLE_OFFSET
 	next_header->executable_offset = executable_offset;
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */
+	SLJIT_ALLOCATOR_UNLOCK();
 	return MEM_START(header);
 }
 


### PR DESCRIPTION
An erroneous locking issue was introduced in the sljit update of commit d84f255bef4d956d67ff5da35024e7a8c0c7e669.

It caused crashes when matching regular expressions in a multi-threaded context.

Fixes #402

Note: I only back-ported the minimal fix, also submitted as part of https://github.com/zherczeg/sljit/pull/244 instead of updating all the sljit source files because:

- I am new to both projects and did not want to introduce other breaking changes
- this is a small change that can be cherry-picked easily by downstream users

If you prefer to update the whole sljit code, as usual, feel free to close this.