### PR TITLE
windows: update CI to make test errors visible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,13 +104,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DCMAKE_IGNORE_PREFIX_PATH=C:/Strawberry/c -B build -A Win32
+        run: cmake -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -B build -A Win32
 
       - name: Build
         run: cmake --build build
 
       - name: Test
+        id: test
         run: |
-          cd build\Debug
-          ..\..\RunTest.bat
-          ./pcre2posix_test -v
+          cd build
+          ctest -C Debug .
+
+      - name: Debug
+        if: ${{ failure() && steps.test.outcome == 'failure' }}
+        run: type build/Testing/Temporary/LastTest.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,24 +997,9 @@ IF(PCRE2_BUILD_TESTS)
   # exes in Debug location tested by the RunTest and RunGrepTest shell scripts
   # via "make test"
 
-  # The commented out code below provokes a warning about future removal
-  # of the facility, and requires policy CMP0026 to be set to "OLD". I have
-  # got fed-up with the warnings, but my plea for help on the mailing list
-  # produced no response. So, I've hacked. The new code below seems to work on
-  # Linux.
-
-#  IF(PCRE2_BUILD_PCRE2GREP)
-#    GET_TARGET_PROPERTY(PCRE2GREP_EXE pcre2grep DEBUG_LOCATION)
-#  ENDIF(PCRE2_BUILD_PCRE2GREP)
-#
-#  GET_TARGET_PROPERTY(PCRE2TEST_EXE pcre2test DEBUG_LOCATION)
-
   IF(PCRE2_BUILD_PCRE2GREP)
     SET(PCRE2GREP_EXE $<TARGET_FILE:pcre2grep>)
   ENDIF(PCRE2_BUILD_PCRE2GREP)
-
-  SET(PCRE2TEST_EXE $<TARGET_FILE:pcre2test>)
-
 
 # =================================================
   # Write out a CTest configuration file
@@ -1058,18 +1043,15 @@ if test \"$?\" != \"0\"; then exit 1; fi
     # Provide environment for executing the bat file version of RunTest
     FILE(TO_NATIVE_PATH ${PROJECT_SOURCE_DIR} winsrc)
     FILE(TO_NATIVE_PATH ${PROJECT_BINARY_DIR} winbin)
-    FILE(TO_NATIVE_PATH ${PCRE2TEST_EXE} winexe)
 
     FILE(WRITE ${PROJECT_BINARY_DIR}/pcre2_test.bat
     "\@REM This is a generated file.
 \@echo off
 setlocal
 SET srcdir=\"${winsrc}\"
-# The next line was replaced by the following one after a user comment.
-# SET pcre2test=\"${winexe}\"
 SET pcre2test=\"${winbin}\\pcre2test.exe\"
 if not [%CMAKE_CONFIG_TYPE%]==[] SET pcre2test=\"${winbin}\\%CMAKE_CONFIG_TYPE%\\pcre2test.exe\"
-call %srcdir%\\RunTest.Bat
+call %srcdir%\\RunTest.bat
 if errorlevel 1 exit /b 1
 echo RunTest.bat tests successfully completed
 ")

--- a/RunTest.bat
+++ b/RunTest.bat
@@ -27,7 +27,7 @@
 @rem Tidied and updated for new tests 21, 22, 23 by PH, October 2015.
 @rem PH added missing "set type" for test 22, April 2016.
 @rem PH added copy command for new testbtables file, November 2020
-@rem PH caused it to show comparison output when comparison faile, July 2023
+@rem PH caused it to show comparison output when comparison failed, July 2023
 @rem PH updated unknown error number in test
 
 


### PR DESCRIPTION
Address a deficiency in the CI that was failing to report a test failure