### PR TITLE
pcre2_compile: make erroroffsets returned from read_number() more accurate

### DIFF
--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -75,6 +75,12 @@
 
 # ---------------------------------------------------------------------
 
+# Use no_start_optimize because the first code unit is different in 8-bit from
+# the wider modes.
+/\65535/IB,utf,no_start_optimize
+
+/\65536/IB,utf,no_start_optimize
+
 /\x{110000}/IB,utf
 
 /\o{4200000}/IB,utf

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -5506,13 +5506,13 @@ Subject length lower bound = 4
 No match
 
 /a{11111111111111111111}/I
-Failed: error 105 at offset 8: number too big in {} quantifier
+Failed: error 105 at offset 22: number too big in {} quantifier
 
 /(){64294967295}/I
-Failed: error 105 at offset 9: number too big in {} quantifier
+Failed: error 105 at offset 14: number too big in {} quantifier
 
 /(){2,4294967295}/I
-Failed: error 105 at offset 11: number too big in {} quantifier
+Failed: error 105 at offset 15: number too big in {} quantifier
 
 "(?i:a)(?i:b)(?i:c)(?i:d)(?i:e)(?i:f)(?i:g)(?i:h)(?i:i)(?i:j)(k)(?i:l)A\1B"I
 Capture group count = 1
@@ -8374,7 +8374,7 @@ No match
 Failed: error 166 at offset 7: (*MARK) must have an argument
 
 /\g6666666666/
-Failed: error 161 at offset 7: subpattern number is too big
+Failed: error 161 at offset 12: subpattern number is too big
 
 /[\g6666666666]/B
 ------------------------------------------------------------------
@@ -14645,7 +14645,7 @@ Failed: error 162 at offset 4: subpattern name expected
 "(?J:(?|(?'R')(\k'R')|((?'R'))))"
 
 /(?<=|(\,\$(?73591620449005828816)\xa8.{7}){6}\x09)/
-Failed: error 161 at offset 17: subpattern number is too big
+Failed: error 161 at offset 32: subpattern number is too big
 
 /^(?:(?(1)x|)+)+$()/B
 ------------------------------------------------------------------
@@ -14836,7 +14836,7 @@ No match
  0: ab
 
 /(?(8000000000/
-Failed: error 161 at offset 8: subpattern number is too big
+Failed: error 161 at offset 13: subpattern number is too big
 
 /((?(R8000000000)))/
 Failed: error 161 at offset 9: subpattern number is too big
@@ -14847,7 +14847,7 @@ Failed: error 161 at offset 9: subpattern number is too big
 No match
 
 /(?(1)()\983040\2)/
-Failed: error 161 at offset 13: subpattern number is too big
+Failed: error 161 at offset 14: subpattern number is too big
 
 /(*LIMIT_MATCH=)abc/
 Failed: error 160 at offset 14: (*VERB) not recognized or malformed
@@ -19219,15 +19219,15 @@ No match
 
 # larger than GROUP_MAX, smaller than INT_MAX
 /a\800000b/
-Failed: error 161 at offset 7: subpattern number is too big
+Failed: error 161 at offset 8: subpattern number is too big
 
 # coming up on INT_MAX... (used to succeed with \8 being literal 8)
 /a\800000000b/
-Failed: error 161 at offset 7: subpattern number is too big
+Failed: error 161 at offset 11: subpattern number is too big
 
 # over INT_MAX (used to succeed with \8 being literal 8)
 /a\8000000000b/
-Failed: error 161 at offset 7: subpattern number is too big
+Failed: error 161 at offset 12: subpattern number is too big
 
 # End of testinput2
 Error -70: PCRE2_ERROR_BADDATA (unknown error number)

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -98,6 +98,28 @@ No match
 
 # ---------------------------------------------------------------------
 
+# Use no_start_optimize because the first code unit is different in 8-bit from
+# the wider modes.
+/\65535/IB,utf,no_start_optimize
+------------------------------------------------------------------
+        Bra
+        \x{1ad}35
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Options: no_start_optimize utf
+
+/\65536/IB,utf,no_start_optimize
+------------------------------------------------------------------
+        Bra
+        \x{1ad}36
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Options: no_start_optimize utf
+
 /\x{110000}/IB,utf
 Failed: error 134 at offset 9: character code point value in \x{} or \o{} is too large
 


### PR DESCRIPTION
A "fixup" to the bug addressed by #472, and that corrects a small regression introduced there
where group numbers larger than 65535 will report and even less accurate erroroffset.