### PR TITLE
m4/pcre2_visibility.m4: make sure PCRE2_EXPORT is always safe

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,8 @@ misunderstanding one of the grapheme sequence breaking rules in Unicode Annex
 break property unless a zero-width joiner intervenes. PCRE2 was not insisting
 on the ZWJ, causing \X to match more than it should. See GitHub issue #410.
 
+8. Avoid compilation issues with propietary compilers in UNIX since 10.43.
+
 
 Version 10.43 16-February-2024
 ------------------------------

--- a/m4/pcre2_visibility.m4
+++ b/m4/pcre2_visibility.m4
@@ -77,6 +77,8 @@ AC_DEFUN([PCRE2_VISIBILITY],
     else
       AC_DEFINE(PCRE2_EXPORT, [], [to make a symbol visible])
     fi
+  else
+    AC_DEFINE(PCRE2_EXPORT, [], [to make a symbol visible])
   fi
   AC_SUBST([VISIBILITY_CFLAGS])
   AC_SUBST([VISIBILITY_CXXFLAGS])


### PR DESCRIPTION
FTBFS with at least xlc or Sun Studio compilers

Fixes: #392