### PR TITLE
pcre2test: memory reports only compiled memory usage for code/data

### DIFF
--- a/doc/pcre2_set_max_pattern_compiled_length.3
+++ b/doc/pcre2_set_max_pattern_compiled_length.3
@@ -1,4 +1,4 @@
-.TH PCRE2_SET_MAX_PATTERN_COMPILED_LENGTH 3 "24 April 2024" "PCRE2 10.44"
+.TH PCRE2_SET_MAX_PATTERN_COMPILED_LENGTH 3 "8 Jun 2024" "PCRE2 10.45"
 .SH NAME
 PCRE2 - Perl-compatible regular expressions (revised API)
 .SH SYNOPSIS
@@ -15,9 +15,9 @@ PCRE2 - Perl-compatible regular expressions (revised API)
 .rs
 .sp
 This function sets, in a compile context, the maximum size (in bytes) for the
-memory needed to hold the compiled version of a pattern that is compiled with
-this context. The result is always zero. If a pattern that is passed to
-\fBpcre2_compile()\fP with this context needs more memory, an error is
+memory needed to hold the compiled version of a pattern that is using this
+context. The result is always zero. If a pattern that is passed to
+\fBpcre2_compile()\fP referencing this context needs more memory, an error is
 generated. The default is the largest number that a PCRE2_SIZE variable can
 hold, which is effectively unlimited.
 .P

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -10608,8 +10608,7 @@ block for storing the compiled pattern and names table. Integer overflow should
 no longer be possible because nowadays we limit the maximum value of
 cb.names_found and cb.name_entry_size. */
 
-re_blocksize = sizeof(pcre2_real_code) +
-  CU2BYTES(length +
+re_blocksize = CU2BYTES(length +
   (PCRE2_SIZE)cb.names_found * (PCRE2_SIZE)cb.name_entry_size);
 
 if (re_blocksize > ccontext->max_pattern_compiled_length)
@@ -10618,6 +10617,7 @@ if (re_blocksize > ccontext->max_pattern_compiled_length)
   goto HAD_CB_ERROR;
   }
 
+re_blocksize += sizeof(pcre2_real_code);
 re = (pcre2_real_code *)
   ccontext->memctl.malloc(re_blocksize, ccontext->memctl.memory_data);
 if (re == NULL)

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -4397,7 +4397,7 @@ static void
 show_memory_info(void)
 {
 uint32_t name_count, name_entry_size;
-PCRE2_SIZE size, cblock_size;
+PCRE2_SIZE size, cblock_size, data_size;
 
 /* One of the test_mode values will always be true, but to stop a compiler
 warning we must initialize cblock_size. */
@@ -4417,18 +4417,19 @@ if (test_mode == PCRE32_MODE) cblock_size = sizeof(pcre2_real_code_32);
 (void)pattern_info(PCRE2_INFO_NAMECOUNT, &name_count, FALSE);
 (void)pattern_info(PCRE2_INFO_NAMEENTRYSIZE, &name_entry_size, FALSE);
 
-/* The uint32_t variables are cast before multiplying to stop code analyzers
-grumbling about potential overflow. */
+/* The uint32_t variables are cast before multiplying to avoid potential
+ integer overflow. */
+data_size = (PCRE2_SIZE)name_count * (PCRE2_SIZE)name_entry_size * (PCRE2_SIZE)code_unit_size;
 
-fprintf(outfile, "Memory allocation - compiled block : %" SIZ_FORM "\n", size);
-fprintf(outfile, "Memory allocation - code portion   : %" SIZ_FORM "\n", size -
-  (PCRE2_SIZE)name_count * (PCRE2_SIZE)name_entry_size * (PCRE2_SIZE)code_unit_size -
-  cblock_size);
+fprintf(outfile, "Memory allocation - code size : %" SIZ_FORM "\n", size -
+  cblock_size - data_size);
+if (data_size != 0)
+  fprintf(outfile, "Memory allocation - data size : %" SIZ_FORM "\n", data_size);
 
 if (pat_patctl.jit != 0)
   {
   (void)pattern_info(PCRE2_INFO_JITSIZE, &size, FALSE);
-  fprintf(outfile, "Memory allocation - JIT code       : %" SIZ_FORM "\n", size);
+  fprintf(outfile, "Memory allocation - JIT code  : %" SIZ_FORM "\n", size);
   }
 }
 

--- a/testdata/testoutput8-16-2
+++ b/testdata/testoutput8-16-2
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   9 Bra
   2   5 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 174
-Memory allocation - code portion   : 38
+Memory allocation - code size : 38
 ------------------------------------------------------------------
   0  16 Bra
   2   7 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 38
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 172
-Memory allocation - code portion   : 36
+Memory allocation - code size : 36
 ------------------------------------------------------------------
   0  15 Bra
   2   6 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 36
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 182
-Memory allocation - code portion   : 46
+Memory allocation - code size : 46
 ------------------------------------------------------------------
   0  20 Bra
   2     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 46
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   2 Bra
   2   2 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   7 Bra
   2     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 20
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0  10 Bra
   2     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 26
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 278
-Memory allocation - code portion   : 142
+Memory allocation - code size : 142
 ------------------------------------------------------------------
   0  68 Bra
   2     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 142
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 1784
-Memory allocation - code portion   : 1648
+Memory allocation - code size : 1648
 ------------------------------------------------------------------
   0 821 Bra
   2     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 1648
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 1764
-Memory allocation - code portion   : 1628
+Memory allocation - code size : 1628
 ------------------------------------------------------------------
   0 811 Bra
   2     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 1628
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  13 Bra
   2   9 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 176
-Memory allocation - code portion   : 40
+Memory allocation - code size : 40
 ------------------------------------------------------------------
   0  17 Bra
   2  13 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 40
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 242
-Memory allocation - code portion   : 54
+Memory allocation - code size : 54
+Memory allocation - data size : 52
 ------------------------------------------------------------------
   0  24 Bra
   2     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 54
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 218
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
+Memory allocation - data size : 18
 ------------------------------------------------------------------
   0  29 Bra
   2  18 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 54
+Memory allocation - code size : 54
+Memory allocation - data size : 6
 ------------------------------------------------------------------
   0  24 Bra
   2   5 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 54
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 186
-Memory allocation - code portion   : 50
+Memory allocation - code size : 50
 ------------------------------------------------------------------
   0  22 Bra
   2     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 50
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 214
-Memory allocation - code portion   : 78
+Memory allocation - code size : 78
 ------------------------------------------------------------------
   0  36 Bra
   2     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 78
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 152
-Memory allocation - code portion   : 16
+Memory allocation - code size : 16
 ------------------------------------------------------------------
   0   5 Bra
   2     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 16
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 152
-Memory allocation - code portion   : 16
+Memory allocation - code size : 16
 ------------------------------------------------------------------
   0   5 Bra
   2     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 16
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 152
-Memory allocation - code portion   : 16
+Memory allocation - code size : 16
 ------------------------------------------------------------------
   0   5 Bra
   2     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 16
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0  10 Bra
   2     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 158
