### PR TITLE
Add test and fix for too-large octals starting with \8 or \9

### DIFF
--- a/testdata/testinput1
+++ b/testdata/testinput1
@@ -6421,7 +6421,28 @@ ef) x/x,mark
 
 /\214748364/
     >\x{8c}748364<
-    
+
+# larger than GROUP_MAX, smaller than INT_MAX
+/a\800000b/
+
+# coming up on INT_MAX... (used to succeed with \8 being literal 8)
+/a\800000000b/
+
+# over INT_MAX (used to succeed with \8 being literal 8)
+/a\8000000000b/
+
+# smaller than GROUP_MAX
+/\21300/
+    \x8b00
+
+# larger than GROUP_MAX
+/\213000/
+    \x8b000
+
+# larger than INT_MAX
+/\21300000000/
+    \x8b00000000
+
 /a{65536/
     >a{65536<
 

--- a/testdata/testoutput1
+++ b/testdata/testoutput1
@@ -10167,7 +10167,34 @@ No match
 /\214748364/
     >\x{8c}748364<
  0: \x8c748364
-    
+
+# larger than GROUP_MAX, smaller than INT_MAX
+/a\800000b/
+Failed: error 161 at offset 7: subpattern number is too big
+
+# coming up on INT_MAX... (used to succeed with \8 being literal 8)
+/a\800000000b/
+Failed: error 161 at offset 7: subpattern number is too big
+
+# over INT_MAX (used to succeed with \8 being literal 8)
+/a\8000000000b/
+Failed: error 161 at offset 7: subpattern number is too big
+
+# smaller than GROUP_MAX
+/\21300/
+    \x8b00
+ 0: \x8b00
+
+# larger than GROUP_MAX
+/\213000/
+    \x8b000
+ 0: \x8b000
+
+# larger than INT_MAX
+/\21300000000/
+    \x8b00000000
+ 0: \x8b00000000
+
 /a{65536/
     >a{65536<
  0: a{65536

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -14723,7 +14723,7 @@ Failed: error 161 at offset 9: subpattern number is too big
 No match
 
 /(?(1)()\983040\2)/
-Failed: error 161 at offset 14: subpattern number is too big
+Failed: error 161 at offset 13: subpattern number is too big
 
 /(*LIMIT_MATCH=)abc/
 Failed: error 160 at offset 14: (*VERB) not recognized or malformed


### PR DESCRIPTION
For backreferences of the form `\8000000` (larger than GROUP_MAX but smaller than INT_MAX) the regex was rejected as invalid, due to an out-of-range backreference.

However, for those of the form `\80000000000` (larger than INT_MAX) it would treat it as a escape for the literal character '8', which is inconsistent with Perl (confirmed by test).

This appears to be just an oversight in the code, and there's no test case so this condition wasn't covered.