### PR TITLE
Implement PCRE2_UNREACHABLE assertion for MS Visual C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,11 @@ CHECK_C_SOURCE_COMPILES([=[
 set(CMAKE_REQUIRED_FLAGS ${ORIG_CMAKE_REQUIRED_FLAGS})
 
 CHECK_C_SOURCE_COMPILES(
+  "int main(void) { __assume(1); return 0; }"
+  HAVE_BUILTIN_ASSUME
+)
+
+CHECK_C_SOURCE_COMPILES(
   "int main(void) { if (__builtin_expect(1+1, 2)) return 1; return 0; }"
   HAVE_BUILTIN_EXPECT
 )

--- a/config-cmake.h.in
+++ b/config-cmake.h.in
@@ -1,6 +1,7 @@
 /* config.h for CMake builds */
 
 #cmakedefine HAVE_ASSERT_H 1
+#cmakedefine HAVE_BUILTIN_ASSUME 1
 #cmakedefine HAVE_BUILTIN_EXPECT 1
 #cmakedefine HAVE_BUILTIN_MUL_OVERFLOW 1
 #cmakedefine HAVE_BUILTIN_UNREACHABLE 1

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,20 @@ fi
 CFLAGS=$tmp_CFLAGS
 AC_LANG_POP([C])
 
+# Check for the assume() builtin
+
+AC_MSG_CHECKING([for __assume()])
+AC_LANG_PUSH([C])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[__assume(1)]])],
+  [pcre2_cc_cv_builtin_assume=yes],
+  [pcre2_cc_cv_builtin_assume=no])
+AC_MSG_RESULT([$pcre2_cc_cv_builtin_assume])
+if test "$pcre2_cc_cv_builtin_assume" = yes; then
+  AC_DEFINE([HAVE_BUILTIN_ASSUME], 1,
+    [Define this if your compiler provides __assume()])
+fi
+AC_LANG_POP([C])
+
 # Check for the expect() builtin
 
 AC_MSG_CHECKING([for __builtin_expect()])

--- a/src/config.h.generic
+++ b/src/config.h.generic
@@ -61,6 +61,9 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define to 1 if you have the 'bcopy' function. */
 /* #undef HAVE_BCOPY */
 
+/* Define this if your compiler provides __assume() */
+/* #undef HAVE_BUILTIN_ASSUME */
+
 /* Define this if your compiler provides __builtin_expect() */
 /* #undef HAVE_BUILTIN_EXPECT */
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -61,6 +61,9 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define to 1 if you have the 'bcopy' function. */
 #undef HAVE_BCOPY
 
+/* Define this if your compiler provides __assume() */
+#undef HAVE_BUILTIN_ASSUME
+
 /* Define this if your compiler provides __builtin_expect() */
 #undef HAVE_BUILTIN_EXPECT
 

--- a/src/pcre2_convert.c
+++ b/src/pcre2_convert.c
@@ -1159,7 +1159,6 @@ for (i = 0; i < 2; i++)
   }
 
 PCRE2_UNREACHABLE(); /* Control never reaches here */
-return PCRE2_ERROR_INTERNAL;
 }
 
 

--- a/src/pcre2_util.h
+++ b/src/pcre2_util.h
@@ -45,6 +45,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef HAVE_BUILTIN_UNREACHABLE
 #define PCRE2_UNREACHABLE() __builtin_unreachable()
+#elif HAVE_BUILTIN_ASSUME
+#define PCRE2_UNREACHABLE() __assume(0)
 #else
 #define PCRE2_UNREACHABLE() do {} while(0)
 #endif


### PR DESCRIPTION
Carlo pointed out that my code in a different PR was causing compiler warnings on Windows. The root cause is that `PCRE2_UNREACHABLE()` was not implemented on Windows.

Have I missed any other files which need to be updated?