-Memory allocation - code portion   : 22
+Memory allocation - code size : 22
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \x{c5b4}
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 158
-Memory allocation - code portion   : 22
+Memory allocation - code size : 22
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x{8a9e}
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 190
-Memory allocation - code portion   : 54
+Memory allocation - code size : 54
 ------------------------------------------------------------------
   0  24 Bra
   2     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 54
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 26
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 26
 Failed: error 106 at offset 13: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  27 Bra
   2     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 194
-Memory allocation - code portion   : 58
+Memory allocation - code size : 58
 ------------------------------------------------------------------
   0  26 Bra
   2     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 58
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  13 Bra
   2  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  13 Bra
   2     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   9 Bra
   2     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  23 Bra
   2  19 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 52
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 178
-Memory allocation - code portion   : 42
+Memory allocation - code size : 42
 ------------------------------------------------------------------
   0  18 Bra
   2  14 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 42
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]

--- a/testdata/testoutput8-16-3
+++ b/testdata/testoutput8-16-3
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  12 Bra
   3   6 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0  20 Bra
   3   8 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 182
-Memory allocation - code portion   : 46
+Memory allocation - code size : 46
 ------------------------------------------------------------------
   0  19 Bra
   3   7 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 46
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 186
-Memory allocation - code portion   : 50
+Memory allocation - code size : 50
 ------------------------------------------------------------------
   0  21 Bra
   3     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 50
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   3 Bra
   3   3 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   8 Bra
   3     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 170
-Memory allocation - code portion   : 34
+Memory allocation - code size : 34
 ------------------------------------------------------------------
   0  13 Bra
   3     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 34
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 302
-Memory allocation - code portion   : 166
+Memory allocation - code size : 166
 ------------------------------------------------------------------
   0  79 Bra
   3     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 166
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 1788
-Memory allocation - code portion   : 1652
+Memory allocation - code size : 1652
 ------------------------------------------------------------------
   0 822 Bra
   3     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 1652
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 1768
-Memory allocation - code portion   : 1632
+Memory allocation - code size : 1632
 ------------------------------------------------------------------
   0 812 Bra
   3     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 1632
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 178
-Memory allocation - code portion   : 42
+Memory allocation - code size : 42
 ------------------------------------------------------------------
   0  17 Bra
   3  11 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 42
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 190
-Memory allocation - code portion   : 54
+Memory allocation - code size : 54
 ------------------------------------------------------------------
   0  23 Bra
   3  17 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 54
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 256
-Memory allocation - code portion   : 68
+Memory allocation - code size : 68
+Memory allocation - data size : 52
 ------------------------------------------------------------------
   0  30 Bra
   3     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 68
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 238
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
+Memory allocation - data size : 18
 ------------------------------------------------------------------
   0  38 Bra
   3  23 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 206
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
+Memory allocation - data size : 6
 ------------------------------------------------------------------
   0  28 Bra
   3   6 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 198
-Memory allocation - code portion   : 62
+Memory allocation - code size : 62
 ------------------------------------------------------------------
   0  27 Bra
   3     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 62
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 242
-Memory allocation - code portion   : 106
+Memory allocation - code size : 106
 ------------------------------------------------------------------
   0  49 Bra
   3     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 106
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 20
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 20
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 20
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0   9 Bra
   3     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \x{c5b4}
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0   9 Bra
   3     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x{8a9e}
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  26 Bra
   3     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  12 Bra
   3     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  12 Bra
   3     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 32
 Failed: error 106 at offset 13: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 202
-Memory allocation - code portion   : 66
+Memory allocation - code size : 66
 ------------------------------------------------------------------
   0  29 Bra
   3     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 66
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 200
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
 ------------------------------------------------------------------
   0  28 Bra
   3     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 172
-Memory allocation - code portion   : 36
+Memory allocation - code size : 36
 ------------------------------------------------------------------
   0  14 Bra
   3  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 36
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 172
-Memory allocation - code portion   : 36
+Memory allocation - code size : 36
 ------------------------------------------------------------------
   0  14 Bra
   3     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 36
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 206
-Memory allocation - code portion   : 70
+Memory allocation - code size : 70
 ------------------------------------------------------------------
   0  31 Bra
   3  25 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 70
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 192
-Memory allocation - code portion   : 56
+Memory allocation - code size : 56
 ------------------------------------------------------------------
   0  24 Bra
   3  18 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 56
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^\x{aa}]

--- a/testdata/testoutput8-16-4
+++ b/testdata/testoutput8-16-4
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  12 Bra
   3   6 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0  20 Bra
   3   8 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 182
-Memory allocation - code portion   : 46
+Memory allocation - code size : 46
 ------------------------------------------------------------------
   0  19 Bra
   3   7 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 46
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 186
-Memory allocation - code portion   : 50
+Memory allocation - code size : 50
 ------------------------------------------------------------------
   0  21 Bra
   3     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 50
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   3 Bra
   3   3 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0   8 Bra
   3     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 170
-Memory allocation - code portion   : 34
+Memory allocation - code size : 34
 ------------------------------------------------------------------
   0  13 Bra
   3     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 34
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 302
-Memory allocation - code portion   : 166
+Memory allocation - code size : 166
 ------------------------------------------------------------------
   0  79 Bra
   3     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 166
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 1788
-Memory allocation - code portion   : 1652
+Memory allocation - code size : 1652
 ------------------------------------------------------------------
   0 822 Bra
   3     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 1652
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 1768
-Memory allocation - code portion   : 1632
+Memory allocation - code size : 1632
 ------------------------------------------------------------------
   0 812 Bra
   3     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 1632
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 178
-Memory allocation - code portion   : 42
+Memory allocation - code size : 42
 ------------------------------------------------------------------
   0  17 Bra
   3  11 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 42
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 190
-Memory allocation - code portion   : 54
+Memory allocation - code size : 54
 ------------------------------------------------------------------
   0  23 Bra
   3  17 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 54
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 256
-Memory allocation - code portion   : 68
+Memory allocation - code size : 68
+Memory allocation - data size : 52
 ------------------------------------------------------------------
   0  30 Bra
   3     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 68
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 238
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
+Memory allocation - data size : 18
 ------------------------------------------------------------------
   0  38 Bra
   3  23 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 206
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
+Memory allocation - data size : 6
 ------------------------------------------------------------------
   0  28 Bra
   3   6 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 198
