### PR TITLE
Add Python-style \1 backreferences in pcre2_substitute()

### DIFF
--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -2050,7 +2050,7 @@ is available. */
 extern int          _pcre2_auto_possessify(PCRE2_UCHAR *,
                       const compile_block *);
 extern int          _pcre2_check_escape(PCRE2_SPTR *, PCRE2_SPTR, uint32_t *,
-                      int *, uint32_t, uint32_t, BOOL, compile_block *);
+                      int *, uint32_t, uint32_t, uint32_t, BOOL, compile_block *);
 extern PCRE2_SPTR   _pcre2_extuni(uint32_t, PCRE2_SPTR, PCRE2_SPTR, PCRE2_SPTR,
                       BOOL, int *);
 extern PCRE2_SPTR   _pcre2_find_bracket(PCRE2_SPTR, BOOL, int);

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4680,6 +4680,15 @@ B)x/alt_verbnames,mark
 /abc/substitute_extended,replace=>\845<
     abc
 
+/a(b)(c)/substitute_extended,replace=>\1<
+    abc
+
+/a(b)(c)/substitute_extended,replace=>\2<
+    abc
+
+/a(b)(c)/substitute_extended,replace=>\3<
+    abc
+
 /^(o(\1{72}{\"{\\{00000059079}\d*){74}}){19}/I
 
 /((p(?'K/

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -14948,7 +14948,19 @@ Failed: error -55 at offset 3 in replacement: requested value is not set
 
 /abc/substitute_extended,replace=>\845<
     abc
- 1: >845<
+Failed: error -49 at offset 5 in replacement: unknown substring
+
+/a(b)(c)/substitute_extended,replace=>\1<
+    abc
+ 1: >b<
+
+/a(b)(c)/substitute_extended,replace=>\2<
+    abc
+ 1: >c<
+
+/a(b)(c)/substitute_extended,replace=>\3<
+    abc
+Failed: error -49 at offset 3 in replacement: unknown substring
 
 /^(o(\1{72}{\"{\\{00000059079}\d*){74}}){19}/I
 Capture group count = 2


### PR DESCRIPTION
Previously, using `\1` inside a pcre2_substitute string would cause a bad-replacement error.

Now, we support this syntax in the same way as Python, to mean the same as `${1}`.