### PR TITLE
Guard against out-of-bounds memory access when parsing LIMIT_HEAP et al

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -10551,12 +10551,12 @@ if ((options & PCRE2_LITERAL) == 0)
             ptr += pp;
             goto HAD_EARLY_ERROR;
             }
-          while (IS_DIGIT(ptr[pp]))
+          while (pp < patlen && IS_DIGIT(ptr[pp]))
             {
             if (c > UINT32_MAX / 10 - 1) break;   /* Integer overflow */
             c = c*10 + (ptr[pp++] - CHAR_0);
             }
-          if (ptr[pp++] != CHAR_RIGHT_PARENTHESIS)
+          if (pp >= patlen || ptr[pp] != CHAR_RIGHT_PARENTHESIS)
             {
             errorcode = ERR60;
             ptr += pp;
@@ -10565,7 +10565,7 @@ if ((options & PCRE2_LITERAL) == 0)
           if (p->type == PSO_LIMH) limit_heap = c;
             else if (p->type == PSO_LIMM) limit_match = c;
             else limit_depth = c;
-          skipatstart += pp - skipatstart;
+          skipatstart = ++pp;
           break;
           }
         break;   /* Out of the table scan loop */
@@ -10573,6 +10573,7 @@ if ((options & PCRE2_LITERAL) == 0)
       }
     if (i >= sizeof(pso_list)/sizeof(pso)) break;   /* Out of pso loop */
     }
+    PCRE2_ASSERT(skipatstart <= patlen);
   }
 
 /* End of pattern-start options; advance to start of real regex. */

--- a/testdata/testoutput15
+++ b/testdata/testoutput15
@@ -111,10 +111,10 @@ Minimum depth limit = 10
  3: ee
 
 /(*LIMIT_MATCH=12bc)abc/
-Failed: error 160 at offset 17: (*VERB) not recognized or malformed
+Failed: error 160 at offset 16: (*VERB) not recognized or malformed
 
 /(*LIMIT_MATCH=4294967290)abc/
-Failed: error 160 at offset 24: (*VERB) not recognized or malformed
+Failed: error 160 at offset 23: (*VERB) not recognized or malformed
 
 /(*LIMIT_DEPTH=4294967280)abc/I
 Capture group count = 0


### PR DESCRIPTION
While fuzzing PCRE2, I found a case in which `pcre2_compile` may incorrectly read past the end of the pattern string which it is given. Here are the details:

Patterns passed to `pcre2_compile` are not guaranteed to be null-terminated. Also, it can happen that there is an invalid pattern like this:

```
(*LIMIT_HEAP=123
```
If the next byte of memory after the end of the pattern happens to be a digit, it will be parsed as part of the limit value. Or, if the next byte is a right parenthesis character, it will be taken as the end of the `(*LIMIT_HEAP=nnn)` construct.

This will result in `skipatstart` being larger than `patlen`, which will result in underflow and an erroneous call to malloc requesting a huge number of bytes.