### PR TITLE
update build.zig to support zig 0.12.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -78,6 +78,6 @@ pub fn build(b: *std.Build) !void {
         },
     });
 
-    lib.installHeader("src/pcre2.h.generic", "pcre2.h");
+    lib.installHeader(.{ .path = "src/pcre2.h.generic" }, "pcre2.h");
     b.installArtifact(lib);
 }


### PR DESCRIPTION
This is the only breaking change since the previous update

https://ziglang.org/documentation/0.12.0/std/#std.Build.Step.Compile.installHeader