### PR TITLE
[Could cause OOB read in clients] Fix incorrect positive error code from pcre2_substitute()

### DIFF
--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -134,7 +134,9 @@ for (; ptr < ptrend; ptr++)
     ptr -= 1;  /* Back to last code unit of escape */
     if (errorcode != 0)
       {
-      rc = errorcode;
+      /* errorcode from check_escape is positive, so must not be returned by
+      pcre2_substitute(). */
+      rc = PCRE2_ERROR_BADREPESCAPE;
       goto EXIT;
       }
 

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4201,6 +4201,12 @@
     123abc123\=substitute_overflow_length,replace=[1]x$1z
     123abc123\=substitute_overflow_length,replace=[0]x$1z
 
+/a(b)c/substitute_extended
+    ZabcZ\=replace=>${1:+ yes : no }
+    ZabcZ\=replace=>${1:+ \o{100} : \o{100} }
+    ZabcZ\=replace=>${1:+ \o{Z} : no }
+    ZabcZ\=replace=>${1:+ yes : \o{Z} }
+
 "((?=(?(?=(?(?=(?(?=()))))))))"
     a
 

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13818,6 +13818,16 @@ Failed: error -48: no more memory: 10 code units are needed
     123abc123\=substitute_overflow_length,replace=[0]x$1z
 Failed: error -48: no more memory: 10 code units are needed
 
+/a(b)c/substitute_extended
+    ZabcZ\=replace=>${1:+ yes : no }
+ 1: Z> yes Z
+    ZabcZ\=replace=>${1:+ \o{100} : \o{100} }
+ 1: Z> @ Z
+    ZabcZ\=replace=>${1:+ \o{Z} : no }
+Failed: error -57 at offset 9 in replacement: bad escape sequence in replacement string
+    ZabcZ\=replace=>${1:+ yes : \o{Z} }
+Failed: error -57 at offset 15 in replacement: bad escape sequence in replacement string
+
 "((?=(?(?=(?(?=(?(?=()))))))))"
     a
  0: 


### PR DESCRIPTION
This has minor security implications.

`pcre2_substitute()` calls `check_escape()` which returns a _positive_ compile-error. Unfortunately, this is returned back to the `pcre2_substitute()` caller, which interprets a non-negative code as meaning "substitute succeeded".

This could cause the client to process the return string, assuming that it is null-terminated, and perform an out-of-bounds read.

Clients which use the `*blength` parameter to determine the length of the returned string are unaffected.

The `pcre2test` application was itself affected: it would print garbage memory because it relies on the null terminator when `pcre2_substitute()` returns non-negative.