### PR TITLE
Set 'first code unit' using 'starting code units' bitmap even when 'required code unit' is same

### DIFF
--- a/src/pcre2_study.c
+++ b/src/pcre2_study.c
@@ -1856,25 +1856,22 @@ if ((re->flags & (PCRE2_FIRSTSET|PCRE2_STARTLINE)) == 0)
         }
       }
 
-    /* Replace the start code unit bits with a first code unit, but only if it
-    is not the same as a required later code unit. This is because a search for
-    a required code unit starts after an explicit first code unit, but at a
-    code unit found from the bitmap. Patterns such as /a*a/ don't work
-    if both the start unit and required unit are the same. */
+    /* Replace the start code unit bits with a first code unit. If it is the
+    same as a required later code unit, then clear the required later code
+    unit. This is because a search for a required code unit starts after an
+    explicit first code unit, but at a code unit found from the bitmap.
+    Patterns such as /a*a/ don't work if both the start unit and required
+    unit are the same. */
 
-    if (a >= 0 &&
-        (
-        (re->flags & PCRE2_LASTSET) == 0 ||
-          (
-          re->last_codeunit != (uint32_t)a &&
-          (b < 0 || re->last_codeunit != (uint32_t)b)
-          )
-        ))
-      {
+    if (a >= 0) {
+      if ((re->flags & PCRE2_LASTSET) && (re->last_codeunit == (uint32_t)a || (b >= 0 && re->last_codeunit == (uint32_t)b))) {
+        re->flags &= ~(PCRE2_LASTSET | PCRE2_LASTCASELESS);
+        re->last_codeunit = 0;
+      }
       re->first_codeunit = a;
       flags = PCRE2_FIRSTSET;
       if (b >= 0) flags |= PCRE2_FIRSTCASELESS;
-      }
+    }
 
     DONE:
     re->flags |= flags;

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -6468,8 +6468,7 @@ No match
 Capture group count = 0
 Compile options: caseless
 Overall options: anchored caseless
-Starting code units: A a
-Last code unit = 'A' (caseless)
+First code unit = 'A' (caseless)
 Subject length lower bound = 2
     aaaA5
  0: aaaA5
@@ -10747,8 +10746,7 @@ Subject length lower bound = 1
 /(?=a{3})[bcd]/Ii
 Capture group count = 0
 Options: caseless
-Starting code units: A a
-Last code unit = 'a' (caseless)
+First code unit = 'A' (caseless)
 Subject length lower bound = 1
 
 /(abc)\1+/
@@ -17481,8 +17479,7 @@ Subject length lower bound = 5
 
 /(a)?a/I
 Capture group count = 1
-Starting code units: a
-Last code unit = 'a'
+First code unit = 'a'
 Subject length lower bound = 1
     manm
  0: a


### PR DESCRIPTION
The 'first code unit' (`firstcu`) optimization is more effective than the 'required code unit' (`reqcu`) optimization, since while `reqcu` can sometimes cause a non-matching subject string to be quickly rejected, `firstcu` can do the same thing _and_ help the regex engine to quickly skip forward to the best position to start matching from.

Hence, in `pcre2_study()`, when there is a conflict between enabling the `firstcu` and `reqcu` optimizations, it is better to choose `firstcu`.