### PR TITLE
Do not use __builtin_unreachable() in PCRE2_ASSERT()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,11 +192,6 @@ CHECK_C_SOURCE_COMPILES(
 )
 
 CHECK_C_SOURCE_COMPILES(
-  "int main(void) { if (__builtin_expect(1+1, 2)) return 1; return 0; }"
-  HAVE_BUILTIN_EXPECT
-)
-
-CHECK_C_SOURCE_COMPILES(
   "#include <stddef.h>
    int main(void) { int a,b; size_t m; __builtin_mul_overflow(a,b,&m); return 0; }"
   HAVE_BUILTIN_MUL_OVERFLOW

--- a/config-cmake.h.in
+++ b/config-cmake.h.in
@@ -2,11 +2,12 @@
 
 #cmakedefine HAVE_ASSERT_H 1
 #cmakedefine HAVE_BUILTIN_ASSUME 1
-#cmakedefine HAVE_BUILTIN_EXPECT 1
 #cmakedefine HAVE_BUILTIN_MUL_OVERFLOW 1
 #cmakedefine HAVE_BUILTIN_UNREACHABLE 1
 #cmakedefine HAVE_ATTRIBUTE_UNINITIALIZED 1
 #cmakedefine HAVE_DIRENT_H 1
+#cmakedefine HAVE_STDIO_H 1
+#cmakedefine HAVE_STDLIB_H 1
 #cmakedefine HAVE_SYS_STAT_H 1
 #cmakedefine HAVE_SYS_TYPES_H 1
 #cmakedefine HAVE_UNISTD_H 1

--- a/configure.ac
+++ b/configure.ac
@@ -107,20 +107,6 @@ if test "$pcre2_cc_cv_builtin_assume" = yes; then
 fi
 AC_LANG_POP([C])
 
-# Check for the expect() builtin
-
-AC_MSG_CHECKING([for __builtin_expect()])
-AC_LANG_PUSH([C])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[if (__builtin_expect(1+1, 2)) return 1]])],
-  [pcre2_cc_cv_builtin_expect=yes],
-  [pcre2_cc_cv_builtin_expect=no])
-AC_MSG_RESULT([$pcre2_cc_cv_builtin_expect])
-if test "$pcre2_cc_cv_builtin_expect" = yes; then
-  AC_DEFINE([HAVE_BUILTIN_EXPECT], 1,
-    [Define this if your compiler provides __builtin_expect()])
-fi
-AC_LANG_POP([C])
-
 # Check for the mul_overflow() builtin
 
 AC_MSG_CHECKING([for __builtin_mul_overflow()])

--- a/src/config.h.generic
+++ b/src/config.h.generic
@@ -64,9 +64,6 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define this if your compiler provides __assume() */
 /* #undef HAVE_BUILTIN_ASSUME */
 
-/* Define this if your compiler provides __builtin_expect() */
-/* #undef HAVE_BUILTIN_EXPECT */
-
 /* Define this if your compiler provides __builtin_mul_overflow() */
 /* #undef HAVE_BUILTIN_MUL_OVERFLOW */
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -64,9 +64,6 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define this if your compiler provides __assume() */
 #undef HAVE_BUILTIN_ASSUME
 
-/* Define this if your compiler provides __builtin_expect() */
-#undef HAVE_BUILTIN_EXPECT
-
 /* Define this if your compiler provides __builtin_mul_overflow() */
 #undef HAVE_BUILTIN_MUL_OVERFLOW
 

--- a/src/pcre2_util.h
+++ b/src/pcre2_util.h
@@ -52,9 +52,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef PCRE2_DEBUG
-#if defined(HAVE_BUILTIN_EXPECT) && defined(HAVE_BUILTIN_UNREACHABLE)
-#define PCRE2_ASSERT(x) do { if (__builtin_expect(!(x), 0)) __builtin_unreachable(); } while (0)
-#elif defined(HAVE_ASSERT_H)
+#if defined(HAVE_ASSERT_H) && !defined(NDEBUG)
 #include <assert.h>
 #define PCRE2_ASSERT(x) assert(x)
 #elif defined(HAVE_STDLIB_H) && defined(HAVE_STDIO_H)

--- a/vms/configure.com
+++ b/vms/configure.com
@@ -502,9 +502,6 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define to 1 if you have the 'bcopy' function. */
 #define HAVE_BCOPY 1
 
-/* Define this if your compiler provides __builtin_expect() */
-#undef HAVE_BUILTIN_EXPECT
-
 /* Define this if your compiler provides __builtin_mul_overflow() */
 #undef HAVE_BUILTIN_MUL_OVERFLOW
 


### PR DESCRIPTION
Simplify PCRE2_ASSERT() and while at it remove no longer needed dependency on __builtin_expect()

Fixes: #484