### PR TITLE
ci: add a full clang integer sanitizer DEV job

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./autogen.sh
 
       - name: Configure
-        run: ./configure CC='clang -fsanitize=undefined,address,integer -fno-sanitize-recover=undefined,integer -fno-sanitize=unsigned-integer-overflow' CPPFLAGS='-Wall -Wextra -Werror -Wno-error=unused-but-set-parameter -Wno-error=deprecated-declarations -Wno-error=incompatible-library-redeclaration -Wno-error=incompatible-pointer-types-discards-qualifiers' --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --with-link-size=3
+        run: ./configure CC='clang -fsanitize=undefined,address,integer -fno-sanitize-recover=undefined,integer -fno-sanitize=unsigned-integer-overflow,function' CPPFLAGS='-Wall -Wextra -Werror -Wno-error=unused-but-set-parameter -Wno-error=deprecated-declarations -Wno-error=incompatible-library-redeclaration -Wno-error=incompatible-pointer-types-discards-qualifiers' --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --with-link-size=3
 
       - name: Build
         run: make -j3
@@ -60,6 +60,36 @@ jobs:
 
       - name: Test (JIT test program)
         run: ./pcre2_jit_test
+
+      - name: Test (pcre2grep test script)
+        run: ./RunGrepTest
+
+      - name: Test (pcre2posix program)
+        run: ./pcre2posix_test -v
+
+  wasp:
+    name: No JIT
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Prepare
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install language-pack-fr
+          ./autogen.sh
+
+      - name: Configure
+        run: ./configure CC='clang -fsanitize=undefined,address,integer -fno-sanitize-recover=undefined,integer -fno-sanitize=function' --enable-pcre2-16 --enable-pcre2-32 --enable-debug
+
+      - name: Build
+        run: make CPPFLAGS='-pedantic -Wall -Wextra -Wpedantic -Wdeclaration-after-statement -Wshadow -Wno-overlength-strings -Werror -Wno-error=incompatible-pointer-types-discards-qualifiers' -j3
+
+      - name: Test (main test script)
+        run: ./RunTest
 
       - name: Test (pcre2grep test script)
         run: ./RunGrepTest

--- a/maint/README
+++ b/maint/README
@@ -160,7 +160,9 @@ new release.
   -fsanitize=undefined -std=gnu99 picks up undefined behaviour at runtime. For
   clang, -fsanitize=address,undefined,integer can be used but
   -fno-sanitize=unsigned-integer-overflow must be added when compiling with
-  JIT. Another useful clang option is -fsanitize=signed-integer-overflow
+  JIT. Newer versions of the compiler also need -fno-sanitize=function, at
+  least until pcre2test stops using generic pointers on its callbacks. Another
+  useful clang option is -fsanitize=signed-integer-overflow.
 
 . Do a test build using CMake. Remove src/config.h first, lest it override the
   version that CMake creates. Also ensure there is no leftover CMakeCache.txt

--- a/maint/utf8.c
+++ b/maint/utf8.c
@@ -271,7 +271,7 @@ for (; i < argc; i++)
         len = -1;
         break;
         }
