### PR TITLE
Fix backtracking bugs in scan_substring

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -2524,6 +2524,13 @@ while (cc < ccend)
     cc += 1 + LINK_SIZE;
     break;
 
+    case OP_ASSERT_SCS:
+    SLJIT_ASSERT(PRIVATE_DATA(cc) != 0);
+    if (recurse_check_bit(common, PRIVATE_DATA(cc)))
+      length += 2;
+    cc += 1 + LINK_SIZE;
+    break;
+
     case OP_CBRA:
     case OP_SCBRA:
     offset = GET2(cc, 1 + LINK_SIZE);
@@ -2870,6 +2877,14 @@ while (cc < ccend)
     private_srcw[0] = PRIVATE_DATA(cc);
     if (recurse_check_bit(common, private_srcw[0]))
       private_count = 1;
+    cc += 1 + LINK_SIZE;
+    break;
+
+    case OP_ASSERT_SCS:
+    private_srcw[0] = PRIVATE_DATA(cc);
+    private_srcw[1] = private_srcw[0] + sizeof(sljit_sw);
+    if (recurse_check_bit(common, private_srcw[0]))
+      private_count = 2;
     cc += 1 + LINK_SIZE;
     break;
 

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -155,7 +155,7 @@ changed, the code at RETURN_SWITCH below must be updated in sync.  */
 enum { RM1=1, RM2,  RM3,  RM4,  RM5,  RM6,  RM7,  RM8,  RM9,  RM10,
        RM11,  RM12, RM13, RM14, RM15, RM16, RM17, RM18, RM19, RM20,
        RM21,  RM22, RM23, RM24, RM25, RM26, RM27, RM28, RM29, RM30,
-       RM31,  RM32, RM33, RM34, RM35, RM36, RM37, RM38 };
+       RM31,  RM32, RM33, RM34, RM35, RM36, RM37, RM38, RM39 };
 
 #ifdef SUPPORT_WIDE_CHARS
 enum { RM100=100, RM101 };
@@ -6155,14 +6155,26 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       case OP_ASSERT_NOT:
       RRETURN(MATCH_MATCH);
 
+      /* A scan substring group must preserve the current end_subject,
+      and restore it before the backtracking is performed into its sub
+      pattern. */
+
+      case OP_ASSERT_SCS:
+      F->temp_sptr[0] = mb->end_subject;
+      mb->end_subject = P->temp_sptr[0];
+      mb->true_end_subject = mb->end_subject + P->temp_size;
+      Feptr = P->temp_sptr[1];
+
+      RMATCH(Fecode + 1 + LINK_SIZE, RM39);
+
+      mb->end_subject = F->temp_sptr[0];
+      mb->true_end_subject = mb->end_subject;
+      RRETURN(rrc);
+      break;
+
       /* At the end of a script run, apply the script-checking rules. This code
       will never by exercised if Unicode support it not compiled, because in
       that environment script runs cause an error at compile time. */
-
-      case OP_ASSERT_SCS:
-      mb->end_subject = P->temp_sptr[0];
-      Feptr = P->temp_sptr[1];
-      break;
 
       case OP_SCRIPT_RUN:
       if (!PRIV(script_run)(P->eptr, Feptr, utf)) RRETURN(MATCH_NOMATCH);
@@ -6601,7 +6613,7 @@ switch (Freturn_id)
   LBL( 9) LBL(10) LBL(11) LBL(12) LBL(13) LBL(14) LBL(15) LBL(16)
   LBL(17) LBL(18) LBL(19) LBL(20) LBL(21) LBL(22) LBL(23) LBL(24)
   LBL(25) LBL(26) LBL(27) LBL(28) LBL(29) LBL(30) LBL(31) LBL(32)
-  LBL(33) LBL(34) LBL(35) LBL(36) LBL(37) LBL(38)
+  LBL(33) LBL(34) LBL(35) LBL(36) LBL(37) LBL(38) LBL(39)
 
 #ifdef SUPPORT_WIDE_CHARS
   LBL(100) LBL(101)

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -6207,8 +6207,9 @@ a)"xI
     $$abacd$$112345$$abca$$
     $$abcdeaf$$1234567819$$123456781$$
 
-/([a-zA-Z]+)(*scs:(1).*?(?<ABC>[A-Z]+)(*scan_substring:('ABC').*(.)\3))/
+/([a-zA-Z]+)(*scs:(1).*?(?<ABC>[A-Z]+)(*scan_substring:('ABC').*(.)\3))#+/
     ##abABCtuTUVXz##abCDEFGxyCDEEFGhi##
