### PR TITLE
Add fix and tests for \x with no hex digits

### DIFF
--- a/src/pcre2_error.c
+++ b/src/pcre2_error.c
@@ -161,7 +161,7 @@ static const unsigned char compile_error_texts[] =
   "using UCP is disabled by the application\0"
   "name is too long in (*MARK), (*PRUNE), (*SKIP), or (*THEN)\0"
   "character code point value in \\u.... sequence is too large\0"
-  "digits missing in \\x{} or \\o{} or \\N{U+}\0"
+  "digits missing after \\x or in \\x{} or \\o{} or \\N{U+}\0"
   "syntax error or number too big in (?(VERSION condition\0"
   /* 80 */
   "internal error: unknown opcode in auto_possessify()\0"

--- a/testdata/testinput1
+++ b/testdata/testinput1
@@ -5610,9 +5610,15 @@ name)/mark
 /^ (?:(?<A>A)|(?'B'B)(?<A>A)) (?('A')x) (?(<B>)y)$/x,dupnames
     Ax
     BAxy 
-    
-/^A\xZ/
-    A\0Z 
+
+/^A\xBz/
+    A\x{0B}z
+
+/^A\xABz/
+    A\x{AB}z
+
+/^A\xABCz/
+    A\x{AB}Cz
 
 /^A\o{123}B/
     A\123B

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -3983,6 +3983,10 @@
 
 /\xthing/
 
+/^A\xZ/
+
+/^A\x/
+
 /\x{}/
 
 /\x{whatever}/

--- a/testdata/testoutput1
+++ b/testdata/testoutput1
@@ -8919,10 +8919,18 @@ No match
  1: <unset>
  2: B
  3: A
-    
-/^A\xZ/
-    A\0Z 
- 0: A\x00Z
+
+/^A\xBz/
+    A\x{0B}z
+ 0: A\x0bz
+
+/^A\xABz/
+    A\x{AB}z
+ 0: A\xabz
+
+/^A\xABCz/
+    A\x{AB}Cz
+ 0: A\xabCz
 
 /^A\o{123}B/
     A\123B

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13239,7 +13239,7 @@ Failed: error 167 at offset 5: non-hex character in \x{} (closing brace missing?
 Failed: error 167 at offset 7: non-hex character in \x{} (closing brace missing?)
 
 /^A\x{/
-Failed: error 178 at offset 5: digits missing in \x{} or \o{} or \N{U+}
+Failed: error 178 at offset 5: digits missing after \x or in \x{} or \o{} or \N{U+}
 
 /[ab]++/B,no_auto_possess
 ------------------------------------------------------------------
@@ -13451,15 +13451,22 @@ Failed: error 133 at offset 7: parentheses are too deeply nested (stack check)
 Failed: error 155 at offset 2: missing opening brace after \o
 
 /\o{}/
-Failed: error 178 at offset 3: digits missing in \x{} or \o{} or \N{U+}
+Failed: error 178 at offset 3: digits missing after \x or in \x{} or \o{} or \N{U+}
 
 /\o{whatever}/
 Failed: error 164 at offset 3: non-octal character in \o{} (closing brace missing?)
 
 /\xthing/
+Failed: error 178 at offset 2: digits missing after \x or in \x{} or \o{} or \N{U+}
+
+/^A\xZ/
+Failed: error 178 at offset 4: digits missing after \x or in \x{} or \o{} or \N{U+}
+
+/^A\x/
+Failed: error 178 at offset 4: digits missing after \x or in \x{} or \o{} or \N{U+}
 
 /\x{}/
-Failed: error 178 at offset 3: digits missing in \x{} or \o{} or \N{U+}
+Failed: error 178 at offset 3: digits missing after \x or in \x{} or \o{} or \N{U+}
 
 /\x{whatever}/
 Failed: error 167 at offset 3: non-hex character in \x{} (closing brace missing?)

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -4702,7 +4702,7 @@ Callout 0: last capture = 1
 Failed: error 193 at offset 2: \N{U+dddd} is supported only in Unicode (UTF) mode
 
 /\N{U+}/utf
-Failed: error 178 at offset 5: digits missing in \x{} or \o{} or \N{U+}
+Failed: error 178 at offset 5: digits missing after \x or in \x{} or \o{} or \N{U+}
 
 /\N{U}/
 Failed: error 137 at offset 2: PCRE2 does not support \F, \L, \l, \N{name}, \U, or \u


### PR DESCRIPTION
Why mess around with something that's broken, and which no users are likely to want?

Grasp the nettle, and simply disallow `\x` with no following hex digits (following non-hex character, or at end of pattern).

As documented in the code comments added, this diverges from Perl's default behaviour, but aligns with Perl+warnings, so is consistent with best-practices Perl usage.