-Memory allocation - code portion   : 62
+Memory allocation - code size : 62
 ------------------------------------------------------------------
   0  27 Bra
   3     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 62
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 242
-Memory allocation - code portion   : 106
+Memory allocation - code size : 106
 ------------------------------------------------------------------
   0  49 Bra
   3     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 106
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 20
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 20
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 20
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0   9 Bra
   3     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \x{c5b4}
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0   9 Bra
   3     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x{8a9e}
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  26 Bra
   3     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  12 Bra
   3     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  12 Bra
   3     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 32
 Failed: error 106 at offset 13: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 202
-Memory allocation - code portion   : 66
+Memory allocation - code size : 66
 ------------------------------------------------------------------
   0  29 Bra
   3     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 66
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 200
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
 ------------------------------------------------------------------
   0  28 Bra
   3     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 172
-Memory allocation - code portion   : 36
+Memory allocation - code size : 36
 ------------------------------------------------------------------
   0  14 Bra
   3  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 36
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 172
-Memory allocation - code portion   : 36
+Memory allocation - code size : 36
 ------------------------------------------------------------------
   0  14 Bra
   3     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 36
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  11 Bra
   3     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 206
-Memory allocation - code portion   : 70
+Memory allocation - code size : 70
 ------------------------------------------------------------------
   0  31 Bra
   3  25 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 70
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 192
-Memory allocation - code portion   : 56
+Memory allocation - code size : 56
 ------------------------------------------------------------------
   0  24 Bra
   3  18 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 56
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0   5 Bra
   3     [^\x{aa}]

--- a/testdata/testoutput8-32-2
+++ b/testdata/testoutput8-32-2
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2   5 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 212
-Memory allocation - code portion   : 76
+Memory allocation - code size : 76
 ------------------------------------------------------------------
   0  16 Bra
   2   7 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 76
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 208
-Memory allocation - code portion   : 72
+Memory allocation - code size : 72
 ------------------------------------------------------------------
   0  15 Bra
   2   6 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 72
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   2 Bra
   2   2 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 176
-Memory allocation - code portion   : 40
+Memory allocation - code size : 40
 ------------------------------------------------------------------
   0   7 Bra
   2     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 40
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 52
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 356
-Memory allocation - code portion   : 220
+Memory allocation - code size : 220
 ------------------------------------------------------------------
   0  52 Bra
   2     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 220
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 3432
-Memory allocation - code portion   : 3296
+Memory allocation - code size : 3296
 ------------------------------------------------------------------
   0 821 Bra
   2     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 3296
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 3392
-Memory allocation - code portion   : 3256
+Memory allocation - code size : 3256
 ------------------------------------------------------------------
   0 811 Bra
   2     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 3256
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 200
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
 ------------------------------------------------------------------
   0  13 Bra
   2   9 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 216
-Memory allocation - code portion   : 80
+Memory allocation - code size : 80
 ------------------------------------------------------------------
   0  17 Bra
   2  13 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 80
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 348
-Memory allocation - code portion   : 108
+Memory allocation - code size : 108
+Memory allocation - data size : 104
 ------------------------------------------------------------------
   0  24 Bra
   2     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 108
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 300
-Memory allocation - code portion   : 128
+Memory allocation - code size : 128
+Memory allocation - data size : 36
 ------------------------------------------------------------------
   0  29 Bra
   2  18 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 128
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 256
-Memory allocation - code portion   : 108
+Memory allocation - code size : 108
+Memory allocation - data size : 12
 ------------------------------------------------------------------
   0  24 Bra
   2   5 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 108
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 236
-Memory allocation - code portion   : 100
+Memory allocation - code size : 100
 ------------------------------------------------------------------
   0  22 Bra
   2     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 100
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 292
-Memory allocation - code portion   : 156
+Memory allocation - code size : 156
 ------------------------------------------------------------------
   0  36 Bra
   2     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 156
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 28
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 180
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \x{c5b4}
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 180
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x{8a9e}
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 212
-Memory allocation - code portion   : 76
+Memory allocation - code size : 76
 ------------------------------------------------------------------
   0  16 Bra
   2     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 76
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 52
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 52
 Failed: error 106 at offset 13: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 224
-Memory allocation - code portion   : 88
+Memory allocation - code size : 88
 ------------------------------------------------------------------
   0  19 Bra
   2     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 88
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 220
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
 ------------------------------------------------------------------
   0  18 Bra
   2     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 240
-Memory allocation - code portion   : 104
+Memory allocation - code size : 104
 ------------------------------------------------------------------
   0  23 Bra
   2  19 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 104
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 220
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
 ------------------------------------------------------------------
   0  18 Bra
   2  14 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]

--- a/testdata/testoutput8-32-3
+++ b/testdata/testoutput8-32-3
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2   5 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 212
-Memory allocation - code portion   : 76
+Memory allocation - code size : 76
 ------------------------------------------------------------------
   0  16 Bra
   2   7 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 76
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 208
-Memory allocation - code portion   : 72
+Memory allocation - code size : 72
 ------------------------------------------------------------------
   0  15 Bra
   2   6 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 72
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   2 Bra
   2   2 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 176
-Memory allocation - code portion   : 40
+Memory allocation - code size : 40
 ------------------------------------------------------------------
   0   7 Bra
   2     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 40
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 52
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 356
-Memory allocation - code portion   : 220
+Memory allocation - code size : 220
 ------------------------------------------------------------------
   0  52 Bra
   2     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 220
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 3432
-Memory allocation - code portion   : 3296
+Memory allocation - code size : 3296
 ------------------------------------------------------------------
   0 821 Bra
   2     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 3296
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 3392
-Memory allocation - code portion   : 3256
+Memory allocation - code size : 3256
 ------------------------------------------------------------------
   0 811 Bra
   2     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 3256
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 200
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
 ------------------------------------------------------------------
   0  13 Bra
   2   9 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 216
