### PR TITLE
Add PCRE2_EXTRA_NEVER_CALLOUT flag to pcre2.h.generic

### DIFF
--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -161,6 +161,7 @@ D   is inspected during pcre2_dfa_match() execution
 #define PCRE2_EXTRA_ASCII_DIGIT              0x00001000u  /* C */
 #define PCRE2_EXTRA_PYTHON_OCTAL             0x00002000u  /* C */
 #define PCRE2_EXTRA_NO_BS0                   0x00004000u  /* C */
+#define PCRE2_EXTRA_NEVER_CALLOUT            0x00008000u  /* C */
 
 /* These are for pcre2_jit_compile(). */
 


### PR DESCRIPTION
Hi everyone,

I noticed that the `PCRE2_EXTRA_NEVER_CALLOUT` flag is missing from pcre2.h.generic. This omission causes errors when using the latest master branch (currently https://github.com/PCRE2Project/pcre2/commit/8c84b4ba5865c1b46313c5cf6325dd28ffc3888a) in my Zig project. Here are the errors I encountered:

```
error: use of undeclared identifier 'PCRE2_EXTRA_NEVER_CALLOUT'
      if ((xoptions & PCRE2_EXTRA_NEVER_CALLOUT) != 0)
                      ^
error: use of undeclared identifier 'PCRE2_EXTRA_NEVER_CALLOUT'
    (ccontext->extra_options & ~PUBLIC_COMPILE_EXTRA_OPTIONS) != 0)
                                ^
note: expanded from macro 'PUBLIC_COMPILE_EXTRA_OPTIONS'
    PCRE2_EXTRA_NEVER_CALLOUT)
```

After adding `PCRE2_EXTRA_NEVER_CALLOUT` (copy from pcre2.h.in) to pcre2.h.generic, these errors were resolved.

Does this look good to you? Feel free to let me know if you need any further adjustments!