### PR TITLE
autotools: fix `make dist`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -277,7 +277,7 @@ EXTRA_DIST += \
 EXTRA_DIST += \
   vms/configure.com \
   vms/openvms_readme.txt \
-  vms/pcre2.h.patch \
+  vms/pcre2.h_patch \
   vms/stdint.h
 
 # These files are used in the preparation of a release


### PR DESCRIPTION
typo in cbff6bb (Install OpenVMS support files, 2024-04-16)