-Memory allocation - code portion   : 80
+Memory allocation - code size : 80
 ------------------------------------------------------------------
   0  17 Bra
   2  13 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 80
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 348
-Memory allocation - code portion   : 108
+Memory allocation - code size : 108
+Memory allocation - data size : 104
 ------------------------------------------------------------------
   0  24 Bra
   2     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 108
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 300
-Memory allocation - code portion   : 128
+Memory allocation - code size : 128
+Memory allocation - data size : 36
 ------------------------------------------------------------------
   0  29 Bra
   2  18 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 128
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 256
-Memory allocation - code portion   : 108
+Memory allocation - code size : 108
+Memory allocation - data size : 12
 ------------------------------------------------------------------
   0  24 Bra
   2   5 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 108
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 236
-Memory allocation - code portion   : 100
+Memory allocation - code size : 100
 ------------------------------------------------------------------
   0  22 Bra
   2     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 100
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 292
-Memory allocation - code portion   : 156
+Memory allocation - code size : 156
 ------------------------------------------------------------------
   0  36 Bra
   2     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 156
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 28
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 180
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \x{c5b4}
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 180
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x{8a9e}
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 212
-Memory allocation - code portion   : 76
+Memory allocation - code size : 76
 ------------------------------------------------------------------
   0  16 Bra
   2     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 76
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 52
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 52
 Failed: error 106 at offset 13: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 224
-Memory allocation - code portion   : 88
+Memory allocation - code size : 88
 ------------------------------------------------------------------
   0  19 Bra
   2     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 88
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 220
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
 ------------------------------------------------------------------
   0  18 Bra
   2     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 240
-Memory allocation - code portion   : 104
+Memory allocation - code size : 104
 ------------------------------------------------------------------
   0  23 Bra
   2  19 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 104
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 220
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
 ------------------------------------------------------------------
   0  18 Bra
   2  14 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]

--- a/testdata/testoutput8-32-4
+++ b/testdata/testoutput8-32-4
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2   5 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 212
-Memory allocation - code portion   : 76
+Memory allocation - code size : 76
 ------------------------------------------------------------------
   0  16 Bra
   2   7 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 76
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 208
-Memory allocation - code portion   : 72
+Memory allocation - code size : 72
 ------------------------------------------------------------------
   0  15 Bra
   2   6 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 72
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0   2 Bra
   2   2 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 176
-Memory allocation - code portion   : 40
+Memory allocation - code size : 40
 ------------------------------------------------------------------
   0   7 Bra
   2     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 40
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 52
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 356
-Memory allocation - code portion   : 220
+Memory allocation - code size : 220
 ------------------------------------------------------------------
   0  52 Bra
   2     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 220
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 3432
-Memory allocation - code portion   : 3296
+Memory allocation - code size : 3296
 ------------------------------------------------------------------
   0 821 Bra
   2     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 3296
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 3392
-Memory allocation - code portion   : 3256
+Memory allocation - code size : 3256
 ------------------------------------------------------------------
   0 811 Bra
   2     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 3256
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 200
-Memory allocation - code portion   : 64
+Memory allocation - code size : 64
 ------------------------------------------------------------------
   0  13 Bra
   2   9 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 64
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 216
-Memory allocation - code portion   : 80
+Memory allocation - code size : 80
 ------------------------------------------------------------------
   0  17 Bra
   2  13 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 80
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 348
-Memory allocation - code portion   : 108
+Memory allocation - code size : 108
+Memory allocation - data size : 104
 ------------------------------------------------------------------
   0  24 Bra
   2     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 108
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 300
-Memory allocation - code portion   : 128
+Memory allocation - code size : 128
+Memory allocation - data size : 36
 ------------------------------------------------------------------
   0  29 Bra
   2  18 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 128
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 256
-Memory allocation - code portion   : 108
+Memory allocation - code size : 108
+Memory allocation - data size : 12
 ------------------------------------------------------------------
   0  24 Bra
   2   5 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 108
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 236
-Memory allocation - code portion   : 100
+Memory allocation - code size : 100
 ------------------------------------------------------------------
   0  22 Bra
   2     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 100
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 292
-Memory allocation - code portion   : 156
+Memory allocation - code size : 156
 ------------------------------------------------------------------
   0  36 Bra
   2     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 156
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 28
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 180
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \x{c5b4}
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 180
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
 ------------------------------------------------------------------
   0   8 Bra
   2     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x{8a9e}
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 212
-Memory allocation - code portion   : 76
+Memory allocation - code size : 76
 ------------------------------------------------------------------
   0  16 Bra
   2     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 76
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 52
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 188
-Memory allocation - code portion   : 52
+Memory allocation - code size : 52
 ------------------------------------------------------------------
   0  10 Bra
   2     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 52
 Failed: error 106 at offset 13: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 224
-Memory allocation - code portion   : 88
+Memory allocation - code size : 88
 ------------------------------------------------------------------
   0  19 Bra
   2     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 88
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 220
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
 ------------------------------------------------------------------
   0  18 Bra
   2     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 196
-Memory allocation - code portion   : 60
+Memory allocation - code size : 60
 ------------------------------------------------------------------
   0  12 Bra
   2     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 60
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0   9 Bra
   2     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 240
-Memory allocation - code portion   : 104
+Memory allocation - code size : 104
 ------------------------------------------------------------------
   0  23 Bra
   2  19 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 104
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 220
-Memory allocation - code portion   : 84
+Memory allocation - code size : 84
 ------------------------------------------------------------------
   0  18 Bra
   2  14 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 84
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0   4 Bra
   2     [^\x{aa}]

--- a/testdata/testoutput8-8-2
+++ b/testdata/testoutput8-8-2
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 153
-Memory allocation - code portion   : 17
+Memory allocation - code size : 17
 ------------------------------------------------------------------
   0  13 Bra
   3   7 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 17
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 161
-Memory allocation - code portion   : 25
+Memory allocation - code size : 25
 ------------------------------------------------------------------
   0  21 Bra
   3   9 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 25
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 159
-Memory allocation - code portion   : 23
+Memory allocation - code size : 23
 ------------------------------------------------------------------
   0  19 Bra
   3   7 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 23
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 177
-Memory allocation - code portion   : 41
+Memory allocation - code size : 41
 ------------------------------------------------------------------
   0  37 Bra
   3     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 41
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 143
-Memory allocation - code portion   : 7
+Memory allocation - code size : 7
 ------------------------------------------------------------------
   0   3 Bra
   3   3 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   9 Bra
   3     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  14 Bra
   3     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 256
-Memory allocation - code portion   : 120
+Memory allocation - code size : 120
 ------------------------------------------------------------------
   0 116 Bra
   3     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 120
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 962
-Memory allocation - code portion   : 826
+Memory allocation - code size : 826
 ------------------------------------------------------------------
   0 822 Bra
   3     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 826
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 952
-Memory allocation - code portion   : 816
+Memory allocation - code size : 816
 ------------------------------------------------------------------
   0 812 Bra
   3     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 816
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 158
-Memory allocation - code portion   : 22
+Memory allocation - code size : 22
 ------------------------------------------------------------------
   0  18 Bra
   3  12 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 22
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0  24 Bra
   3  18 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 200
