### PR TITLE
pcre2grep: add --posix-pattern-file for compatibility with other grep

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,13 +7,17 @@ there is also the log of commit messages.
 Version 10.45 xx-xxx-2024
 -------------------------
 
-1. Change 6 of 10.44 broke 32-bit compiles because pcre2test's reporting of 
-memory size was changed to the entire compiled data block, instead of just the 
-pattern and tables data, so as to align with the new length restriction. 
+1. Change 6 of 10.44 broke 32-bit tests because pcre2test's reporting of
+memory size was changed to the entire compiled data block, instead of just the
+pattern and tables data, so as to align with the new length restriction.
 Because the block's header contains pointers, this meant the pcre2test output
 was different in 32-bit mode. A patch by Carlo reverts to the preevious state
 and makes sure that any limit set by pcre2_set_max_pattern_compiled_length()
 also avoids the internal struct overhead.
+
+2. Add --posix-pattern-file to pcre2grep to allow processing of empty patterns
+through the -f option, as well as patterns that end in space characters for
+compatibility with other grep tools.
 
 
 Version 10.44 07-June-2024

--- a/RunGrepTest
+++ b/RunGrepTest
@@ -861,6 +861,35 @@ echo "---------------------------- Test 153 -----------------------------" >>tes
 (cd $srcdir; $valgrind $vjs $pcre2grep -nA3 --no-group-separator 'four' ./testdata/grepinputx) >>testtrygrep
 echo "RC=$?" >>testtrygrep
 
+echo "---------------------------- Test 154 -----------------------------" >>testtrygrep
+>testtemp1grep
+(cd $srcdir; $valgrind $vjs $pcre2grep -f $builddir/testtemp1grep ./testdata/grepinputv) >>testtrygrep
+echo "RC=$?" >>testtrygrep
+
+echo "---------------------------- Test 155 -----------------------------" >>testtrygrep
+echo "" >testtemp1grep
+(cd $srcdir; $valgrind $vjs $pcre2grep -f $builddir/testtemp1grep ./testdata/grepinputv) >>testtrygrep
+echo "RC=$?" >>testtrygrep
+
+echo "---------------------------- Test 156 -----------------------------" >>testtrygrep
+echo "" >testtemp1grep
+(cd $srcdir; $valgrind $vjs $pcre2grep --posix-pattern-file --file $builddir/testtemp1grep ./testdata/grepinputv) >>testtrygrep
+echo "RC=$?" >>testtrygrep
+
+echo "---------------------------- Test 157 -----------------------------" >>testtrygrep
+echo "spaces " >testtemp1grep
+(cd $srcdir; $valgrind $vjs $pcre2grep -o --posix-pattern-file --file=$builddir/testtemp1grep ./testdata/grepinputv >testtemp2grep && $valgrind $vjs $pcre2grep -q "s " testtemp2grep) >>testtrygrep
+echo "RC=$?" >>testtrygrep
+
+echo "---------------------------- Test 158 -----------------------------" >>testtrygrep
+echo "spaces." >testtemp1grep
+(cd $srcdir; $valgrind $vjs $pcre2grep -f $builddir/testtemp1grep ./testdata/grepinputv) >>testtrygrep
+echo "RC=$?" >>testtrygrep
+
+echo "---------------------------- Test 159 -----------------------------" >>testtrygrep
+printf "spaces.\015\012" >testtemp1grep
+(cd $srcdir; $valgrind $vjs $pcre2grep --posix-pattern-file -f$builddir/testtemp1grep ./testdata/grepinputv) >>testtrygrep
+echo "RC=$?" >>testtrygrep
 
 # Now compare the results.
 

--- a/doc/html/pcre2_set_max_pattern_compiled_length.html
+++ b/doc/html/pcre2_set_max_pattern_compiled_length.html
@@ -27,9 +27,9 @@ DESCRIPTION
 </b><br>
 <P>
 This function sets, in a compile context, the maximum size (in bytes) for the
-memory needed to hold the compiled version of a pattern that is compiled with
-this context. The result is always zero. If a pattern that is passed to
-<b>pcre2_compile()</b> with this context needs more memory, an error is
+memory needed to hold the compiled version of a pattern that is using this
+context. The result is always zero. If a pattern that is passed to
+<b>pcre2_compile()</b> referencing this context needs more memory, an error is
 generated. The default is the largest number that a PCRE2_SIZE variable can
 hold, which is effectively unlimited.
 </P>

--- a/doc/html/pcre2grep.html
+++ b/doc/html/pcre2grep.html
@@ -391,9 +391,10 @@ Read patterns from the file, one per line. As is the case with patterns on the
 command line, no delimiters should be used. What constitutes a newline when
 reading the file is the operating system's default interpretation of \n. The
 <b>--newline</b> option has no effect on this option. Trailing white space is
-removed from each line, and blank lines are ignored. An empty file contains no
+removed from each line, and blank lines are ignored unless the
+<b>--posix-pattern-file</b> option is also provided. An empty file contains no
 patterns and therefore matches nothing. Patterns read from a file in this way
-may contain binary zeros, which are treated as ordinary data characters.
+may contain binary zeros, which are treated as ordinary character literals.
 <br>
 <br>
 If this option is given more than once, all the specified files are read. A
