### PR TITLE
Add Perl titlecasing

### DIFF
--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -839,6 +839,12 @@ do
         forcecase = -1;
         forcecasereset = 0;
         ptr += 2;
+        if (ptr + 2 < repend && ptr[0] == CHAR_BACKSLASH && ptr[1] == CHAR_U)
+          {
+          /* Perl title-casing feature for \l\U (and \u\L) */
+          forcecasereset = 1;
+          ptr += 2;
+          }
         continue;
 
         case CHAR_U:
@@ -850,6 +856,11 @@ do
         forcecase = 1;
         forcecasereset = 0;
         ptr += 2;
+        if (ptr + 2 < repend && ptr[0] == CHAR_BACKSLASH && ptr[1] == CHAR_L)
+          {
+          forcecasereset = -1;
+          ptr += 2;
+          }
         continue;
 
         default:

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4612,6 +4612,9 @@ B)x/alt_verbnames,mark
 /a(bc)(DE)/replace=a\u$1\U$1\E$1\l$2\L$2\Eab\Uab\LYZ\EDone,substitute_extended
     abcDE
 
+/(Hello)|wORLD/g,replace=>${1:+\l\U$0:\u\L$0}<,substitute_extended
+    Hello between wORLD
+
 /abcd/replace=xy\kz,substitute_extended
     abcd
 

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -14854,6 +14854,10 @@ No match
     abcDE
  1: aBcBCbcdEdeabAByzDone
 
+/(Hello)|wORLD/g,replace=>${1:+\l\U$0:\u\L$0}<,substitute_extended
+    Hello between wORLD
+ 2: >hELLO< between >World<
+
 /abcd/replace=xy\kz,substitute_extended
     abcd
 Failed: error -57 at offset 4 in replacement: bad escape sequence in replacement string


### PR DESCRIPTION
This is a feature in Perl, which combines the functionality of the replacement casing operators:

```perl
$thevar = "Hello";
$thevar =~ s/(Hello)/>\l\U${1}</g;
print $thevar
```

PCRE2 should support this, for Perl compatibility.