-Memory allocation - code portion   : 36
+Memory allocation - code size : 36
+Memory allocation - data size : 28
 ------------------------------------------------------------------
   0  32 Bra
   3     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 36
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 193
-Memory allocation - code portion   : 45
+Memory allocation - code size : 45
+Memory allocation - data size : 12
 ------------------------------------------------------------------
   0  41 Bra
   3  25 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 45
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 174
-Memory allocation - code portion   : 34
+Memory allocation - code size : 34
+Memory allocation - data size : 4
 ------------------------------------------------------------------
   0  30 Bra
   3   7 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 34
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 167
-Memory allocation - code portion   : 31
+Memory allocation - code size : 31
 ------------------------------------------------------------------
   0  27 Bra
   3     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 31
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 189
-Memory allocation - code portion   : 53
+Memory allocation - code size : 53
 ------------------------------------------------------------------
   0  49 Bra
   3     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 53
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 10
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   7 Bra
   3     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   8 Bra
   3     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   8 Bra
   3     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   8 Bra
   3     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 12
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 10
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 10
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 10
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 10
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  14 Bra
   3     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 155
-Memory allocation - code portion   : 19
+Memory allocation - code size : 19
 ------------------------------------------------------------------
   0  15 Bra
   3     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \xb4
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 155
-Memory allocation - code portion   : 19
+Memory allocation - code size : 19
 ------------------------------------------------------------------
   0  15 Bra
   3     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x9e
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 10
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 183
-Memory allocation - code portion   : 47
+Memory allocation - code size : 47
 ------------------------------------------------------------------
   0  43 Bra
   3     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 47
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  14 Bra
   3     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  14 Bra
   3     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 18
 Failed: error 106 at offset 15: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 151
-Memory allocation - code portion   : 15
+Memory allocation - code size : 15
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 15
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 151
-Memory allocation - code portion   : 15
+Memory allocation - code size : 15
 ------------------------------------------------------------------
   0  11 Bra
   3     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 15
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 151
-Memory allocation - code portion   : 15
+Memory allocation - code size : 15
 ------------------------------------------------------------------
   0  11 Bra
   3     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 15
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 151
-Memory allocation - code portion   : 15
+Memory allocation - code size : 15
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 15
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 186
-Memory allocation - code portion   : 50
+Memory allocation - code size : 50
 ------------------------------------------------------------------
   0  46 Bra
   3     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 50
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 151
-Memory allocation - code portion   : 15
+Memory allocation - code size : 15
 ------------------------------------------------------------------
   0  11 Bra
   3     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 15
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 48
+Memory allocation - code size : 48
 ------------------------------------------------------------------
   0  44 Bra
   3     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 48
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 161
-Memory allocation - code portion   : 25
+Memory allocation - code size : 25
 ------------------------------------------------------------------
   0  21 Bra
   3  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 25
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 161
-Memory allocation - code portion   : 25
+Memory allocation - code size : 25
 ------------------------------------------------------------------
   0  21 Bra
   3     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 25
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 153
-Memory allocation - code portion   : 17
+Memory allocation - code size : 17
 ------------------------------------------------------------------
   0  13 Bra
   3     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 17
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 174
-Memory allocation - code portion   : 38
+Memory allocation - code size : 38
 ------------------------------------------------------------------
   0  34 Bra
   3  28 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 38
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  26 Bra
   3  20 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 10
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   5 Bra
   3     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 9
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 146
-Memory allocation - code portion   : 10
+Memory allocation - code size : 10
 ------------------------------------------------------------------
   0   6 Bra
   3     [^\x{aa}]

--- a/testdata/testoutput8-8-3
+++ b/testdata/testoutput8-8-3
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  16 Bra
   4   8 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 21
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 166
-Memory allocation - code portion   : 30
+Memory allocation - code size : 30
 ------------------------------------------------------------------
   0  25 Bra
   4  10 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 30
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 164
-Memory allocation - code portion   : 28
+Memory allocation - code size : 28
 ------------------------------------------------------------------
   0  23 Bra
   4   8 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 28
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 179
-Memory allocation - code portion   : 43
+Memory allocation - code size : 43
 ------------------------------------------------------------------
   0  38 Bra
   4     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 43
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 145
-Memory allocation - code portion   : 9
+Memory allocation - code size : 9
 ------------------------------------------------------------------
   0   4 Bra
   4   4 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 151
-Memory allocation - code portion   : 15
+Memory allocation - code size : 15
 ------------------------------------------------------------------
   0  10 Bra
   4     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 15
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 158
-Memory allocation - code portion   : 22
+Memory allocation - code size : 22
 ------------------------------------------------------------------
   0  17 Bra
   4     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 22
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 268
-Memory allocation - code portion   : 132
+Memory allocation - code size : 132
 ------------------------------------------------------------------
   0 127 Bra
   4     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 132
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 964
-Memory allocation - code portion   : 828
+Memory allocation - code size : 828
 ------------------------------------------------------------------
   0 823 Bra
   4     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 828
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 954
-Memory allocation - code portion   : 818
+Memory allocation - code size : 818
 ------------------------------------------------------------------
   0 813 Bra
   4     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 818
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 163
-Memory allocation - code portion   : 27
+Memory allocation - code size : 27
 ------------------------------------------------------------------
   0  22 Bra
   4  14 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 27
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 171
-Memory allocation - code portion   : 35
+Memory allocation - code size : 35
 ------------------------------------------------------------------
   0  30 Bra
   4  22 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 35
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 207
-Memory allocation - code portion   : 43
+Memory allocation - code size : 43
+Memory allocation - data size : 28
 ------------------------------------------------------------------
   0  38 Bra
   4     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 43
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 203
-Memory allocation - code portion   : 55
+Memory allocation - code size : 55
+Memory allocation - data size : 12
 ------------------------------------------------------------------
   0  50 Bra
   4  30 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 55
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 179
-Memory allocation - code portion   : 39
+Memory allocation - code size : 39
+Memory allocation - data size : 4
 ------------------------------------------------------------------
   0  34 Bra
   4   8 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 39
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 173
-Memory allocation - code portion   : 37
+Memory allocation - code size : 37
 ------------------------------------------------------------------
   0  32 Bra
   4     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 37
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 203
-Memory allocation - code portion   : 67
+Memory allocation - code size : 67
 ------------------------------------------------------------------
   0  62 Bra
   4     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 67
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   8 Bra
   4     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   9 Bra
   4     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   9 Bra
   4     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   9 Bra
   4     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 14
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0  15 Bra
   4     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  16 Bra
   4     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \xb4
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  16 Bra
   4     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x9e
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 186
-Memory allocation - code portion   : 50
+Memory allocation - code size : 50
 ------------------------------------------------------------------
   0  45 Bra
   4     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 50
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  16 Bra
   4     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 21
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  16 Bra
   4     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 21
 Failed: error 106 at offset 15: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  13 Bra
   4     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  13 Bra
   4     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  13 Bra
   4     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  13 Bra
   4     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 189
