### PR TITLE
Fix handling of \g<0> in pcre2_substitute

### DIFF
--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -1077,7 +1077,7 @@ do
         if (rc < 0)
           {
           special = 0;
-          group = -rc;
+          group = -rc - 1;
           goto GROUP_SUBSTITUTE;
           }
         goto BADESCAPE;

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4234,6 +4234,8 @@
     ZabcZ\=replace=>$< 1 ><
     ZabcZ\=replace=>$<2><
     ZabcZ\=replace=>$<8><
+    ZabcZ\=replace=>\g<-1><
+    ZabcZ\=replace=>\g<0><
     ZabcZ\=replace=>\g<1><
     ZabcZ\=replace=>\g< 1 ><
     ZabcZ\=replace=>\g<2><

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13907,6 +13907,10 @@ Failed: error -35 at offset 3 in replacement: invalid replacement string
 Failed: error -49 at offset 5 in replacement: unknown substring
     ZabcZ\=replace=>$<8><
 Failed: error -49 at offset 5 in replacement: unknown substring
+    ZabcZ\=replace=>\g<-1><
+Failed: error -57 at offset 4 in replacement: bad escape sequence in replacement string
+    ZabcZ\=replace=>\g<0><
+ 1: Z>abc<Z
     ZabcZ\=replace=>\g<1><
  1: Z>b<Z
     ZabcZ\=replace=>\g< 1 ><


### PR DESCRIPTION
I made a mess-up, and didn't notice because I foolishly didn't add a test for this case.

The `check_escape()` function returns a negative value for backreferences, which is fine for backrefs in a pattern, because they can't be zero. But the special `\g<...>` handling I added to `pcre2_substitute()` does need to support a zero backref.

I hummed and haa'd about the right way to do it. The `read_number()` helper isn't even exported for `pcre2_substitute.c` to use, and it feels like this is the responsibility of `check_escape()`.

In the end, I've just offset the values by 1, and checked all four callsites of `check_escape()` to make sure they are all updated to cope with that.