### PR TITLE
Fix pcre2_substitute() to allow all named captures to be referenced

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -2574,6 +2574,9 @@ if (ptr >= ptrend)                 /* No characters in name */
 *nameptr = ptr;
 *offsetptr = (PCRE2_SIZE)(ptr - cb->start_pattern);
 
+/* If this logic were ever to change, the matching function in pcre2_substitute.c
+ought to be updated to match. */
+
 /* In UTF mode, a group name may contain letters and decimal digits as defined
 by Unicode properties, and underscores, but must not start with a digit. */
 

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -697,7 +697,7 @@ do
         if (!read_name(&ptr, repend, utf, code->tables + ctypes_offset))
           goto BAD;
         PCRE2_SIZE name_len = ptr - name_start;
-        memcpy(name, name_start, name_len);
+        memcpy(name, name_start, CU2BYTES(name_len));
         name[name_len] = 0;
         }
 

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -596,7 +596,7 @@ do
     {
     uint32_t ch;
     unsigned int chlen;
-    int group, n;
+    int group;
     uint32_t special;
     PCRE2_SPTR text1_start = NULL;
     PCRE2_SPTR text1_end = NULL;
@@ -645,7 +645,6 @@ do
       text2_start = NULL;
       text2_end = NULL;
       group = -1;
-      n = 0;
       inparens = FALSE;
       star = FALSE;
 

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -165,6 +165,86 @@ return rc;
 }
 
 
+/*************************************************
+*           Validate group name                  *
+*************************************************/
+
+/* This function scans for a capture group name, validating it
+consists of legal characters, is not empty, and does not exceed
+MAX_NAME_SIZE.
+
+Arguments:
+  ptrptr    points to the pointer to the start of the text (updated)
+  ptrend    end of the whole string
+  utf       true if the input is UTF-encoded
+  ctypes    pointer to the character types table
+
+Returns:    TRUE if a name was read
+            FALSE otherwise
+*/
+
+static BOOL
+read_name(PCRE2_SPTR *ptrptr, PCRE2_SPTR ptrend, BOOL utf,
+    const uint8_t* ctypes)
+{
+PCRE2_SPTR ptr = *ptrptr;
+PCRE2_SPTR nameptr = ptr;
+
+if (ptr >= ptrend)                 /* No characters in name */
+  goto FAILED;
+
+/* We do not need to check whether the name starts with a non-digit.
+We are simply referencing names here, not defining them. */
+
+/* See read_name in the pcre2_compile.c for the corresponding logic
+restricting group names inside the pattern itself. */
+
+#ifdef SUPPORT_UNICODE
+if (utf)
+  {
+  uint32_t c, type;
+
+  while (ptr < ptrend)
+    {
+    GETCHAR(c, ptr);
+    type = UCD_CHARTYPE(c);
+    if (type != ucp_Nd && PRIV(ucp_gentype)[type] != ucp_L &&
+        c != CHAR_UNDERSCORE) break;
+    ptr++;
+    FORWARDCHARTEST(ptr, ptrend);
+    }
+  }
+else
+#else
+(void)utf;  /* Avoid compiler warning */
+#endif      /* SUPPORT_UNICODE */
+
+/* Handle group names in non-UTF modes. */
+
+  {
+  while (ptr < ptrend && MAX_255(*ptr) && (ctypes[*ptr] & ctype_word) != 0)
+    {
+    ptr++;
+    }
+  }
+
+/* Check name length */
+
+if (ptr - nameptr > MAX_NAME_SIZE)
+  goto FAILED;
+
+/* Subpattern names must not be empty */
+if (ptr == nameptr)
+  goto FAILED;
+
+*ptrptr = ptr;
+return TRUE;
+
+FAILED:
+*ptrptr = ptr;
+return FALSE;
+}
+
 
 /*************************************************
 *              Match and substitute              *
@@ -554,7 +634,7 @@ do
       BOOL star;
       PCRE2_SIZE sublength;
       PCRE2_UCHAR next;
-      PCRE2_UCHAR name[33];
+      PCRE2_UCHAR name[MAX_NAME_SIZE + 1];
 
       if (++ptr >= repend) goto BAD;
       if ((next = *ptr) == CHAR_DOLLAR_SIGN) goto LOADLITERAL;
@@ -614,17 +694,15 @@ do
         }
       else
         {
-        const uint8_t *ctypes = code->tables + ctypes_offset;
-        while (MAX_255(next) && (ctypes[next] & ctype_word) != 0)
-          {
-          name[n++] = next;
-          if (n > 32) goto BAD;
-          if (++ptr >= repend) break;
-          next = *ptr;
-          }
-        if (n == 0) goto BAD;
-        name[n] = 0;
+        PCRE2_SPTR name_start = ptr;
+        if (!read_name(&ptr, repend, utf, code->tables + ctypes_offset))
+          goto BAD;
+        PCRE2_SIZE name_len = ptr - name_start;
+        memcpy(name, name_start, name_len);
+        name[name_len] = 0;
         }
+
+      next = 0; /* not used or updated after this point */
 
       /* In extended mode we recognize ${name:+set text:unset text} and
       ${name:-default text}. */
