### PR TITLE
Add PCRE2_EXTRA_VANILLA_SYNTAX to disable PCRE2 extensions

### DIFF
--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -161,6 +161,7 @@ D   is inspected during pcre2_dfa_match() execution
 #define PCRE2_EXTRA_ASCII_DIGIT              0x00001000u  /* C */
 #define PCRE2_EXTRA_PYTHON_OCTAL             0x00002000u  /* C */
 #define PCRE2_EXTRA_NO_BS0                   0x00004000u  /* C */
+#define PCRE2_EXTRA_VANILLA_SYNTAX           0x10000000u  /* C */
 
 /* These are for pcre2_jit_compile(). */
 

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -791,6 +791,7 @@ static modstruct modlist[] = {
   { "use_offset_limit",            MOD_PAT,  MOD_OPT, PCRE2_USE_OFFSET_LIMIT,     PO(options) },
   { "utf",                         MOD_PATP, MOD_OPT, PCRE2_UTF,                  PO(options) },
   { "utf8_input",                  MOD_PAT,  MOD_CTL, CTL_UTF8_INPUT,             PO(control) },
+  { "vanilla_syntax",              MOD_CTC,  MOD_OPT, PCRE2_EXTRA_VANILLA_SYNTAX, CO(extra_options) },
   { "zero_terminate",              MOD_DAT,  MOD_CTL, CTL_ZERO_TERMINATE,         DO(control) }
 };
 

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -6630,4 +6630,119 @@ a)"xI
     abc\=replace=\1
     abc\=replace=\12
 
+# --------------
+
+# "Vanilla" syntax option
+
+# -- start of pattern
+
+/(*NOTEMPTY)a/
+    a
+
+/(*NtOMeTpY)a/
+
+/(*NOTEMPTY)a/vanilla_syntax
+
+# -- inline pattern options
+
+/Z(?a)Z(?a:Z)Z(?^a)Z(?x-a)Z(?r)Z/
+    ZZZZZZZ
+
+/Z(?F)Z/
+
+/Z(?a)Z/vanilla_syntax
+
+/Z(?a:Z)Z/vanilla_syntax
+
+/Z(?^a)Z/vanilla_syntax
+
+/Z(?x-a)Z/vanilla_syntax
+
+/Z(?r)Z/vanilla_syntax
+
+/Z(?i:z)Z/vanilla_syntax
+    ZZZ
+
+# -- version detection
+
+/(?(VERSION>=10.4)yes|no)/
+    yes
+
+/(?(vReSoIn>=10.4)yes|no)/
+
+/(?(VERSION>=10.4)yes|no)/vanilla_syntax
+
+# -- callouts
+
+/A(?C0)B/
+    AB
+
+/A(?F0)B/
+
+/A(?C0)B/vanilla_syntax
+
+# -- scan_substring
+
+/\b(\w++)(*scs:(1).+rh)/
+    >myrrh<
+
+/\b(\w++)(*szz:(1).+rh)/
+
+/\b(\w++)(*scs:(1).+rh)/vanilla_syntax
+
+/\b(\w++)(*scan_substring:(1).+rh)/
+    >myrrh<
+
+/\b(\w++)(*szzz_zzzzzzzzz:(1).+rh)/
+
+/\b(\w++)(*scan_substring:(1).+rh)/vanilla_syntax
+
+# -- napla
+
+/(*napla:(a{1,2}))\1\1/
+    aa
+
+/(*nzzzz:(a{1,2}))\1\1/
+
+/(*napla:(a{1,2}))\1\1/vanilla_syntax
+
+/(*non_atomic_positive_lookahead:(a{1,2}))\1\1/
+    aa
+
+/(*nzz_zzzzzz_positive_lookahead:(a{1,2}))\1\1/
+
+/(*non_atomic_positive_lookahead:(a{1,2}))\1\1/vanilla_syntax
+
+/(?*(a{1,2}))\1\1/
+    aa
+
+/(?;(a{1,2}))\1\1/
+
+/(?*(a{1,2}))\1\1/vanilla_syntax
+
+# -- naplb
+
+/^..(*naplb:a(b)|(a)b)\2\2/
+    abaa
+
+/^..(*nzzzz:a(b)|(a)b)\2\2/
+
+/^..(*naplb:a(b)|(a)b)\2\2/vanilla_syntax
+
+/^..(*non_atomic_positive_lookbehind:a(b)|(a)b)\2\2/
+    abaa
+
+/^..(*nzz_zzzzzz_positive_lookbehind:a(b)|(a)b)\2\2/
+
+/^..(*non_atomic_positive_lookbehind:a(b)|(a)b)\2\2/vanilla_syntax
+
+/^..(?<*a(b)|(a)b)\2\2/
+    abaa
+
+/^..(?<;a(b)|(a)b)\2\2/
+
+/^..(?<*a(b)|(a)b)\2\2/vanilla_syntax
+
+# --------------
+
 # End of testinput2

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -19558,6 +19558,175 @@ Failed: error -49 at offset 2 in replacement: unknown substring
     abc\=replace=\12
 Failed: error -49 at offset 3 in replacement: unknown substring
 
