### PR TITLE
Substitute: add support for $& $` $' $_ and \b \v

### DIFF
--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4803,6 +4803,15 @@ B)x/alt_verbnames,mark
 /a(?<namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1>b)c/substitute_extended
     abc\=replace=>${namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1}<
 
+/abc/substitute_extended
+    abc\=replace=\a\b\e\f\n\r\t\v\\
+
+/a(b)c/substitute_extended
+    LabcR\=replace=>$&<
+    LabcR\=replace=>$`<
+    LabcR\=replace=>$'<
+    LabcR\=replace=>$_<
+
 /^(o(\1{72}{\"{\\{00000059079}\d*){74}}){19}/I
 
 /((p(?'K/

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -15246,6 +15246,20 @@ Failed: error -49 at offset 3 in replacement: unknown substring
     abc\=replace=>${namedverylongbutperfectlylegalsoyoushouldnthaveaproblem_1}<
  1: >b<
 
+/abc/substitute_extended
+    abc\=replace=\a\b\e\f\n\r\t\v\\
+ 1: \x07\x08\x1b\x0c\x0a\x0d\x09\x0b\
+
+/a(b)c/substitute_extended
+    LabcR\=replace=>$&<
+ 1: L>abc<R
+    LabcR\=replace=>$`<
+ 1: L>L<R
+    LabcR\=replace=>$'<
+ 1: L>R<R
+    LabcR\=replace=>$_<
+ 1: L>LabcR<R
+
 /^(o(\1{72}{\"{\\{00000059079}\d*){74}}){19}/I
 Capture group count = 2
 Max back reference = 1


### PR DESCRIPTION
The `$&` replacement, and `` $` `` and `$'` are common sequences for `$0`, and "left of $0" / "right of $0" respectively. Perl supports these, so PCRE2 surely should.

The `$_` is less common but supported by some engines.

---

Finally, very very minor:

The `\b` escape is supported by Perl, so we should add it too.

The `\v` escape is there for completeness - it's not apparently supported by Perl, but many other dialects such as JavaScript or .NET use this C-inspired escape sequence for "vertical tab". It's obviously not possible to support this in patterns, but in the replacement string I can't see a reason not support it.