### PR TITLE
pcre2test: avoid overreading subject buffer with leading spaces

### DIFF
--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -6920,7 +6920,11 @@ len = strlen((const char *)buffer);
 while (len > 0 && isspace(buffer[len-1])) len--;
 buffer[len] = 0;
 p = buffer;
-while (isspace(*p)) p++;
+while (isspace(*p))
+  {
+  p++;
+  len--;
+  }
 
 /* Check that the data is well-formed UTF-8 if we're in UTF mode. To create
 invalid input to pcre2_match(), you must use \x?? or \x{} sequences. */


### PR DESCRIPTION
Could trick pcre2test into trying to decode a trailing utf character from the subject  using data outside of what was read into its buffer.

Note that under normal circumstances the buffer is zero terminated and so any over read will be limited and likely to keep within the buffer even without the fix.