### PR TITLE
test: use a fully spec locale name in RunGrepTest

### DIFF
--- a/RunGrepTest
+++ b/RunGrepTest
@@ -842,11 +842,11 @@ echo "RC=$?" >>testtrygrep
 echo "---------------------------- Test 150 -----------------------------" >>testtrygrep
 which locale >/dev/null 2>&1
 if [ $? -ne 0 ]; then
-  echo "pcre2grep: Failed to set locale badlocale (obtained from LC_CTYPE)" >>testtrygrep
+  echo "pcre2grep: Failed to set locale locale.bad (obtained from LC_CTYPE)" >>testtrygrep
   echo "RC=2" >>testtrygrep
 else
 
-  (cd $srcdir; unset LC_ALL; env LC_CTYPE=badlocale $valgrind $vjs $pcre2grep abc /dev/null) >>testtrygrep 2>&1
+  (cd $srcdir; unset LC_ALL; env LC_CTYPE=locale.bad $valgrind $vjs $pcre2grep abc /dev/null) >>testtrygrep 2>&1
   echo "RC=$?" >>testtrygrep
 fi
 

--- a/testdata/grepoutput
+++ b/testdata/grepoutput
@@ -1225,7 +1225,7 @@ Usage: pcre2grep [-AaBCcDdEeFfHhIilLMmNnOoPqrstuUVvwxZ] [long options] [pattern]
 Type "pcre2grep --help" for more information and the long options.
 RC=2
 ---------------------------- Test 150 -----------------------------
-pcre2grep: Failed to set locale badlocale (obtained from LC_CTYPE)
+pcre2grep: Failed to set locale locale.bad (obtained from LC_CTYPE)
 RC=2
 ---------------------------- Test 151 -----------------------------
 [1;31mThe[0m quick brown


### PR DESCRIPTION
Fix `RunGrepTest` at least in OpenBSD, where the validation for a locale mostly concerns with the charmap.