-      y = y * 16 + tolower(*x) - ((isdigit(*x))? '0' : 'W');
+      y = y * 16 + (tolower(*x) - ((isdigit(*x))? '0' : 'W'));
       x++;
       if (z)
         {

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -1258,7 +1258,7 @@ if (allow_sign >= 0 && ptr < ptrend)
 if (ptr >= ptrend || !IS_DIGIT(*ptr)) return FALSE;
 while (ptr < ptrend && IS_DIGIT(*ptr))
   {
-  n = n * 10 + *ptr++ - CHAR_0;
+  n = n * 10 + (*ptr++ - CHAR_0);
   if (n > max_value)
     {
     *errorcodeptr = max_error;
@@ -4662,7 +4662,7 @@ while (ptr < ptrend)
         parsed_pattern += 3;                       /* Skip pattern info */
         while (ptr < ptrend && IS_DIGIT(*ptr))
           {
-          n = n * 10 + *ptr++ - CHAR_0;
+          n = n * 10 + (*ptr++ - CHAR_0);
           if (n > 255)
             {
             errorcode = ERR38;
@@ -6702,7 +6702,7 @@ for (;; pptr++)
           {
           for (i = 1; i < length; i++)
             {
-            groupnumber = groupnumber * 10 + name[i] - CHAR_0;
+            groupnumber = groupnumber * 10 + (name[i] - CHAR_0);
             if (groupnumber > MAX_GROUP_NUMBER)
               {
               *errorcodeptr = ERR61;

--- a/src/pcre2_fuzzsupport.c
+++ b/src/pcre2_fuzzsupport.c
@@ -373,7 +373,7 @@ if (size > 3)
           j--;               /* Ensure this character is checked next. The */
           goto OUTERLOOP;    /* string might be (e.g.) "){9){234}" */
           }
-        q = q * 10 + wdata[j] - '0';
+        q = q * 10 + (wdata[j] - '0');
         }
 
       if (j >= size) goto END_QSCAN;  /* End of data */

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -5937,8 +5937,11 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
 #ifdef SUPPORT_UNICODE
     if (utf)
       {
-      while (number-- > 0)
+      /* We used to do a simpler `while (number-- > 0)` but that triggers
+      clang's unsigned integer overflow sanitizer. */
+      while (number > 0)
         {
+        --number;
         if (Feptr <= mb->check_subject) RRETURN(MATCH_NOMATCH);
         Feptr--;
         BACKCHAR(Feptr);
@@ -6870,9 +6873,6 @@ if (use_jit)
 #ifdef SUPPORT_UNICODE
   if (utf && (options & PCRE2_NO_UTF_CHECK) == 0 && !allow_invalid)
     {
-#if PCRE2_CODE_UNIT_WIDTH != 32
-    unsigned int i;
-#endif
 
     /* For 8-bit and 16-bit UTF, check that the first code unit is a valid
     character start. */
@@ -6893,7 +6893,7 @@ if (use_jit)
     start of matching. */
 
 #if PCRE2_CODE_UNIT_WIDTH != 32
-    for (i = re->max_lookbehind; i > 0 && start_match > subject; i--)
+    for (unsigned int i = re->max_lookbehind; i > 0 && start_match > subject; i--)
       {
       start_match--;
       while (start_match > subject &&

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -731,7 +731,7 @@ do
           {
           next = *ptr;
           if (next < CHAR_0 || next > CHAR_9) break;
-          group = group * 10 + next - CHAR_0;
+          group = group * 10 + (next - CHAR_0);
 
           /* A check for a number greater than the hightest captured group
           is sufficient here; no need for a separate overflow check. If unknown

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -7153,7 +7153,7 @@ while ((c = *p++) != 0)
     case '4': case '5': case '6': case '7':
     c -= '0';
     while (i++ < 2 && isdigit(*p) && *p != '8' && *p != '9')
-      c = c * 8 + *p++ - '0';
+      c = c * 8 + (*p++ - '0');
     break;
 
     case 'o':
@@ -7166,7 +7166,7 @@ while ((c = *p++) != 0)
         if (++i == 12)
           fprintf(outfile, "** Too many octal digits in \\o{...} item; "
                            "using only the first twelve.\n");
-        else c = c * 8 + *pt - '0';
+        else c = c * 8 + (*pt - '0');
         }
       if (*pt == '}') p = pt + 1;
         else fprintf(outfile, "** Missing } after \\o{ (assumed)\n");
@@ -7182,14 +7182,14 @@ while ((c = *p++) != 0)
       /* We used to have "while (isxdigit(*(++pt)))" here, but it fails
       when isxdigit() is a macro that refers to its argument more than
       once. This is banned by the C Standard, but apparently happens in at
-      least one MacOS environment. */
+      least one macOS environment. */
 
       for (pt++; isxdigit(*pt); pt++)
         {
         if (++i == 9)
           fprintf(outfile, "** Too many hex digits in \\x{...} item; "
                            "using only the first eight.\n");
-        else c = c * 16 + tolower(*pt) - ((isdigit(*pt))? '0' : 'a' - 10);
+        else c = c * 16 + (tolower(*pt) - ((isdigit(*pt))? '0' : 'a' - 10));
         }
       if (*pt == '}')
         {
@@ -7207,7 +7207,7 @@ while ((c = *p++) != 0)
     c = 0;
     while (i++ < 2 && isxdigit(*p))
       {
-      c = c * 16 + tolower(*p) - ((isdigit(*p))? '0' : 'a' - 10);
+      c = c * 16 + (tolower(*p) - ((isdigit(*p))? '0' : 'a' - 10));
       p++;
       }
 #if defined SUPPORT_PCRE2_8
@@ -7697,7 +7697,7 @@ if (dat_datctl.replacement[0] != 0)
   if (*pr == '[')
     {
     PCRE2_SIZE n = 0;
-    while ((c = *(++pr)) >= CHAR_0 && c <= CHAR_9) n = n * 10 + c - CHAR_0;
+    while ((c = *(++pr)) >= CHAR_0 && c <= CHAR_9) n = n * 10 + (c - CHAR_0);
     if (*pr++ != ']')
       {
       fprintf(outfile, "Bad buffer size in replacement string\n");


### PR DESCRIPTION
Make sure that no undesired integer wraparounds happen in the code, and that it is clear from other common issues.

It includes a "fix" in `pcre2_match.c` that could be handled better by the sanitizer and could be considered
a "false positive", and that future versions of the compiler would be able to avoid by using (the yet not released) `-fsanitize-undefined-ignore-overflow-pattern=unsigned-post-decr-while` option.