### PR TITLE
Reserve syntax for (unimplemented) extended character classes

### DIFF
--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -143,6 +143,7 @@ D   is inspected during pcre2_dfa_match() execution
 #define PCRE2_EXTENDED_MORE       0x01000000u  /* C       */
 #define PCRE2_LITERAL             0x02000000u  /* C       */
 #define PCRE2_MATCH_INVALID_UTF   0x04000000u  /*   J M D */
+#define PCRE2_EXTENDED_CLASS      0x08000000u  /* C       */
 
 /* An additional compile options word is available in the compile context. */
 
@@ -326,6 +327,7 @@ pcre2_pattern_convert(). */
 #define PCRE2_ERROR_MAX_VAR_LOOKBEHIND_EXCEEDED    200
 #define PCRE2_ERROR_PATTERN_COMPILED_SIZE_TOO_BIG  201
 #define PCRE2_ERROR_OVERSIZE_PYTHON_OCTAL          202
+#define PCRE2_ERROR_UNSUPPORTED_EXTENDED_CLASS     203 /* temporary code */
 
 
 /* "Expected" matching error codes: no match and partial match. */

--- a/src/pcre2_compile.h
+++ b/src/pcre2_compile.h
@@ -61,7 +61,7 @@ enum { ERR0 = COMPILE_ERROR_BASE,
        ERR71, ERR72, ERR73, ERR74, ERR75, ERR76, ERR77, ERR78, ERR79, ERR80,
        ERR81, ERR82, ERR83, ERR84, ERR85, ERR86, ERR87, ERR88, ERR89, ERR90,
        ERR91, ERR92, ERR93, ERR94, ERR95, ERR96, ERR97, ERR98, ERR99, ERR100,
-       ERR101,ERR102 };
+       ERR101,ERR102,ERR103 };
 
 /* Code values for parsed patterns, which are stored in a vector of 32-bit
 unsigned ints. Values less than META_END are literal data values. The coding

--- a/src/pcre2_error.c
+++ b/src/pcre2_error.c
@@ -191,6 +191,7 @@ static const unsigned char compile_error_texts[] =
   "branch too long in variable-length lookbehind assertion\0"
   "compiled pattern would be longer than the limit set by the application\0"
   "octal value given by \\ddd is greater than \\377 (forbidden by PCRE2_EXTRA_PYTHON_OCTAL)\0"
+  "unsupported extended character class\0"
   ;
 
 /* Match-time and UTF error texts are in the same format. */

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -698,6 +698,7 @@ static modstruct modlist[] = {
   { "escaped_cr_is_lf",            MOD_CTC,  MOD_OPT, PCRE2_EXTRA_ESCAPED_CR_IS_LF, CO(extra_options) },
   { "expand",                      MOD_PAT,  MOD_CTL, CTL_EXPAND,                 PO(control) },
   { "extended",                    MOD_PATP, MOD_OPT, PCRE2_EXTENDED,             PO(options) },
+  { "extended_class",              MOD_PAT,  MOD_OPT, PCRE2_EXTENDED_CLASS,       PO(options) },
   { "extended_more",               MOD_PATP, MOD_OPT, PCRE2_EXTENDED_MORE,        PO(options) },
   { "extra_alt_bsux",              MOD_CTC,  MOD_OPT, PCRE2_EXTRA_ALT_BSUX,       CO(extra_options) },
   { "find_limits",                 MOD_DAT,  MOD_CTL, CTL_FINDLIMITS,             DO(control) },

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -6621,4 +6621,26 @@ a)"xI
     abc\=replace=\1
     abc\=replace=\12
 
+/[[a]/
+    [
+    a
+
+/[[a]/extended_class
+
+/[!--a]/
+    !
+    "
+    a
+    -
+
+/[!--a]/extended_class
+
+/[a||a]/extended_class
+
+/[a&&a]/extended_class
+
+/[a~~a]/extended_class
+
+/[a-/extended_class
+
 # End of testinput2

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -19544,6 +19544,40 @@ Failed: error -49 at offset 2 in replacement: unknown substring
     abc\=replace=\12
 Failed: error -49 at offset 3 in replacement: unknown substring
 
+/[[a]/
+    [
+ 0: [
+    a
+ 0: a
+
+/[[a]/extended_class
+Failed: error 203 at offset 2: unsupported extended character class
+
+/[!--a]/
+    !
+ 0: !
+    "
+ 0: "
+    a
+ 0: a
+    -
+ 0: -
+
+/[!--a]/extended_class
+Failed: error 203 at offset 3: unsupported extended character class
+
+/[a||a]/extended_class
+Failed: error 203 at offset 3: unsupported extended character class
+
+/[a&&a]/extended_class
+Failed: error 203 at offset 3: unsupported extended character class
+
+/[a~~a]/extended_class
+Failed: error 203 at offset 3: unsupported extended character class
+
+/[a-/extended_class
+Failed: error 106 at offset 3: missing terminating ] for character class
+
 # End of testinput2
 Error -70: PCRE2_ERROR_BADDATA (unknown error number)
 Error -62: bad serialized data


### PR DESCRIPTION
I'm not expecting this to be merged - I'm guessing you don't want this code until the "extended classes" are actually implemented!

But this is a "for your information" PR. We will be shipping this diff in our product.

It is benign: if there is an unescaped '[' or '--', '&&' sequence inside a character class, then it rejects it. These are the new metacharacters in extended character classes. As you can see from the tests, this has backwards-compatibility implications, so even though we haven't implemented the feature yet, we'd like to "reserve" the syntax for future use in our application.

Do let me know if there's anything bad about this code though!

I'll be following up with the actual implementation in due course.