+# --------------
+
+# "Vanilla" syntax option
+
+# -- start of pattern
+
+/(*NOTEMPTY)a/
+    a
+ 0: a
+
+/(*NtOMeTpY)a/
+Failed: error 160 at offset 10: (*VERB) not recognized or malformed
+
+/(*NOTEMPTY)a/vanilla_syntax
+Failed: error 160 at offset 10: (*VERB) not recognized or malformed
+
+# -- inline pattern options
+
+/Z(?a)Z(?a:Z)Z(?^a)Z(?x-a)Z(?r)Z/
+    ZZZZZZZ
+ 0: ZZZZZZZ
+
+/Z(?F)Z/
+Failed: error 111 at offset 3: unrecognized character after (? or (?-
+
+/Z(?a)Z/vanilla_syntax
+Failed: error 111 at offset 3: unrecognized character after (? or (?-
+
+/Z(?a:Z)Z/vanilla_syntax
+Failed: error 111 at offset 3: unrecognized character after (? or (?-
+
+/Z(?^a)Z/vanilla_syntax
+Failed: error 111 at offset 4: unrecognized character after (? or (?-
+
+/Z(?x-a)Z/vanilla_syntax
+Failed: error 111 at offset 5: unrecognized character after (? or (?-
+
+/Z(?r)Z/vanilla_syntax
+Failed: error 111 at offset 3: unrecognized character after (? or (?-
+
+/Z(?i:z)Z/vanilla_syntax
+    ZZZ
+ 0: ZZZ
+
+# -- version detection
+
+/(?(VERSION>=10.4)yes|no)/
+    yes
+ 0: yes
+
+/(?(vReSoIn>=10.4)yes|no)/
+Failed: error 142 at offset 10: syntax error in subpattern name (missing terminator?)
+
+/(?(VERSION>=10.4)yes|no)/vanilla_syntax
+Failed: error 142 at offset 10: syntax error in subpattern name (missing terminator?)
+
+# -- callouts
+
+/A(?C0)B/
+    AB
+--->AB
+  0 ^^     B
+ 0: AB
+
+/A(?F0)B/
+Failed: error 111 at offset 3: unrecognized character after (? or (?-
+
+/A(?C0)B/vanilla_syntax
+Failed: error 111 at offset 3: unrecognized character after (? or (?-
+
+# -- scan_substring
+
+/\b(\w++)(*scs:(1).+rh)/
+    >myrrh<
+ 0: myrrh
+ 1: myrrh
+
+/\b(\w++)(*szz:(1).+rh)/
+Failed: error 195 at offset 13: (*alpha_assertion) not recognized
+
+/\b(\w++)(*scs:(1).+rh)/vanilla_syntax
+Failed: error 195 at offset 13: (*alpha_assertion) not recognized
+
+/\b(\w++)(*scan_substring:(1).+rh)/
+    >myrrh<
+ 0: myrrh
+ 1: myrrh
+
+/\b(\w++)(*szzz_zzzzzzzzz:(1).+rh)/
+Failed: error 195 at offset 24: (*alpha_assertion) not recognized
+
+/\b(\w++)(*scan_substring:(1).+rh)/vanilla_syntax
+Failed: error 195 at offset 24: (*alpha_assertion) not recognized
+
+# -- napla
+
+/(*napla:(a{1,2}))\1\1/
+    aa
+ 0: aa
+ 1: a
+
+/(*nzzzz:(a{1,2}))\1\1/
+Failed: error 195 at offset 7: (*alpha_assertion) not recognized
+
+/(*napla:(a{1,2}))\1\1/vanilla_syntax
+Failed: error 195 at offset 7: (*alpha_assertion) not recognized
+
+/(*non_atomic_positive_lookahead:(a{1,2}))\1\1/
+    aa
+ 0: aa
+ 1: a
+
+/(*nzz_zzzzzz_positive_lookahead:(a{1,2}))\1\1/
+Failed: error 195 at offset 31: (*alpha_assertion) not recognized
+
+/(*non_atomic_positive_lookahead:(a{1,2}))\1\1/vanilla_syntax
+Failed: error 195 at offset 31: (*alpha_assertion) not recognized
+
+/(?*(a{1,2}))\1\1/
+    aa
+ 0: aa
+ 1: a
+
+/(?;(a{1,2}))\1\1/
+Failed: error 111 at offset 2: unrecognized character after (? or (?-
+
+/(?*(a{1,2}))\1\1/vanilla_syntax
+Failed: error 111 at offset 2: unrecognized character after (? or (?-
+
+# -- naplb
+
+/^..(*naplb:a(b)|(a)b)\2\2/
+    abaa
+ 0: abaa
+ 1: <unset>
+ 2: a
+
+/^..(*nzzzz:a(b)|(a)b)\2\2/
+Failed: error 195 at offset 10: (*alpha_assertion) not recognized
+
+/^..(*naplb:a(b)|(a)b)\2\2/vanilla_syntax
+Failed: error 195 at offset 10: (*alpha_assertion) not recognized
+
+/^..(*non_atomic_positive_lookbehind:a(b)|(a)b)\2\2/
+    abaa
+ 0: abaa
+ 1: <unset>
+ 2: a
+
+/^..(*nzz_zzzzzz_positive_lookbehind:a(b)|(a)b)\2\2/
+Failed: error 195 at offset 35: (*alpha_assertion) not recognized
+
+/^..(*non_atomic_positive_lookbehind:a(b)|(a)b)\2\2/vanilla_syntax
+Failed: error 195 at offset 35: (*alpha_assertion) not recognized
+
+/^..(?<*a(b)|(a)b)\2\2/
+    abaa
+ 0: abaa
+ 1: <unset>
+ 2: a
+
+/^..(?<;a(b)|(a)b)\2\2/
+Failed: error 162 at offset 6: subpattern name expected
+
+/^..(?<*a(b)|(a)b)\2\2/vanilla_syntax
+Failed: error 162 at offset 6: subpattern name expected
+
+# --------------
+
 # End of testinput2
 Error -70: PCRE2_ERROR_BADDATA (unknown error number)
 Error -62: bad serialized data


### PR DESCRIPTION
!!!

BIKESHEDDING / ARGUMENT WARNING

!!!

This PR is harmless in principle, but I expect people will have different opinions on the details.

Personally, I don't mind much.

### Goal

Add an `PCRE2_EXTRA_VANILLA_SYNTAX` to remove syntax which is specific to PCRE2. It will be treated as if PCRE2 didn't even parse the syntax, giving the same syntax errors you'd get from (say) Perl.

The goal here is to remove things which are invented by PCRE2 - not because it's bad (I'm not passing judgement), but simply so that users who want a more "vanilla" syntax can do so.

Things that are in .NET, Ruby (oniguruma), Perl, ... are all OK, because they're not invented by PCRE2. So this option isn't bringing PCRE2 into alignment with Perl (which would be stricter than this PR). I'm merely restricting it from offering syntax that's not supported by any other engine.

First draft includes:
* The pre-pattern syntax such as `(*NOTEMPTY)`
* PCRE2-specific inline pattern options such as `(?aX)`
* PCRE2 version detection such as `(?(VERSION>=10.4)yes|no)`
* Callouts such as `(?C0)`
* `scan_substring`
* `non_atomic_positive_look(ahead|behind)`