+    ##abAABCtuTUVXXz!!abCDEFGxyCDEFGGhi##
 
 /([a-zA-Z]+)(*scs:(1)(xy|ab(*ACCEPT)cd))/
     ##cdefgh##cdeabxy##
@@ -6243,6 +6244,34 @@ a)"xI
 
 /(\d++)(*scs:(1)\d+$)(\w+)/
     X123XYZ
+
+/([a-z]{2})[a-z](*scs:(1)(.*?))\2$/
+    abcab
+    abcabc
+
+/^(([a-z]([a-z]*+))(*scs:(2).(?=(?1)|$)\3)|#){5}/
+    abcdefg#hijk#!
+    abcdefg#hijk#lmnopqr#
+
+/(*scs:(1)a)(a)|x/
+    a
+    x
+
+/(*scs:(<GOOD_NAME>)a)(?<GOOD_NAME>a)(?<GOOD_NAME>b)(?<GOOD_NAME>c)(?<GOOD_NAME>d)|x/dupnames
+    abcd
+    x
+
+/(*scs:(1)a)?(a)/
+    b
+    a
+
+/(*scs:(1)a)??(a)/
+    b
+    a
+
+# Custom backtrack, goes back n - 1 characters in the input (n=8)
+/x(?|(*scs:(1)(?<=(.)))|()){8}/
+    abcdefghx
 
 # --------------
 

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -18519,12 +18519,17 @@ No match
  3: 123456781
  4: 1
 
-/([a-zA-Z]+)(*scs:(1).*?(?<ABC>[A-Z]+)(*scan_substring:('ABC').*(.)\3))/
+/([a-zA-Z]+)(*scs:(1).*?(?<ABC>[A-Z]+)(*scan_substring:('ABC').*(.)\3))#+/
     ##abABCtuTUVXz##abCDEFGxyCDEEFGhi##
- 0: abCDEFGxyCDEEFGhi
+ 0: abCDEFGxyCDEEFGhi##
  1: abCDEFGxyCDEEFGhi
  2: CDEEFG
  3: E
+    ##abAABCtuTUVXXz!!abCDEFGxyCDEFGGhi##
+ 0: abCDEFGxyCDEFGGhi##
+ 1: abCDEFGxyCDEFGGhi
+ 2: CDEFGG
+ 3: G
 
 /([a-zA-Z]+)(*scs:(1)(xy|ab(*ACCEPT)cd))/
     ##cdefgh##cdeabxy##
@@ -18596,6 +18601,57 @@ No match
  0: 123XYZ
  1: 123
  2: XYZ
+
+/([a-z]{2})[a-z](*scs:(1)(.*?))\2$/
+    abcab
+ 0: abcab
+ 1: ab
+ 2: ab
+    abcabc
+ 0: bcabc
+ 1: bc
+ 2: bc
+
+/^(([a-z]([a-z]*+))(*scs:(2).(?=(?1)|$)\3)|#){5}/
+    abcdefg#hijk#!
+No match
+    abcdefg#hijk#lmnopqr#
+ 0: abcdefg#hijk#lmnopqr
+ 1: lmnopqr
+ 2: lmnopqr
+ 3: mnopqr
+
+/(*scs:(1)a)(a)|x/
+    a
+No match
+    x
+ 0: x
+
+/(*scs:(<GOOD_NAME>)a)(?<GOOD_NAME>a)(?<GOOD_NAME>b)(?<GOOD_NAME>c)(?<GOOD_NAME>d)|x/dupnames
+    abcd
+No match
+    x
+ 0: x
+
+/(*scs:(1)a)?(a)/
+    b
+No match
+    a
+ 0: a
+ 1: a
+
+/(*scs:(1)a)??(a)/
+    b
+No match
+    a
+ 0: a
+ 1: a
+
+# Custom backtrack, goes back n - 1 characters in the input (n=8)
+/x(?|(*scs:(1)(?<=(.)))|()){8}/
+    abcdefghx
+ 0: x
+ 1: c
 
 # --------------
 


### PR DESCRIPTION
I tried to figure out how to fix the bugs in the interpreter. Unfortunately the F,N,P, Flast_group_offset variables are a bit confusing for me, but at least the tests pass. I am thinking about whether keeping the current F instead of another RMATCH is a better idea. I am not even sure it is possible to do that.