### PR TITLE
Improve caseless character range processing when utf is enabled

### DIFF
--- a/maint/GenerateUcd.py
+++ b/maint/GenerateUcd.py
@@ -800,6 +800,8 @@ const ucd_record PRIV(ucd_records)[] = {{0,0,0,0,0,0,0}};
 const uint16_t PRIV(ucd_stage1)[] = {0};
 const uint16_t PRIV(ucd_stage2)[] = {0};
 const uint32_t PRIV(ucd_caseless_sets)[] = {0};
+const uint32_t PRIV(ucd_nocase_ranges)[] = {0};
+const uint32_t PRIV(ucd_nocase_ranges_size) = 0;
 #else
 \n""")
 
@@ -858,6 +860,40 @@ the large main UCD tables. */
 
 #ifndef PCRE2_PCRE2TEST
 \n""")
+
+# --- Output the nocase sets ---
+
+f.write("""\
+/* This table contains character ranges, where the characters in the range has
+no other case. Both start and end values are excluded from the range. */
+
+const uint32_t PRIV(ucd_nocase_ranges)[] = {
+""")
+
+range_start = 0
+size = 0
+# The range size is bigger than eight characters.
+expected_size = 8
+total = 0
+
+for c in range(1, MAX_UNICODE):
+  if other_case[c] != 0:
+    if c - range_start > expected_size:
+      range_size = c - range_start - 1
+      f.write('  0x%04x, 0x%04x, /* %d */\n' % (range_start, c, range_size))
+      total += range_size
+      size += 2
+    range_start = c
+
+# The else case is unlikely
+if other_case[MAX_UNICODE - 1] == 0 and MAX_UNICODE - range_start > expected_size:
+  range_size = MAX_UNICODE - range_start - 1
+  f.write('  0x%04x, 0x%04x, /* %d */\n' % (range_start, MAX_UNICODE, range_size))
+  total += range_size
+  size += 2
+
+f.write('  0xffffffff, 0xffffffff /* terminator */\n};\n\n');
+f.write('/* Total: %d characters. */\nconst uint32_t PRIV(ucd_nocase_ranges_size) = %d;\n\n' % (total, size))
 
 # --- Read Scripts.txt again for the sets of 10 digits. ---
 

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -5340,6 +5340,44 @@ for (++c; c <= d; c++)
 *cptr = c;             /* Rest of input range */
 return 0;
 }
+
+
+
+/*************************************************
+*             Get nocase ranges                  *
+*************************************************/
+
+/* This function returns the next nocase range after a character
+using binary search. The character might be included in the range.
+
+Arguments:
+  c           current character
+
+Yield:        range (start/end pair)
+*/
+
+static const uint32_t*
+get_nocase_range(uint32_t c)
+{
+uint32_t left = 0;
+uint32_t right = PRIV(ucd_nocase_ranges_size);
+uint32_t middle;
+
+if (c > MAX_UTF_CODE_POINT) return PRIV(ucd_nocase_ranges) + right;
+
+while (TRUE)
+  {
+  /* Range end of the middle element. */
+  middle = ((left + right) >> 1) | 0x1;
+
+  if (PRIV(ucd_nocase_ranges)[middle] <= c)
+    left = middle + 1;
+  else if (middle > 1 && PRIV(ucd_nocase_ranges)[middle - 2] > c)
+    right = middle - 1;
+  else
+    return PRIV(ucd_nocase_ranges) + (middle - 1);
+  }
+}
 #endif  /* SUPPORT_UNICODE */
 
 