-Memory allocation - code portion   : 53
+Memory allocation - code size : 53
 ------------------------------------------------------------------
   0  48 Bra
   4     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 53
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 154
-Memory allocation - code portion   : 18
+Memory allocation - code size : 18
 ------------------------------------------------------------------
   0  13 Bra
   4     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 18
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 187
-Memory allocation - code portion   : 51
+Memory allocation - code size : 51
 ------------------------------------------------------------------
   0  46 Bra
   4     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 51
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 163
-Memory allocation - code portion   : 27
+Memory allocation - code size : 27
 ------------------------------------------------------------------
   0  22 Bra
   4  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 27
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 163
-Memory allocation - code portion   : 27
+Memory allocation - code size : 27
 ------------------------------------------------------------------
   0  22 Bra
   4     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 27
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 156
-Memory allocation - code portion   : 20
+Memory allocation - code size : 20
 ------------------------------------------------------------------
   0  15 Bra
   4     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 20
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 183
-Memory allocation - code portion   : 47
+Memory allocation - code size : 47
 ------------------------------------------------------------------
   0  42 Bra
   4  34 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 47
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 173
-Memory allocation - code portion   : 37
+Memory allocation - code size : 37
 ------------------------------------------------------------------
   0  32 Bra
   4  24 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 37
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 12
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   6 Bra
   4     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 11
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 148
-Memory allocation - code portion   : 12
+Memory allocation - code size : 12
 ------------------------------------------------------------------
   0   7 Bra
   4     [^\x{aa}]

--- a/testdata/testoutput8-8-4
+++ b/testdata/testoutput8-8-4
@@ -10,8 +10,7 @@
 #pattern fullbincode,memory
 
 /((?i)b)/
-Memory allocation - compiled block : 161
-Memory allocation - code portion   : 25
+Memory allocation - code size : 25
 ------------------------------------------------------------------
   0  19 Bra
   5   9 CBra 1
@@ -22,8 +21,7 @@ Memory allocation - code portion   : 25
 ------------------------------------------------------------------
 
 /(?s)(.*X|^B)/
-Memory allocation - compiled block : 171
-Memory allocation - code portion   : 35
+Memory allocation - code size : 35
 ------------------------------------------------------------------
   0  29 Bra
   5  11 CBra 1
@@ -38,8 +36,7 @@ Memory allocation - code portion   : 35
 ------------------------------------------------------------------
 
 /(?s:.*X|^B)/
-Memory allocation - compiled block : 169
-Memory allocation - code portion   : 33
+Memory allocation - code size : 33
 ------------------------------------------------------------------
   0  27 Bra
   5   9 Bra
@@ -54,8 +51,7 @@ Memory allocation - code portion   : 33
 ------------------------------------------------------------------
 
 /^[[:alnum:]]/
-Memory allocation - compiled block : 181
-Memory allocation - code portion   : 45
+Memory allocation - code size : 45
 ------------------------------------------------------------------
   0  39 Bra
   5     ^
@@ -65,8 +61,7 @@ Memory allocation - code portion   : 45
 ------------------------------------------------------------------
 
 /#/Ix
-Memory allocation - compiled block : 147
-Memory allocation - code portion   : 11
+Memory allocation - code size : 11
 ------------------------------------------------------------------
   0   5 Bra
   5   5 Ket
@@ -78,8 +73,7 @@ Options: extended
 Subject length lower bound = 0
 
 /a#/Ix
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     a
@@ -92,8 +86,7 @@ First code unit = 'a'
 Subject length lower bound = 1
 
 /x?+/
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     x?+
@@ -102,8 +95,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /x++/
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     x++
@@ -112,8 +104,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /x{1,3}+/
-Memory allocation - compiled block : 153
-Memory allocation - code portion   : 17
+Memory allocation - code size : 17
 ------------------------------------------------------------------
   0  11 Bra
   5     x
@@ -123,8 +114,7 @@ Memory allocation - code portion   : 17
 ------------------------------------------------------------------
 
 /(x)*+/
-Memory allocation - compiled block : 162
-Memory allocation - code portion   : 26
+Memory allocation - code size : 26
 ------------------------------------------------------------------
   0  20 Bra
   5     Braposzero
@@ -136,8 +126,7 @@ Memory allocation - code portion   : 26
 ------------------------------------------------------------------
 
 /^((a+)(?U)([ab]+)(?-U)([bc]+)(\w*))/
-Memory allocation - compiled block : 280
-Memory allocation - code portion   : 144
+Memory allocation - code size : 144
 ------------------------------------------------------------------
   0 138 Bra
   5     ^
@@ -160,8 +149,7 @@ Memory allocation - code portion   : 144
 ------------------------------------------------------------------
 
 "8J\$WE\<\.rX\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 966
-Memory allocation - code portion   : 830
+Memory allocation - code size : 830
 ------------------------------------------------------------------
   0 824 Bra
   5     8J$WE<.rX+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -171,8 +159,7 @@ Memory allocation - code portion   : 830
 ------------------------------------------------------------------
 
 "\$\<\.X\+ix\[d1b\!H\#\?vV0vrK\:ZH1\=2M\>iV\;\?aPhFB\<\*vW\@QW\@sO9\}cfZA\-i\'w\%hKd6gt1UJP\,15_\#QY\$M\^Mss_U\/\]\&LK9\[5vQub\^w\[KDD\<EjmhUZ\?\.akp2dF\>qmj\;2\}YWFdYx\.Ap\]hjCPTP\(n28k\+3\;o\&WXqs\/gOXdr\$\:r\'do0\;b4c\(f_Gr\=\"\\4\)\[01T7ajQJvL\$W\~mL_sS\/4h\:x\*\[ZN\=KLs\&L5zX\/\/\>it\,o\:aU\(\;Z\>pW\&T7oP\'2K\^E\:x9\'c\[\%z\-\,64JQ5AeH_G\#KijUKghQw\^\\vea3a\?kka_G\$8\#\`\*kynsxzBLru\'\]k_\[7FrVx\}\^\=\$blx\>s\-N\%j\;D\*aZDnsw\:YKZ\%Q\.Kne9\#hP\?\+b3\(SOvL\,\^\;\&u5\@\?5C5Bhb\=m\-vEh_L15Jl\]U\)0RP6\{q\%L\^_z5E\'Dw6X\b"
