### PR TITLE
Add missing 'expand' modifier to list in pcre2test manpage

### DIFF
--- a/doc/html/pcre2test.html
+++ b/doc/html/pcre2test.html
@@ -698,6 +698,7 @@ heavily used in the test files.
       convert_glob_separator=c  set glob separator character
       convert_length            set convert buffer length
       debug                     same as info,fullbincode
+      expand                    expand repetition syntax in pattern
       framesize                 show matching frame size
       fullbincode               show binary code with lengths
   /I  info                      show info about compiled pattern

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -654,6 +654,7 @@ heavily used in the test files.
       convert_glob_separator=c  set glob separator character
       convert_length            set convert buffer length
       debug                     same as info,fullbincode
+      expand                    expand repetition syntax in pattern
       framesize                 show matching frame size
       fullbincode               show binary code with lengths
   /I  info                      show info about compiled pattern

--- a/doc/pcre2test.txt
+++ b/doc/pcre2test.txt
@@ -632,6 +632,7 @@ PATTERN MODIFIERS
              convert_glob_separator=c  set glob separator character
              convert_length            set convert buffer length
              debug                     same as info,fullbincode
+             expand                    expand repetition syntax in pattern
              framesize                 show matching frame size
              fullbincode               show binary code with lengths
          /I  info                      show info about compiled pattern


### PR DESCRIPTION
The 'expand' modifier is mentioned in later sections of the manpage, but is not included in any of the lists of possible modifiers.