### PR TITLE
m4/pcre2_visibility.m4: add basic support for non GCC compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ m4_define(libpcre2_posix_version, [3:5:0])
 # NOTE: The CMakeLists.txt file searches for the above variables in the first
 # 50 lines of this file. Please update that if the variables above are moved.
 
-AC_PREREQ([2.62])
+AC_PREREQ([2.60])
 AC_INIT([PCRE2],pcre2_major.pcre2_minor[]pcre2_prerelease,[],[pcre2])
 AC_CONFIG_SRCDIR([src/pcre2.h.in])
 AM_INIT_AUTOMAKE([dist-bzip2 dist-zip])

--- a/m4/pcre2_visibility.m4
+++ b/m4/pcre2_visibility.m4
@@ -4,63 +4,56 @@ dnl This file is free software; the Free Software Foundation
 dnl gives unlimited permission to copy and/or distribute it,
 dnl with or without modifications, as long as this notice is preserved.
 
-dnl From Bruno Haible.
+dnl Originally From Bruno Haible.
 
 dnl Tests whether the compiler supports the command-line option
-dnl -fvisibility=hidden and the function and variable attributes
-dnl __attribute__((__visibility__("hidden"))) and
+dnl -fvisibility=hidden and the function attribute
 dnl __attribute__((__visibility__("default"))).
-dnl Does *not* test for __visibility__("protected") - which has tricky
-dnl semantics (see the 'vismain' test in glibc) and does not exist e.g. on
-dnl MacOS X.
-dnl Does *not* test for __visibility__("internal") - which has processor
-dnl dependent semantics.
-dnl Does *not* test for #pragma GCC visibility push(hidden) - which is
-dnl "really only recommended for legacy code".
-dnl Set the variable CFLAG_VISIBILITY.
+dnl
+dnl Set the variable VISIBILITY_CFLAGS.
 dnl Defines and sets the variable HAVE_VISIBILITY.
 
 dnl Modified to fit with PCRE build environment by Cristian Rodríguez.
 dnl Adjusted for PCRE2 by PH
+dnl Refactored to work with non GCC (but compatible) compilers
 
 AC_DEFUN([PCRE2_VISIBILITY],
 [
   AC_REQUIRE([AC_PROG_CC])
   VISIBILITY_CFLAGS=
-  VISIBILITY_CXXFLAGS=
   HAVE_VISIBILITY=0
-  if test -n "$GCC"; then
-    dnl First, check whether -Werror can be added to the command line, or
-    dnl whether it leads to an error because of some other option that the
-    dnl user has put into $CC $CFLAGS $CPPFLAGS.
-    AC_MSG_CHECKING([whether the -Werror option is usable])
-    AC_CACHE_VAL([pcre2_cv_cc_vis_werror], [
-      pcre2_save_CFLAGS="$CFLAGS"
-      CFLAGS="$CFLAGS -Werror"
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[]], [[]])],
-        [pcre2_cv_cc_vis_werror=yes],
-        [pcre2_cv_cc_vis_werror=no])
-      CFLAGS="$pcre2_save_CFLAGS"])
-    AC_MSG_RESULT([$pcre2_cv_cc_vis_werror])
-    dnl Now check whether visibility declarations are supported.
-    AC_MSG_CHECKING([for simple visibility declarations])
+  dnl First, check whether -Werror can be added to the command line, or
+  dnl whether it leads to an error because of some other option that the
+  dnl user has put into $CC $CFLAGS $CPPFLAGS.
+  AC_MSG_CHECKING([whether the -Werror option is usable])
+  AC_CACHE_VAL([pcre2_cv_cc_vis_werror], [
+    pcre2_save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS -Werror"
+    pcre2_cv_cc_vis_werror=no
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[]], [[]])],
+      [
+	AC_COMPILE_IFELSE(
+	  [AC_LANG_PROGRAM([[]], [[ #warning e ]])],
+          [], [pcre2_cv_cc_vis_werror=yes]
+	)
+      ], [])
+    CFLAGS="$pcre2_save_CFLAGS"])
+  AC_MSG_RESULT([$pcre2_cv_cc_vis_werror])
+  if test $pcre2_cv_cc_vis_werror = yes; then
+    dnl Now check whether GCC compatible visibility declarations are supported.
+    AC_MSG_CHECKING([for GCC compatible visibility declarations])
     AC_CACHE_VAL([pcre2_cv_cc_visibility], [
       pcre2_save_CFLAGS="$CFLAGS"
-      CFLAGS="$CFLAGS -fvisibility=hidden"
+      CFLAGS="$CFLAGS -Werror -fvisibility=hidden"
       dnl We use the option -Werror and a function dummyfunc, because on some
       dnl platforms (Cygwin 1.7) the use of -fvisibility triggers a warning
       dnl "visibility attribute not supported in this configuration; ignored"
       dnl at the first function definition in every compilation unit, and we
       dnl don't want to use the option in this case.
-      if test $pcre2_cv_cc_vis_werror = yes; then
-        CFLAGS="$CFLAGS -Werror"
-      fi
       AC_COMPILE_IFELSE(
         [AC_LANG_PROGRAM(
-           [[extern __attribute__((__visibility__("hidden"))) int hiddenvar;
-             extern __attribute__((__visibility__("default"))) int exportedvar;
-             extern __attribute__((__visibility__("hidden"))) int hiddenfunc (void);
+           [[extern __attribute__((__visibility__("hidden"))) int hiddenfunc (void);
              extern __attribute__((__visibility__("default"))) int exportedfunc (void);
              void dummyfunc (void) {}
            ]],
@@ -68,21 +61,18 @@ AC_DEFUN([PCRE2_VISIBILITY],
         [pcre2_cv_cc_visibility=yes],
         [pcre2_cv_cc_visibility=no])
       CFLAGS="$pcre2_save_CFLAGS"])
-    AC_MSG_RESULT([$pcre2_cv_cc_visibility])
-    if test $pcre2_cv_cc_visibility = yes; then
-      VISIBILITY_CFLAGS="-fvisibility=hidden"
-      VISIBILITY_CXXFLAGS="-fvisibility=hidden -fvisibility-inlines-hidden"
-      HAVE_VISIBILITY=1
-      AC_DEFINE(PCRE2_EXPORT, [__attribute__ ((visibility ("default")))], [to make a symbol visible])
-    else
-      AC_DEFINE(PCRE2_EXPORT, [], [to make a symbol visible])
-    fi
+      AC_MSG_RESULT([$pcre2_cv_cc_visibility])
+  fi
+  if test -n "$pcre2_cv_cc_visibility" && test $pcre2_cv_cc_visibility = yes
+  then
+    VISIBILITY_CFLAGS="-fvisibility=hidden"
+    HAVE_VISIBILITY=1
+    AC_DEFINE(PCRE2_EXPORT, [__attribute__ ((visibility ("default")))], [to make a symbol visible])
   else
     AC_DEFINE(PCRE2_EXPORT, [], [to make a symbol visible])
   fi
   AC_SUBST([VISIBILITY_CFLAGS])
-  AC_SUBST([VISIBILITY_CXXFLAGS])
   AC_SUBST([HAVE_VISIBILITY])
   AC_DEFINE_UNQUOTED([HAVE_VISIBILITY], [$HAVE_VISIBILITY],
-    [Define to 1 if the compiler supports simple visibility declarations.])
+    [Define to 1 if the compiler supports GCC compatible visibility declarations.])
 ])


### PR DESCRIPTION
Tested with the latest version of SunPro and TinyCC. It would also allow for other clang proprietary derivatives.

As usual, would fall cleanly for the cases where there is no support for `-fvisibility`