-Memory allocation - compiled block : 956
-Memory allocation - code portion   : 820
+Memory allocation - code size : 820
 ------------------------------------------------------------------
   0 814 Bra
   5     $<.X+ix[d1b!H#?vV0vrK:ZH1=2M>iV;?aPhFB<*vW@QW@sO9}cfZA-i'w%hKd6gt1UJP,15_#QY$M^Mss_U/]&LK9[5vQub^w[KDD<EjmhUZ?.akp2dF>qmj;2}YWFdYx.Ap]hjCPTP(n28k+3;o&WXqs/gOXdr$:r'do0;b4c(f_Gr="\4)[01T7ajQJvL$W~mL_sS/4h:x*[ZN=KLs&L5zX//>it,o:aU(;Z>pW&T7oP'2K^E:x9'c[%z-,64JQ5AeH_G#KijUKghQw^\vea3a?kka_G$8#`*kynsxzBLru']k_[7FrVx}^=$blx>s-N%j;D*aZDnsw:YKZ%Q.Kne9#hP?+b3(SOvL,^;&u5@?5C5Bhb=m-vEh_L15Jl]U)0RP6{q%L^_z5E'Dw6X
@@ -182,8 +169,7 @@ Memory allocation - code portion   : 820
 ------------------------------------------------------------------
 
 /(a(?1)b)/
-Memory allocation - compiled block : 168
-Memory allocation - code portion   : 32
+Memory allocation - code size : 32
 ------------------------------------------------------------------
   0  26 Bra
   5  16 CBra 1
@@ -196,8 +182,7 @@ Memory allocation - code portion   : 32
 ------------------------------------------------------------------
 
 /(a(?1)+b)/
-Memory allocation - compiled block : 178
-Memory allocation - code portion   : 42
+Memory allocation - code size : 42
 ------------------------------------------------------------------
   0  36 Bra
   5  26 CBra 1
@@ -212,8 +197,8 @@ Memory allocation - code portion   : 42
 ------------------------------------------------------------------
 
 /a(?P<name1>b|c)d(?P<longername2>e)/
-Memory allocation - compiled block : 214
-Memory allocation - code portion   : 50
+Memory allocation - code size : 50
+Memory allocation - data size : 28
 ------------------------------------------------------------------
   0  44 Bra
   5     a
@@ -231,8 +216,8 @@ Memory allocation - code portion   : 50
 ------------------------------------------------------------------
 
 /(?:a(?P<c>c(?P<d>d)))(?P<a>a)/
-Memory allocation - compiled block : 213
-Memory allocation - code portion   : 65
+Memory allocation - code size : 65
+Memory allocation - data size : 12
 ------------------------------------------------------------------
   0  59 Bra
   5  35 Bra
@@ -252,8 +237,8 @@ Memory allocation - code portion   : 65
 ------------------------------------------------------------------
 
 /(?P<a>a)...(?P=a)bbb(?P>a)d/
-Memory allocation - compiled block : 184
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
+Memory allocation - data size : 4
 ------------------------------------------------------------------
   0  38 Bra
   5   9 CBra 1
@@ -271,8 +256,7 @@ Memory allocation - code portion   : 44
 ------------------------------------------------------------------
 
 /abc(?C255)de(?C)f/
-Memory allocation - compiled block : 179
-Memory allocation - code portion   : 43
+Memory allocation - code size : 43
 ------------------------------------------------------------------
   0  37 Bra
   5     abc
@@ -285,8 +269,7 @@ Memory allocation - code portion   : 43
 ------------------------------------------------------------------
 
 /abcde/auto_callout
-Memory allocation - compiled block : 217
-Memory allocation - code portion   : 81
+Memory allocation - code size : 81
 ------------------------------------------------------------------
   0  75 Bra
   5     Callout 255 0 1
@@ -305,8 +288,7 @@ Memory allocation - code portion   : 81
 ------------------------------------------------------------------
 
 /\x{100}/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     \x{100}
@@ -315,8 +297,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x{1000}/utf
-Memory allocation - compiled block : 151
-Memory allocation - code portion   : 15
+Memory allocation - code size : 15
 ------------------------------------------------------------------
   0   9 Bra
   5     \x{1000}
@@ -325,8 +306,7 @@ Memory allocation - code portion   : 15
 ------------------------------------------------------------------
 
 /\x{10000}/utf
-Memory allocation - compiled block : 152
-Memory allocation - code portion   : 16
+Memory allocation - code size : 16
 ------------------------------------------------------------------
   0  10 Bra
   5     \x{10000}
@@ -335,8 +315,7 @@ Memory allocation - code portion   : 16
 ------------------------------------------------------------------
 
 /\x{100000}/utf
-Memory allocation - compiled block : 152
-Memory allocation - code portion   : 16
+Memory allocation - code size : 16
 ------------------------------------------------------------------
   0  10 Bra
   5     \x{100000}
@@ -345,8 +324,7 @@ Memory allocation - code portion   : 16
 ------------------------------------------------------------------
 
 /\x{10ffff}/utf
-Memory allocation - compiled block : 152
-Memory allocation - code portion   : 16
+Memory allocation - code size : 16
 ------------------------------------------------------------------
   0  10 Bra
   5     \x{10ffff}
@@ -358,8 +336,7 @@ Memory allocation - code portion   : 16
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 
 /[\x{ff}]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     \x{ff}
@@ -368,8 +345,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     \x{100}
@@ -378,8 +354,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x80/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     \x{80}
@@ -388,8 +363,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\xff/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     \x{ff}
@@ -398,8 +372,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /\x{0041}\x{2262}\x{0391}\x{002e}/I,utf
-Memory allocation - compiled block : 158
-Memory allocation - code portion   : 22
+Memory allocation - code size : 22
 ------------------------------------------------------------------
   0  16 Bra
   5     A\x{2262}\x{391}.
@@ -413,8 +386,7 @@ Last code unit = '.'
 Subject length lower bound = 4
 
 /\x{D55c}\x{ad6d}\x{C5B4}/I,utf
-Memory allocation - compiled block : 159
-Memory allocation - code portion   : 23
+Memory allocation - code size : 23
 ------------------------------------------------------------------
   0  17 Bra
   5     \x{d55c}\x{ad6d}\x{c5b4}
@@ -428,8 +400,7 @@ Last code unit = \xb4
 Subject length lower bound = 3
 
 /\x{65e5}\x{672c}\x{8a9e}/I,utf
-Memory allocation - compiled block : 159
-Memory allocation - code portion   : 23
+Memory allocation - code size : 23
 ------------------------------------------------------------------
   0  17 Bra
   5     \x{65e5}\x{672c}\x{8a9e}
@@ -443,8 +414,7 @@ Last code unit = \x9e
 Subject length lower bound = 3
 
 /[\x{100}]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     \x{100}
@@ -453,8 +423,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[Z\x{100}]/utf
-Memory allocation - compiled block : 189
-Memory allocation - code portion   : 53
+Memory allocation - code size : 53
 ------------------------------------------------------------------
   0  47 Bra
   5     [Z\x{100}]
@@ -463,8 +432,7 @@ Memory allocation - code portion   : 53
 ------------------------------------------------------------------
 
 /^[\x{100}\E-\Q\E\x{150}]/utf
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0  18 Bra
   5     ^
@@ -474,8 +442,7 @@ Memory allocation - code portion   : 24
 ------------------------------------------------------------------
 
 /^[\QĀ\E-\QŐ\E]/utf
-Memory allocation - compiled block : 160
-Memory allocation - code portion   : 24
+Memory allocation - code size : 24
 ------------------------------------------------------------------
   0  18 Bra
   5     ^
@@ -488,8 +455,7 @@ Memory allocation - code portion   : 24
 Failed: error 106 at offset 15: missing terminating ] for character class
 
 /[\p{L}]/
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  15 Bra
   5     [\p{L}]
