### PR TITLE
Use assertion to ensure erroroffset return from pcre2_compile is valid

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -11147,6 +11147,8 @@ HAD_CB_ERROR:
 ptr = pattern + cb.erroroffset;
 
 HAD_EARLY_ERROR:
+PCRE2_ASSERT(ptr >= pattern); /* Ensure we don't return invalid erroroffset */
+PCRE2_ASSERT(ptr <= (pattern + patlen));
 *erroroffset = ptr - pattern;
 
 HAD_ERROR:


### PR DESCRIPTION
When testing the new pattern rewriting phase for regex compilation using a fuzzer, I had a scary experience. Due to a bug in my pattern rewriting code, pcre2_compile() could return a totally invalid erroroffset. If a library user tried to do something with the erroroffset without checking it for validity, in the worst case, this had the potential to lead to an RCE vulnerability.

In case something similar ever happens again, I've added an assertion which will make it easier to notice the problem.