@@ -806,6 +807,15 @@ as was the case in earlier releases. Note that there are now more fine-grained
 option settings within patterns that affect individual classes. For example,
 when in UCP mode, the sequence (?aP) restricts [:word:] to ASCII letters, while
 allowing \w to match Unicode letters and digits.
+</P>
+<P>
+<b>--posix-pattern-file</b>
+When patterns are provided with the <b>-f</b> option, do not trim trailing
+spaces or ignore empty lines in a similar way than other grep tools. To keep
+the behaviour consistent with older versions, if the pattern read was
+terminated with CRLF (as character literals) then both characters won't be
+included as part of it, so if you really need to have pattern ending in '\r',
+use a escape sequence or provide it by a different method.
 </P>
 <P>
 <b>-q</b>, <b>--quiet</b>

--- a/doc/pcre2grep.1
+++ b/doc/pcre2grep.1
@@ -337,9 +337,10 @@ Read patterns from the file, one per line. As is the case with patterns on the
 command line, no delimiters should be used. What constitutes a newline when
 reading the file is the operating system's default interpretation of \en. The
 \fB--newline\fP option has no effect on this option. Trailing white space is
-removed from each line, and blank lines are ignored. An empty file contains no
+removed from each line, and blank lines are ignored unless the
+\fB--posix-pattern-file\fP option is also provided. An empty file contains no
 patterns and therefore matches nothing. Patterns read from a file in this way
-may contain binary zeros, which are treated as ordinary data characters.
+may contain binary zeros, which are treated as ordinary character literals.
 .sp
 If this option is given more than once, all the specified files are read. A
 data line is output if any of the patterns match it. A file name can be given
@@ -700,6 +701,14 @@ as was the case in earlier releases. Note that there are now more fine-grained
 option settings within patterns that affect individual classes. For example,
 when in UCP mode, the sequence (?aP) restricts [:word:] to ASCII letters, while
 allowing \ew to match Unicode letters and digits.
+.TP
+\fB--posix-pattern-file\fP
+When patterns are provided with the \fB-f\fP option, do not trim trailing
+spaces or ignore empty lines in a similar way than other grep tools. To keep
+the behaviour consistent with older versions, if the pattern read was
+terminated with CRLF (as character literals) then both characters won't be
+included as part of it, so if you really need to have pattern ending in '\er',
+use a escape sequence or provide it by a different method.
 .TP
 \fB-q\fP, \fB--quiet\fP
 Work quietly, that is, display nothing except error messages. The exit

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -145,7 +145,8 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Define to 1 if the compiler supports simple visibility declarations. */
+/* Define to 1 if the compiler supports GCC compatible visibility
+   declarations. */
 #undef HAVE_VISIBILITY
 
 /* Define to 1 if you have the <wchar.h> header file. */

--- a/testdata/grepinputv
+++ b/testdata/grepinputv
@@ -7,3 +7,4 @@ The word is cat in this line
 The caterpillar sat on the mat
 The snowcat is not an animal
 A buried feline in the syndicate
+trailing spaces 

--- a/testdata/grepoutput
+++ b/testdata/grepoutput
@@ -464,6 +464,7 @@ The word is cat in this line
 The caterpillar sat on the mat
 The snowcat is not an animal
 A buried feline in the syndicate
+trailing spaces 
 RC=0
 ---------------------------- Test 52 ------------------------------
 fox [1;31mjumps[0m
@@ -1169,6 +1170,7 @@ The word is cat in this line
 The caterpillar sat on the mat
 The snowcat is not an animal
 A buried feline in the syndicate
+trailing spaces 
 RC=0
 ---------------------------- Test 146 -----------------------------
 (standard input):A123B
@@ -1252,4 +1254,28 @@ RC=0
 35-fifteen
 36-sixteen
 37-seventeen
+RC=0
+---------------------------- Test 154 -----------------------------
+RC=1
+---------------------------- Test 155 -----------------------------
+RC=1
+---------------------------- Test 156 -----------------------------
+The quick brown
+fox jumps
+over the lazy dog.
+This time it jumps and jumps and jumps.
+This line contains \E and (regex) *meta* [characters].
+The word is cat in this line
+The caterpillar sat on the mat
+The snowcat is not an animal
+A buried feline in the syndicate
+trailing spaces 
+RC=0
+---------------------------- Test 157 -----------------------------
+RC=0
+---------------------------- Test 158 -----------------------------
+trailing spaces 
+RC=0
+---------------------------- Test 159 -----------------------------
+trailing spaces 
 RC=0


### PR DESCRIPTION
Historically, `pcre2grep` removes empty lines of the file provided with the `-f` option and trims trailing space characters on each line, this means (among other differences) that it is not possible to provide an empty pattern through it and the following inconsistency is observed (comparing against GNU/*NIX grep):

```
% echo "" > input && cp input pat
% grep -qf pat input; echo $?
0
% ggrep -qf pat input; echo $?
0
% pcre2grep -qf pat input; echo $?
1
% pcre2grep -q "" input; echo $?
0
```

This allows for the more consistent:
```
% pcre2grep --posix-pattern-file -qf pat input; echo $?
0
% pcre2grep --posix-pattern-file -q -e "" input; echo $?
0
```