### PR TITLE
ci: add very basic 64bit Windows DEV job

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -68,7 +68,7 @@ jobs:
         run: ./pcre2posix_test -v
 
   bat:
-    name: MSVC
+    name: 32bit MSVC
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -78,6 +78,28 @@ jobs:
 
       - name: Configure
         run: cmake -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DPCRE2GREP_SUPPORT_CALLOUT_FORK=OFF -DPCRE2_DEBUG=ON -DPCRE2_NEWLINE=ANYCRLF -DPCRE2_STATIC_PIC=ON -DPCRE2_STATIC_RUNTIME=ON -DPCRE2_SUPPORT_BSR_ANYCRLF=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_VERBOSE_MAKEFILE=ON -B build -A Win32
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        shell: cmd
+        run: |
+          cd build
+          ctest -C Debug .
+          type Testing\Temporary\LastTest.log
+
+  pterodactyl:
+    name: MSVC
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Configure
+        run: cmake -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DPCRE2_DEBUG=ON -DPCRE2_BUILD_PCRE2GREP=OFF -DPCRE2_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -B build
 
       - name: Build
         run: cmake --build build

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -8794,10 +8794,10 @@ for (;;)
     {
     if (lengthptr == NULL)
       {
-      PCRE2_SIZE branch_length = code - last_branch;
+      uint32_t branch_length = (uint32_t)(code - last_branch);
       do
         {
-        PCRE2_SIZE prev_length = GET(last_branch, 1);
+        uint32_t prev_length = GET(last_branch, 1);
         PUT(last_branch, 1, branch_length);
         branch_length = prev_length;
         last_branch -= branch_length;
@@ -8808,7 +8808,7 @@ for (;;)
     /* Fill in the ket */
 
     *code = OP_KET;
-    PUT(code, 1, (int)(code - start_bracket));
+    PUT(code, 1, (uint32_t)(code - start_bracket));
     code += 1 + LINK_SIZE;
 
     /* Set values to pass back */
@@ -11006,7 +11006,7 @@ if (errorcode == 0 && cb.had_recurse)
         }
       }
 
-    PUT(rcode, 1, rgroup - codestart);
+    PUT(rcode, 1, (uint32_t)(rgroup - codestart));
     }
   }
 

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -5071,15 +5071,14 @@ switch(cmd)
     {
     while (isspace(*argptr)) argptr++;
     if (*argptr == 0) break;
-    for (i = 1; i < sizeof(newlines)/sizeof(char *); i++)
+    for (uint16_t j = 1; j < sizeof(newlines)/sizeof(char *); j++)
       {
-      size_t nlen = strlen(newlines[i]);
-      if (strncmpic(argptr, (const uint8_t *)newlines[i], nlen) == 0 &&
+      size_t nlen = strlen(newlines[j]);
+      if (strncmpic(argptr, (const uint8_t *)newlines[j], nlen) == 0 &&
           isspace(argptr[nlen]))
         {
-        if (i == NEWLINE_DEFAULT) return PR_OK;  /* Default is valid */
-        PCRE2_ASSERT(i <= UINT16_MAX);
-        if (first_listed_newline == 0) first_listed_newline = (uint16_t)i;
+        if (j == NEWLINE_DEFAULT) return PR_OK;  /* Default is valid */
+        if (first_listed_newline == 0) first_listed_newline = j;
         }
       }
     while (*argptr != 0 && !isspace(*argptr)) argptr++;


### PR DESCRIPTION
This job should at least ensure the library builds cleanly (although without JIT) and creates a DLL.

Its not as verbose as the original MSVC job (which has been renamed so it is clear it is 32bit) so that any warnings are clearly visible if building `pcre2grep`, `pcre2test` or JIT is enabled.