@@ -498,8 +464,7 @@ Memory allocation - code portion   : 21
 ------------------------------------------------------------------
 
 /[\p{^L}]/
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  15 Bra
   5     [\P{L}]
@@ -508,8 +473,7 @@ Memory allocation - code portion   : 21
 ------------------------------------------------------------------
 
 /[\P{L}]/
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  15 Bra
   5     [\P{L}]
@@ -518,8 +482,7 @@ Memory allocation - code portion   : 21
 ------------------------------------------------------------------
 
 /[\P{^L}]/
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  15 Bra
   5     [\p{L}]
@@ -528,8 +491,7 @@ Memory allocation - code portion   : 21
 ------------------------------------------------------------------
 
 /[abc\p{L}\x{0660}]/utf
-Memory allocation - compiled block : 192
-Memory allocation - code portion   : 56
+Memory allocation - code size : 56
 ------------------------------------------------------------------
   0  50 Bra
   5     [a-c\p{L}\x{660}]
@@ -538,8 +500,7 @@ Memory allocation - code portion   : 56
 ------------------------------------------------------------------
 
 /[\p{Nd}]/utf
-Memory allocation - compiled block : 157
-Memory allocation - code portion   : 21
+Memory allocation - code size : 21
 ------------------------------------------------------------------
   0  15 Bra
   5     [\p{Nd}]
@@ -548,8 +509,7 @@ Memory allocation - code portion   : 21
 ------------------------------------------------------------------
 
 /[\p{Nd}+-]+/utf
-Memory allocation - compiled block : 190
-Memory allocation - code portion   : 54
+Memory allocation - code size : 54
 ------------------------------------------------------------------
   0  48 Bra
   5     [+\-\p{Nd}]++
@@ -558,8 +518,7 @@ Memory allocation - code portion   : 54
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/i,utf
-Memory allocation - compiled block : 165
-Memory allocation - code portion   : 29
+Memory allocation - code size : 29
 ------------------------------------------------------------------
   0  23 Bra
   5  /i A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -568,8 +527,7 @@ Memory allocation - code portion   : 29
 ------------------------------------------------------------------
 
 /A\x{391}\x{10427}\x{ff3a}\x{1fb0}/utf
-Memory allocation - compiled block : 165
-Memory allocation - code portion   : 29
+Memory allocation - code size : 29
 ------------------------------------------------------------------
   0  23 Bra
   5     A\x{391}\x{10427}\x{ff3a}\x{1fb0}
@@ -578,8 +536,7 @@ Memory allocation - code portion   : 29
 ------------------------------------------------------------------
 
 /[\x{105}-\x{109}]/i,utf
-Memory allocation - compiled block : 159
-Memory allocation - code portion   : 23
+Memory allocation - code size : 23
 ------------------------------------------------------------------
   0  17 Bra
   5     [\x{104}-\x{109}]
@@ -588,8 +545,7 @@ Memory allocation - code portion   : 23
 ------------------------------------------------------------------
 
 /( ( (?(1)0|) )*   )/x
-Memory allocation - compiled block : 192
-Memory allocation - code portion   : 56
+Memory allocation - code size : 56
 ------------------------------------------------------------------
   0  50 Bra
   5  40 CBra 1
@@ -607,8 +563,7 @@ Memory allocation - code portion   : 56
 ------------------------------------------------------------------
 
 /(  (?(1)0|)*   )/x
-Memory allocation - compiled block : 180
-Memory allocation - code portion   : 44
+Memory allocation - code size : 44
 ------------------------------------------------------------------
   0  38 Bra
   5  28 CBra 1
@@ -624,8 +579,7 @@ Memory allocation - code portion   : 44
 ------------------------------------------------------------------
 
 /[a]/
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     a
@@ -634,8 +588,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /[a]/utf
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     a
@@ -644,8 +597,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /[\xaa]/
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     \x{aa}
@@ -654,8 +606,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /[\xaa]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     \x{aa}
@@ -664,8 +615,7 @@ Memory allocation - code portion   : 14
 ------------------------------------------------------------------
 
 /[^a]/
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     [^a]
@@ -674,8 +624,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /[^a]/utf
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     [^a]
@@ -684,8 +633,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /[^\xaa]/
-Memory allocation - compiled block : 149
-Memory allocation - code portion   : 13
+Memory allocation - code size : 13
 ------------------------------------------------------------------
   0   7 Bra
   5     [^\x{aa}]
@@ -694,8 +642,7 @@ Memory allocation - code portion   : 13
 ------------------------------------------------------------------
 
 /[^\xaa]/utf
-Memory allocation - compiled block : 150
-Memory allocation - code portion   : 14
+Memory allocation - code size : 14
 ------------------------------------------------------------------
   0   8 Bra
   5     [^\x{aa}]


### PR DESCRIPTION
Since 05aafb2 (Implement pcre2_set_max_pattern_compiled_length() and set this limit in the fuzzer, 2024-04-24), the memory modifier has reported the full size of the allocated "code" returned by `pcre2_compile`.

Problem is that the size of the structure used to hold that in memory also depends on the platform ABI and even alignment by the compiler, and has been therefore fragile to compare.

Revert to reporting only the additional memory that `pcre2_compile()` will use for the compiled pattern (including any data tables) and make sure that the limit provided with `pcre2_set_max_pattern_compiled_length()` also avoid the internal struct overhead.

Fixes: #415