### PR TITLE
Fix two small issues with substitution nulls

### DIFF
--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -514,8 +514,9 @@ do
 
     save_start = start_offset++;
     if (subject[start_offset-1] == CHAR_CR &&
-        code->newline_convention != PCRE2_NEWLINE_CR &&
-        code->newline_convention != PCRE2_NEWLINE_LF &&
+        (code->newline_convention == PCRE2_NEWLINE_CRLF ||
+         code->newline_convention == PCRE2_NEWLINE_ANY ||
+         code->newline_convention == PCRE2_NEWLINE_ANYCRLF) &&
         start_offset < length &&
         subject[start_offset] == CHAR_LF)
       start_offset++;
@@ -824,10 +825,10 @@ do
           PCRE2_SPTR mark = pcre2_get_mark(match_data);
           if (mark != NULL)
             {
-            PCRE2_SPTR mark_start = mark;
-            while (*mark != 0) mark++;
-            fraglength = mark - mark_start;
-            CHECKMEMCPY(mark_start, fraglength);
+            /* Peek backwards one code unit to obtain the length of the mark.
+            It can (theoretically) contain an embedded NUL. */
+            fraglength = mark[-1];
+            CHECKMEMCPY(mark, fraglength);
             }
           }
         else goto BAD;

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4208,6 +4208,9 @@
 /(*:pear)apple|(*:orange)lemon|(*:strawberry)blackberry/g,replace=[23]${*MARK}
     apple lemon blackberry
 
+/"(*:fruit" 00 "juice)apple"/hex,g,replace=${*MARK}
+    apple lemon blackberry
+
 /abc/
     123abc123\=replace=[9]XYZ
     123abc123\=substitute_overflow_length,replace=[9]XYZ

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13860,6 +13860,10 @@ Failed: error -48: no more memory: 23 code units are needed
     apple lemon blackberry
  3: pear orange strawberry
 
+/"(*:fruit" 00 "juice)apple"/hex,g,replace=${*MARK}
+    apple lemon blackberry
+ 1: fruit\x00juice lemon blackberry
+
 /abc/
     123abc123\=replace=[9]XYZ
 Failed: error -48: no more memory


### PR DESCRIPTION
* `pcre2_substitute()` is not following the documentation's recommended practice for handling MARK names with embedded NULs.
* The CRLF-handling code assumes that, if newline_convention is not CR or LF, then CRLF is a valid newline. Presumably, this was true once upon a time, but now PCRE2_NEWLINE_NUL has been added. Corrected this minuscule error.