@@ -632,7 +710,7 @@ do
       if (inparens)
         {
         if ((suboptions & PCRE2_SUBSTITUTE_EXTENDED) != 0 &&
-             !star && ptr < repend - 2 && next == CHAR_COLON)
+             !star && ptr < repend - 2 && *ptr == CHAR_COLON)
           {
           special = *(++ptr);
           if (special != CHAR_PLUS && special != CHAR_MINUS)

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -316,8 +316,8 @@ BOOL escaped_literal = FALSE;
 BOOL overflowed = FALSE;
 BOOL use_existing_match;
 BOOL replacement_only;
-#ifdef SUPPORT_UNICODE
 BOOL utf = (code->overall_options & PCRE2_UTF) != 0;
+#ifdef SUPPORT_UNICODE
 BOOL ucp = (code->overall_options & PCRE2_UCP) != 0;
 #endif
 PCRE2_UCHAR temp[6];

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4696,6 +4696,12 @@ B)x/alt_verbnames,mark
 /a(b)(c)/substitute_extended,replace=>\3<
     abc
 
+/a(?<namED_1>b)c/substitute_extended
+    abc\=replace=>${namED_1}<
+
+/a(?<namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1>b)c/substitute_extended
+    abc\=replace=>${namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1}<
+
 /^(o(\1{72}{\"{\\{00000059079}\d*){74}}){19}/I
 
 /((p(?'K/

--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -2508,4 +2508,16 @@
 /abc/utf,substitute_extended,replace=>\777<
     abc
 
+/a(?<namED_1>b)c/utf,substitute_extended
+    abc\=replace=>${namED_1}<
+
+/a(?<namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1>b)c/utf,substitute_extended
+    abc\=replace=>${namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1}<
+
+/a(?<nämed>b)c/utf,substitute_extended
+    abc\=replace=>${nämed}<
+
+/a(?<nämedverylongbutperfectlylegalsoyoushouldnthaveaproblem_٢>b)c/utf,substitute_extended
+    abc\=replace=>${nämedverylongbutperfectlylegalsoyoushouldnthaveaproblem_٢}<
+
 # End of testinput5

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13696,7 +13696,7 @@ Failed: error -49 at offset 36 in replacement: unknown substring
 
 /abc/replace=a${A23456789012345678901234567890123}z
     123abc
-Failed: error -35 at offset 35 in replacement: invalid replacement string
+Failed: error -49 at offset 37 in replacement: unknown substring
 
 /abc/replace=a${bcd
     123abc
@@ -14972,6 +14972,14 @@ Failed: error -49 at offset 5 in replacement: unknown substring
 /a(b)(c)/substitute_extended,replace=>\3<
     abc
 Failed: error -49 at offset 3 in replacement: unknown substring
+
+/a(?<namED_1>b)c/substitute_extended
+    abc\=replace=>${namED_1}<
+ 1: >b<
+
+/a(?<namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1>b)c/substitute_extended
+    abc\=replace=>${namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1}<
+ 1: >b<
 
 /^(o(\1{72}{\"{\\{00000059079}\d*){74}}){19}/I
 Capture group count = 2

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -5482,4 +5482,20 @@ Failed: error 147 at offset 10: unknown property after \P or \p
     abc
  1: >\x{1ff}<
 
+/a(?<namED_1>b)c/utf,substitute_extended
+    abc\=replace=>${namED_1}<
+ 1: >b<
+
+/a(?<namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1>b)c/utf,substitute_extended
+    abc\=replace=>${namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1}<
+ 1: >b<
+
+/a(?<nämed>b)c/utf,substitute_extended
+    abc\=replace=>${nämed}<
+ 1: >b<
+
+/a(?<nämedverylongbutperfectlylegalsoyoushouldnthaveaproblem_٢>b)c/utf,substitute_extended
+    abc\=replace=>${nämedverylongbutperfectlylegalsoyoushouldnthaveaproblem_٢}<
+ 1: >b<
+
 # End of testinput5


### PR DESCRIPTION
* Capture group names can be up to 128 characters, but `pcre2_substitute()` was only allowing 32-character names
* With `/utf`, capture group names can contain non-ASCII characters, but `pcre2_substitute()` was allowing ASCII names only

The new function `read_name()` takes a silly number of lines of code given what it does, but I wanted it to match visually as closely as possible with the corresponding function in `pcre2_compile.c`.

Note that we don't allow SPACE and HT inside `${name}` replacements, even though Perl does. I have kept this unchanged. I have no opinion or desire to add more whitespace skipping.