### PR TITLE
Add missing constants for ERR100 and ERR101 in pcre.h

### DIFF
--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -321,6 +321,8 @@ pcre2_pattern_convert(). */
 #define PCRE2_ERROR_TOO_MANY_CAPTURES              197
 #define PCRE2_ERROR_CONDITION_ATOMIC_ASSERTION_EXPECTED  198
 #define PCRE2_ERROR_BACKSLASH_K_IN_LOOKAROUND      199
+#define PCRE2_ERROR_MAX_VAR_LOOKBEHIND_EXCEEDED    200
+#define PCRE2_ERROR_PATTERN_COMPILED_SIZE_TOO_BIG  201
 
 
 /* "Expected" matching error codes: no match and partial match. */

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -321,6 +321,8 @@ pcre2_pattern_convert(). */
 #define PCRE2_ERROR_TOO_MANY_CAPTURES              197
 #define PCRE2_ERROR_CONDITION_ATOMIC_ASSERTION_EXPECTED  198
 #define PCRE2_ERROR_BACKSLASH_K_IN_LOOKAROUND      199
+#define PCRE2_ERROR_MAX_VAR_LOOKBEHIND_EXCEEDED    200
+#define PCRE2_ERROR_PATTERN_COMPILED_SIZE_TOO_BIG  201
 
 
 /* "Expected" matching error codes: no match and partial match. */


### PR DESCRIPTION
For all other error codes returned by pcre2_compile(), there are constants defined in pcre2.h which describe the error. Add the missing constants for the last two error codes.