### PR TITLE
Implement pre-processed character range list caching

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -598,9 +598,13 @@ do.
 
 For classes containing characters with values greater than 255 or that contain
 \p or \P, OP_XCLASS is used. It optionally uses a bit map if any acceptable
-code points are less than 256, followed by a list of pairs (for a range) and/or
-single characters and/or properties. In caseless mode, all equivalent
-characters are explicitly listed.
+code points are less than 256. After the bit map, the properties of the
+character class are listed, if they are present. The items in the list
+follows the declaration order of the pattern string. The property list
+is followed by single characters and/or character ranges, if they are
+present. The characters/ranges are sorted in ascending order, and at
+least one non-matching character must be present between any two of
+them. In caseless mode, all equivalent characters are explicitly listed.
 
 OP_XCLASS is followed by a LINK_SIZE value containing the total length of the
 opcode and its data. This is followed by a code unit containing flag bits:

--- a/src/pcre2_compile.h
+++ b/src/pcre2_compile.h
@@ -175,8 +175,8 @@ therefore no need for it to have a length entry, so use a high value. */
 
 /* Merge intersecting ranges of classes. */
 
-uint32_t *PRIV(optimize_class)(uint32_t *start_ptr, uint32_t options,
-  size_t *buffer_size, compile_block* cb);
+class_ranges *PRIV(optimize_class)(uint32_t *start_ptr,
+  uint32_t options, compile_block* cb);
 
 #endif  /* PCRE2_COMPILE_H_IDEMPOTENT_GUARD */
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -723,6 +723,15 @@ typedef struct named_group {
   uint16_t     isdup;         /* TRUE if a duplicate */
 } named_group;
 
+/* Structure for caching sorted ranges. This improves the performance
+of translating META code to byte code. */
+
+typedef struct class_ranges {
+  struct class_ranges *next;  /* Next class ranges */
+  size_t range_list_size;     /* Size of ranges array */
+  /* Followed by the list of ranges (start/end pairs) */
+} class_ranges;
+
 /* Structure for passing "static" information around between the functions
 doing the compiling, so that they are thread-safe. */
 
@@ -767,6 +776,10 @@ typedef struct compile_block {
   BOOL had_pruneorskip;            /* (*PRUNE) or (*SKIP) encountered */
   BOOL had_recurse;                /* Had a pattern recursion or subroutine call */
   BOOL dupnames;                   /* Duplicate names exist */
+#ifdef SUPPORT_WIDE_CHARS
+  class_ranges* cranges;           /* First class range. */
+  class_ranges* next_cranges;      /* Next class range. */
+#endif
 } compile_block;
 
 /* Structure for keeping the properties of the in-memory stack used

--- a/src/pcre2_xclass.c
+++ b/src/pcre2_xclass.c
@@ -111,7 +111,10 @@ while ((t = *data++) != XCL_END)
     else
 #endif
     x = *data++;
-    if (c == x) return !negated;
+
+    /* Since character ranges follow the properties, and they are
+    sorted, early return is possible for all characters <= x. */
+    if (c <= x) return (c == x) ? !negated : negated;
     }
   else if (t == XCL_RANGE)
     {
@@ -127,7 +130,10 @@ while ((t = *data++) != XCL_END)
       x = *data++;
       y = *data++;
       }
-    if (c >= x && c <= y) return !negated;
+
+    /* Since character ranges follow the properties, and they are
+    sorted, early return is possible for all characters <= y. */
+    if (c <= y) return (c >= x) ? !negated : negated;
     }
 
 #ifdef SUPPORT_UNICODE

--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -2555,4 +2555,9 @@
     \x{2c63}\x{2c64}\x{2c65}\x{2c66}\x{2c67}
     \x{a7af}\x{a7b0}\x{a7b1}\x{a7b2}\x{a7b3}
 
+/[\x{100}-\x{400}\p{Ll}\x{500}-\x{700}\p{OldHungarian}\x{701}\p{bidiLRI}]/B,utf
+
+# Freeing memory on error test
+/[\x{100}-\x{400}][\x{100}-\x{300}][\x{100}-\x{200}]\8/i,utf
+
 # End of testinput5

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -5586,4 +5586,16 @@ Failed: error -57 at offset 4 in replacement: bad escape sequence in replacement
     \x{a7af}\x{a7b0}\x{a7b1}\x{a7b2}\x{a7b3}
  0: \x{a7b0}\x{a7b1}\x{a7b2}
 
+/[\x{100}-\x{400}\p{Ll}\x{500}-\x{700}\p{OldHungarian}\x{701}\p{bidiLRI}]/B,utf
+------------------------------------------------------------------
+        Bra
+        [\p{Ll}\p{Oldhungarian}\p{Bidilri}\x{100}-\x{400}\x{500}-\x{701}]
+        Ket
+        End
+------------------------------------------------------------------
+
+# Freeing memory on error test
+/[\x{100}-\x{400}][\x{100}-\x{300}][\x{100}-\x{200}]\8/i,utf
+Failed: error 115 at offset 52: reference to non-existent subpattern
+
 # End of testinput5


### PR DESCRIPTION
The new method for processing ranges allows some optimizations in the code, e.g. the xclass processing can return early. Furthermore, the data-set created for each range is cached, and during the second pass of byte code generation the cache is used.