@@ -5388,14 +5426,45 @@ if ((options & PCRE2_CASELESS) != 0)
   if ((options & (PCRE2_UTF|PCRE2_UCP)) != 0)
     {
     int rc;
-    uint32_t oc, od;
+    uint32_t oc, od, skip_start;
+    const uint32_t *skip_range;
 
     options &= ~PCRE2_CASELESS;   /* Remove for recursive calls */
     c = start;
+    skip_range = get_nocase_range(c);
+    skip_start = skip_range[0];
+    if (c > skip_start)
+      {
+      c = skip_range[1];
+      skip_range += 2;
+      skip_start = skip_range[0];
+      }
 
     while ((rc = get_othercase_range(&c, end, &oc, &od,
              (xoptions & PCRE2_EXTRA_CASELESS_RESTRICT) != 0)) >= 0)
       {
+      if (c > skip_start)
+        {
+        if (c < skip_range[1])
+          {
+          c = skip_range[1];
+          skip_range += 2;
+          skip_start = skip_range[0];
+          }
+        else
+          {
+          skip_range = get_nocase_range(c);
+          skip_start = skip_range[0];
+
+          if (c > skip_start)
+            {
+            c = skip_range[1];
+            skip_range += 2;
+            skip_start = skip_range[0];
+            }
+          }
+        }
+
       /* Handle a single character that has more than one other case. */
 
       if (rc > 0) n8 += add_list_to_class_internal(classbits, uchardptr,

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -1962,6 +1962,8 @@ extern const uint8_t          PRIV(utf8_table4)[];
 #define _pcre2_vspace_list             PCRE2_SUFFIX(_pcre2_vspace_list_)
 #define _pcre2_ucd_boolprop_sets       PCRE2_SUFFIX(_pcre2_ucd_boolprop_sets_)
 #define _pcre2_ucd_caseless_sets       PCRE2_SUFFIX(_pcre2_ucd_caseless_sets_)
+#define _pcre2_ucd_nocase_ranges       PCRE2_SUFFIX(_pcre2_ucd_nocase_ranges_)
+#define _pcre2_ucd_nocase_ranges_size  PCRE2_SUFFIX(_pcre2_ucd_nocase_ranges_size_)
 #define _pcre2_ucd_digit_sets          PCRE2_SUFFIX(_pcre2_ucd_digit_sets_)
 #define _pcre2_ucd_script_sets         PCRE2_SUFFIX(_pcre2_ucd_script_sets_)
 #define _pcre2_ucd_records             PCRE2_SUFFIX(_pcre2_ucd_records_)
@@ -1986,6 +1988,8 @@ extern const uint32_t                  PRIV(hspace_list)[];
 extern const uint32_t                  PRIV(vspace_list)[];
 extern const uint32_t                  PRIV(ucd_boolprop_sets)[];
 extern const uint32_t                  PRIV(ucd_caseless_sets)[];
+extern const uint32_t                  PRIV(ucd_nocase_ranges)[];
+extern const uint32_t                  PRIV(ucd_nocase_ranges_size);
 extern const uint32_t                  PRIV(ucd_digit_sets)[];
 extern const uint32_t                  PRIV(ucd_script_sets)[];
 extern const ucd_record                PRIV(ucd_records)[];

--- a/src/pcre2_ucd.c
+++ b/src/pcre2_ucd.c
@@ -72,6 +72,8 @@ const ucd_record PRIV(ucd_records)[] = {{0,0,0,0,0,0,0}};
 const uint16_t PRIV(ucd_stage1)[] = {0};
 const uint16_t PRIV(ucd_stage2)[] = {0};
 const uint32_t PRIV(ucd_caseless_sets)[] = {0};
+const uint32_t PRIV(ucd_nocase_ranges)[] = {0};
+const uint32_t PRIV(ucd_nocase_ranges_size) = 0;
 #else
 
 /* Total size: 112564 bytes, block size: 128. */
@@ -146,6 +148,53 @@ const uint32_t PRIV(ucd_caseless_sets)[] = {
 the large main UCD tables. */
 
 #ifndef PCRE2_PCRE2TEST
+
+/* This table contains character ranges, where the characters in the range has
+no other case. Both start and end values are excluded from the range. */
+
+const uint32_t PRIV(ucd_nocase_ranges)[] = {
+  0x0000, 0x0041, /* 64 */
+  0x007a, 0x00b5, /* 58 */
+  0x00b5, 0x00c0, /* 10 */
+  0x0292, 0x029d, /* 10 */
+  0x029e, 0x0345, /* 166 */
+  0x0345, 0x0370, /* 42 */
+  0x0481, 0x048a, /* 8 */
+  0x0556, 0x0561, /* 10 */
+  0x0586, 0x10a0, /* 2841 */
+  0x10ff, 0x13a0, /* 672 */
+  0x13fd, 0x1c80, /* 2178 */
+  0x1cbf, 0x1d79, /* 185 */
+  0x1d7d, 0x1d8e, /* 16 */
+  0x1d8e, 0x1e00, /* 113 */
+  0x1ffc, 0x2126, /* 297 */
+  0x2132, 0x214e, /* 27 */
+  0x214e, 0x2160, /* 17 */
+  0x2184, 0x24b6, /* 817 */
+  0x24e9, 0x2c00, /* 1814 */
+  0x2cf3, 0x2d00, /* 12 */
+  0x2d2d, 0xa640, /* 30994 */
+  0xa66d, 0xa680, /* 18 */
+  0xa69b, 0xa722, /* 134 */
+  0xa76f, 0xa779, /* 9 */
+  0xa7d9, 0xa7f5, /* 27 */
+  0xa7f6, 0xab53, /* 860 */
+  0xab53, 0xab70, /* 28 */
+  0xabbf, 0xff21, /* 21345 */
+  0xff5a, 0x10400, /* 1189 */
+  0x1044f, 0x104b0, /* 96 */
+  0x104fb, 0x10570, /* 116 */
+  0x105bc, 0x10c80, /* 1731 */
+  0x10cb2, 0x10cc0, /* 13 */
+  0x10cf2, 0x118a0, /* 2989 */
+  0x118df, 0x16e40, /* 21856 */
+  0x16e7f, 0x1e900, /* 31360 */
+  0x1e943, 0x110000, /* 988860 */
+  0xffffffff, 0xffffffff /* terminator */
+};
+
+/* Total: 1110982 characters. */
+const uint32_t PRIV(ucd_nocase_ranges_size) = 74;
 
 /* This table lists the code points for the '9' characters in each set of
 decimal digits. It is used to ensure that all the digits in a script run come


### PR DESCRIPTION
Currently when utf caseless matching is requested, each character in a class range is checked one-by-one to find their other cases. I always thought this is inefficient, even if it is only done by the parser.

To speed things up, I have added a data structure, which contains ranges where characters have no other cases. The ranges have a minimum size. The size in uint32_t units with different minimum sizes (the number of ranges is half of that size):

```
minimum size 4: 124; /* 1111114 characters */
minimum size 8: 74; /* 1110983 characters */
minimum size 16: 60; /* 1110911 characters */
```

I choose 8 at the end, because only 74 values are needed, and these ranges cover 1110983 characters, which is 99.7% of all utf characters.

Performance improvement by the patch:

Original (-O3):
```
./pcre2test -t 100
PCRE2 version 10.45-DEV 2024-06-09 (8-bit)
  re> /[\x{100}-\x{100000}]/iB,utf
Compile time 8957.8600 microseconds
------------------------------------------------------------------
        Bra
        [KSks\xb5\xc5\xdf\xe5\xff\x{100}-\x{100000}]
        Ket
        End
------------------------------------------------------------------
```

New (-O3)
```
./pcre2test -t 100
PCRE2 version 10.45-DEV 2024-06-09 (8-bit)
  re> /[\x{100}-\x{100000}]/iB,utf
Compile time  83.0600 microseconds
------------------------------------------------------------------
        Bra
        [KSks\xb5\xc5\xdf\xe5\xff\x{100}-\x{100000}]
        Ket
        End
------------------------------------------------------------------
```

The new one is 107 times faster than the old, I think this is a nice speedup.
