### PR TITLE
Silence one warning in pcre2test code (when compiled with Visual C++)

### DIFF
--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -5078,7 +5078,8 @@ switch(cmd)
           isspace(argptr[nlen]))
         {
         if (i == NEWLINE_DEFAULT) return PR_OK;  /* Default is valid */
-        if (first_listed_newline == 0) first_listed_newline = i;
+        PCRE2_ASSERT(i <= UINT16_MAX);
+        if (first_listed_newline == 0) first_listed_newline = (uint16_t)i;
         }
       }
     while (*argptr != 0 && !isspace(*argptr)) argptr++;


### PR DESCRIPTION
I believe that this will silence one warning when pcre2test is compiled with MS Visual C++. (However, I will double-check in the build for this PR to ensure that the warning is gone.)

The warning points out that there is a possible loss of precision when assigning a `size_t` value to a `uint16_t` variable. However, it is hard to imagine that the total number of "newline" characters recognized when performing a regex match will overflow a 16-bit unsigned int.