### PR TITLE
Add substitute case callout function

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,7 @@ dist_html_DATA = \
   doc/html/pcre2_set_recursion_limit.html \
   doc/html/pcre2_set_recursion_memory_management.html \
   doc/html/pcre2_set_substitute_callout.html \
+  doc/html/pcre2_set_substitute_case_callout.html \
   doc/html/pcre2_substitute.html \
   doc/html/pcre2_substring_copy_byname.html \
   doc/html/pcre2_substring_copy_bynumber.html \
@@ -190,6 +191,7 @@ dist_man_MANS = \
   doc/pcre2_set_recursion_limit.3 \
   doc/pcre2_set_recursion_memory_management.3 \
   doc/pcre2_set_substitute_callout.3 \
+  doc/pcre2_set_substitute_case_callout.3 \
   doc/pcre2_substitute.3 \
   doc/pcre2_substring_copy_byname.3 \
   doc/pcre2_substring_copy_bynumber.3 \

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -279,6 +279,12 @@ in the library.
 <tr><td><a href="pcre2_set_recursion_memory_management.html">pcre2_set_recursion_memory_management</a></td>
     <td>&nbsp;&nbsp;Obsolete function that (from 10.30 onwards) does nothing</td></tr>
 
+<tr><td><a href="pcre2_set_substitute_callout.html">pcre2_set_substitute_callout</a></td>
+    <td>&nbsp;&nbsp;Set a substitution callout function</td></tr>
+
+<tr><td><a href="pcre2_set_substitute_case_callout.html">pcre2_set_substitute_case_callout</a></td>
+    <td>&nbsp;&nbsp;Set a substitution case callout function</td></tr>
+
 <tr><td><a href="pcre2_substitute.html">pcre2_substitute</a></td>
     <td>&nbsp;&nbsp;Match a compiled pattern to a subject string and do
     substitutions</td></tr>

--- a/doc/html/pcre2_set_substitute_case_callout.html
+++ b/doc/html/pcre2_set_substitute_case_callout.html
@@ -1,9 +1,9 @@
 <html>
 <head>
-<title>pcre2_set_substitute_callout specification</title>
+<title>pcre2_set_substitute_case_callout specification</title>
 </head>
 <body bgcolor="#FFFFFF" text="#00005A" link="#0066FF" alink="#3399FF" vlink="#2222BB">
-<h1>pcre2_set_substitute_callout man page</h1>
+<h1>pcre2_set_substitute_case_callout man page</h1>
 <p>
 Return to the <a href="index.html">PCRE2 index page</a>.
 </p>
@@ -19,16 +19,16 @@ SYNOPSIS
 <b>#include &#60;pcre2.h&#62;</b>
 </P>
 <P>
-<b>int pcre2_set_substitute_callout(pcre2_match_context *<i>mcontext</i>,</b>
-<b>  int (*<i>callout_function</i>)(pcre2_substitute_callout_block *, void *),</b>
+<b>int pcre2_set_substitute_case_callout(pcre2_match_context *<i>mcontext</i>,</b>
+<b>  uint32_t (*<i>callout_function</i>)(uint32_t, int, void *),</b>
 <b>  void *<i>callout_data</i>);</b>
 </P>
 <br><b>
 DESCRIPTION
 </b><br>
 <P>
-This function sets the substitute callout fields in a match context (the first
-argument). The second argument specifies a callout function, and the third
+This function sets the substitute case callout fields in a match context (the
+first argument). The second argument specifies a callout function, and the third
 argument is an opaque data item that is passed to it. The result of this
 function is always zero.
 </P>

--- a/doc/html/pcre2api.html
+++ b/doc/html/pcre2api.html
@@ -207,6 +207,11 @@ document for an overview of all the PCRE2 documentation.
 <b>  void *<i>callout_data</i>);</b>
 <br>
 <br>
+<b>int pcre2_set_substitute_case_callout(pcre2_match_context *<i>mcontext</i>,</b>
+<b>  uint32_t (*<i>callout_function</i>)(uint32_t, int, void *),</b>
+<b>  void *<i>callout_data</i>);</b>
+<br>
+<br>
 <b>int pcre2_set_offset_limit(pcre2_match_context *<i>mcontext</i>,</b>
 <b>  PCRE2_SIZE <i>value</i>);</b>
 <br>
@@ -1117,6 +1122,17 @@ documentation.
 This sets up a callout function for PCRE2 to call after each substitution
 made by <b>pcre2_substitute()</b>. Details are given in the section entitled
 "Creating a new string with substitutions"
+<a href="#substitutions">below.</a>
+<br>
+<br>
+<b>int pcre2_set_substitute_case_callout(pcre2_match_context *<i>mcontext</i>,</b>
+<b>  uint32_t (*<i>callout_function</i>)(uint32_t, int, void *),</b>
+<b>  void *<i>callout_data</i>);</b>
+<br>
+<br>
+This sets up a callout function for PCRE2 to call when performing case
+transformations inside <b>pcre2_substitute()</b>. Details are given in the
+section entitled "Creating a new string with substitutions"
 <a href="#substitutions">below.</a>
 <br>
 <br>
@@ -4039,6 +4055,58 @@ PCRE2_SUBSTITUTE_GLOBAL is set. Otherwise (the value is less than zero or
 PCRE2_SUBSTITUTE_GLOBAL is not set), the rest of the input is copied to the
 output and the call to <b>pcre2_substitute()</b> exits, returning the number of
 matches so far.
+</P>
+<br><b>
+Substitution case callouts
+</b><br>
+<P>
+<b>int pcre2_set_substitute_case_callout(pcre2_match_context *<i>mcontext</i>,</b>
+<b>  uint32_t (*<i>callout_function</i>)(uint32_t, int, void *),</b>
+<b>  void *<i>callout_data</i>);</b>
+<br>
+<br>
+The <b>pcre2_set_substitution_case_callout()</b> function can be used to specify
+a callout function for <b>pcre2_substitute()</b> to use when performing case
+transformations. This does not affect any case insensitivity behaviour when
+performing a match, but only the user-visible transformations performed when
+processing a substitution such as:
+<pre>
+    pcre2_substitute(..., "\\U$1")
+</PRE>
+</P>
+<P>
+The default case transformations applied by PCRE2 are reasonably complete, and
+perform the basic locale-invariant case transformations as specified by
+Unicode. This is suitable for the internal (invisible) case-equivalence
+procedures used during pattern matching, but an application may wish to use
+more sophisticated locale-aware processing for the user-visible substitution
+transformations.
+</P>
+<P>
+One example implementation of the <i>callout_function</i> using the ICU
+library would be:
+<pre>
+    static uint32_t icu_case_callout(uint32_t ch, int to, void *)
+    {
+      return to == PCRE2_SUBSTITUTE_CASE_LOWER ? u_tolower(ch)
+           : to == PCRE2_SUBSTITUTE_CASE_UPPER ? u_toupper(ch)
+           : to == PCRE2_SUBSTITUTE_CASE_TITLE ? u_totitle(ch)
+           : ch;
+    }
+</PRE>
+</P>
+<P>
+The first argument of the case callout function is the Unicode character to
+transform.
+</P>
+<P>
+The second argument is one of the constants PCRE2_SUBSTITUTE_CASE_LOWER,
+PCRE2_SUBSTITUTE_CASE_UPPER, or PCRE2_SUBSTITUTE_CASE_TITLE.
+</P>
+<P>
+The third argument is the <i>callout_data</i> supplied to
+<b>pcre2_set_substitute_case_callout()</b>, and the return value is the
+transformed Unicode character, which may be equal to the input character.
 </P>
 <br><a name="SEC38" href="#TOC1">DUPLICATE CAPTURE GROUP NAMES</a><br>
 <P>

--- a/doc/html/pcre2compat.html
+++ b/doc/html/pcre2compat.html
@@ -266,7 +266,7 @@ handled by PCRE2, either by the interpreter or the JIT. An example is
 <P>
 23. From release 10.45, PCRE2 gives an error if \x is not followed by a 
 hexadecimal digit or a curly bracket. It used to interpret this as the NUL 
-character. Perl still generates NUL, but warns in its warning and strict modes.
+character. Perl still generates NUL, but warns in its warning mode.
 </P>
 <br><b>
 AUTHOR

--- a/doc/html/pcre2pattern.html
+++ b/doc/html/pcre2pattern.html
@@ -452,7 +452,7 @@ By default, after \x that is not followed by {, one or two hexadecimal
 digits are read (letters can be in upper or lower case). If the character that
 follows \x is neither { nor a hexadecimal digit, an error occurs. This is
 different from Perl's default behaviour, which generates a NUL character, but
-is in line with Perl's "strict" behaviour.
+is in line with the behaviour of Perl's 'strict' mode in re.
 </P>
 <P>
 Any number of hexadecimal digits may appear between \x{ and }. If a character

--- a/doc/html/pcre2test.html
+++ b/doc/html/pcre2test.html
@@ -1158,6 +1158,7 @@ process.
       replace=&#60;string&#62;            specify a replacement string
       startchar                   show starting character when relevant
       substitute_callout          use substitution callouts
+      substitute_case_callout=&#60;string&#62; use substitution case callouts
       substitute_extended         use PCRE2_SUBSTITUTE_EXTENDED
       substitute_literal          use PCRE2_SUBSTITUTE_LITERAL
       substitute_matched          use PCRE2_SUBSTITUTE_MATCHED
@@ -1336,6 +1337,7 @@ pattern, but can be overridden by modifiers on the subject.
       startchar                  show startchar when relevant
       startoffset=&#60;n&#62;            same as offset=&#60;n&#62;
       substitute_callout         use substitution callouts
+      substitute_case_callout=&#60;string&#62; use substitution case callouts
       substitute_extedded        use PCRE2_SUBSTITUTE_EXTENDED
       substitute_literal         use PCRE2_SUBSTITUTE_LITERAL
       substitute_matched         use PCRE2_SUBSTITUTE_MATCHED
@@ -1620,6 +1622,27 @@ either of them are set, <b>substitute_callout</b> is assumed. For example:
 </pre>
 If both are set for the same number, stop takes precedence. Only a single skip
 or stop is supported, which is sufficient for testing that the feature works.
+</P>
+<br><b>
+Testing substitute case callouts
+</b><br>
+<P>
+If the <b>substitute_case_callout=&#60;string&#62;</b> modifier is set, a substitution
+case callout function is set up. The callout function is called for each
+substituted character which is to be case-transformed, and the mapping used
+is specified by the modifier's string argument.
+</P>
+<P>
+The string argument is parsed as four-character blocks, with each block
+interpreted as "&#60;input&#62;&#60;lower&#62;&#60;upper&#62;&#60;title&#62;". The input character is used
+to find a matching block, and the corresponding character is then returned.
+For example, to specify a custom uppercasing of the letter "a" to "Z":
+<pre>
+  /a/g,replace=\U$0,substitute_extended,substitute_case_callout=a.Z.
+      a
+   1: Z
+
+</PRE>
 </P>
 <br><b>
 Setting the JIT stack size

--- a/doc/index.html.src
+++ b/doc/index.html.src
@@ -279,6 +279,12 @@ in the library.
 <tr><td><a href="pcre2_set_recursion_memory_management.html">pcre2_set_recursion_memory_management</a></td>
     <td>&nbsp;&nbsp;Obsolete function that (from 10.30 onwards) does nothing</td></tr>
 
+<tr><td><a href="pcre2_set_substitute_callout.html">pcre2_set_substitute_callout</a></td>
+    <td>&nbsp;&nbsp;Set a substitution callout function</td></tr>
+
+<tr><td><a href="pcre2_set_substitute_case_callout.html">pcre2_set_substitute_case_callout</a></td>
+    <td>&nbsp;&nbsp;Set a substitution case callout function</td></tr>
+
 <tr><td><a href="pcre2_substitute.html">pcre2_substitute</a></td>
     <td>&nbsp;&nbsp;Match a compiled pattern to a subject string and do
     substitutions</td></tr>

--- a/doc/pcre2_set_substitute_case_callout.3
+++ b/doc/pcre2_set_substitute_case_callout.3
@@ -1,4 +1,4 @@
-.TH PCRE2_SET_SUBSTITUTE_CALLOUT 3 "12 November 2018" "PCRE2 10.33"
+.TH PCRE2_SET_SUBSTITUTE_CASE_CALLOUT 3 "4 October 2024" "PCRE2 10.33"
 .SH NAME
 PCRE2 - Perl-compatible regular expressions (revised API)
 .SH SYNOPSIS
@@ -7,16 +7,16 @@ PCRE2 - Perl-compatible regular expressions (revised API)
 .B #include <pcre2.h>
 .PP
 .nf
-.B int pcre2_set_substitute_callout(pcre2_match_context *\fImcontext\fP,
-.B "  int (*\fIcallout_function\fP)(pcre2_substitute_callout_block *, void *),"
+.B int pcre2_set_substitute_case_callout(pcre2_match_context *\fImcontext\fP,
+.B "  uint32_t (*\fIcallout_function\fP)(uint32_t, int, void *),"
 .B "  void *\fIcallout_data\fP);"
 .fi
 .
 .SH DESCRIPTION
 .rs
 .sp
-This function sets the substitute callout fields in a match context (the first
-argument). The second argument specifies a callout function, and the third
+This function sets the substitute case callout fields in a match context (the
+first argument). The second argument specifies a callout function, and the third
 argument is an opaque data item that is passed to it. The result of this
 function is always zero.
 .P

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -141,6 +141,10 @@ document for an overview of all the PCRE2 documentation.
 .B "  int (*\fIcallout_function\fP)(pcre2_substitute_callout_block *, void *),"
 .B "  void *\fIcallout_data\fP);"
 .sp
+.B int pcre2_set_substitute_case_callout(pcre2_match_context *\fImcontext\fP,
+.B "  uint32_t (*\fIcallout_function\fP)(uint32_t, int, void *),"
+.B "  void *\fIcallout_data\fP);"
+.sp
 .B int pcre2_set_offset_limit(pcre2_match_context *\fImcontext\fP,
 .B "  PCRE2_SIZE \fIvalue\fP);"
 .sp
@@ -1040,6 +1044,20 @@ documentation.
 This sets up a callout function for PCRE2 to call after each substitution
 made by \fBpcre2_substitute()\fP. Details are given in the section entitled
 "Creating a new string with substitutions"
+.\" HTML <a href="#substitutions">
+.\" </a>
+below.
+.\"
+.sp
+.nf
+.B int pcre2_set_substitute_case_callout(pcre2_match_context *\fImcontext\fP,
+.B "  uint32_t (*\fIcallout_function\fP)(uint32_t, int, void *),"
+.B "  void *\fIcallout_data\fP);"
+.fi
+.sp
+This sets up a callout function for PCRE2 to call when performing case
+transformations inside \fBpcre2_substitute()\fP. Details are given in the
+section entitled "Creating a new string with substitutions"
 .\" HTML <a href="#substitutions">
 .\" </a>
 below.
@@ -4020,6 +4038,52 @@ PCRE2_SUBSTITUTE_GLOBAL is set. Otherwise (the value is less than zero or
 PCRE2_SUBSTITUTE_GLOBAL is not set), the rest of the input is copied to the
 output and the call to \fBpcre2_substitute()\fP exits, returning the number of
 matches so far.
+.
+.
+.SS "Substitution case callouts"
+.rs
+.sp
+.nf
+.B int pcre2_set_substitute_case_callout(pcre2_match_context *\fImcontext\fP,
+.B "  uint32_t (*\fIcallout_function\fP)(uint32_t, int, void *),"
+.B "  void *\fIcallout_data\fP);"
+.fi
+.sp
+The \fBpcre2_set_substitution_case_callout()\fP function can be used to specify
+a callout function for \fBpcre2_substitute()\fP to use when performing case
+transformations. This does not affect any case insensitivity behaviour when
+performing a match, but only the user-visible transformations performed when
+processing a substitution such as:
+.sp
+    pcre2_substitute(..., "\e\eU$1")
+.P
+The default case transformations applied by PCRE2 are reasonably complete, and
+perform the basic locale-invariant case transformations as specified by
+Unicode. This is suitable for the internal (invisible) case-equivalence
+procedures used during pattern matching, but an application may wish to use
+more sophisticated locale-aware processing for the user-visible substitution
+transformations.
+.P
+One example implementation of the \fIcallout_function\fP using the ICU
+library would be:
+.sp
+    static uint32_t icu_case_callout(uint32_t ch, int to, void *)
+    {
+      return to == PCRE2_SUBSTITUTE_CASE_LOWER ? u_tolower(ch)
+           : to == PCRE2_SUBSTITUTE_CASE_UPPER ? u_toupper(ch)
+           : to == PCRE2_SUBSTITUTE_CASE_TITLE ? u_totitle(ch)
+           : ch;
+    }
+.P
+The first argument of the case callout function is the Unicode character to
+transform.
+.P
+The second argument is one of the constants PCRE2_SUBSTITUTE_CASE_LOWER,
+PCRE2_SUBSTITUTE_CASE_UPPER, or PCRE2_SUBSTITUTE_CASE_TITLE.
+.P
+The third argument is the \fIcallout_data\fP supplied to
+\fBpcre2_set_substitute_case_callout()\fP, and the return value is the
+transformed Unicode character, which may be equal to the input character.
 .
 .
 .SH "DUPLICATE CAPTURE GROUP NAMES"

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -1117,6 +1117,7 @@ process.
       replace=<string>            specify a replacement string
       startchar                   show starting character when relevant
       substitute_callout          use substitution callouts
+      substitute_case_callout=<string> use substitution case callouts
       substitute_extended         use PCRE2_SUBSTITUTE_EXTENDED
       substitute_literal          use PCRE2_SUBSTITUTE_LITERAL
       substitute_matched          use PCRE2_SUBSTITUTE_MATCHED
@@ -1302,6 +1303,7 @@ pattern, but can be overridden by modifiers on the subject.
       startchar                  show startchar when relevant
       startoffset=<n>            same as offset=<n>
       substitute_callout         use substitution callouts
+      substitute_case_callout=<string> use substitution case callouts
       substitute_extedded        use PCRE2_SUBSTITUTE_EXTENDED
       substitute_literal         use PCRE2_SUBSTITUTE_LITERAL
       substitute_matched         use PCRE2_SUBSTITUTE_MATCHED
@@ -1585,6 +1587,25 @@ either of them are set, \fBsubstitute_callout\fP is assumed. For example:
 .sp
 If both are set for the same number, stop takes precedence. Only a single skip
 or stop is supported, which is sufficient for testing that the feature works.
+.
+.
+.SS "Testing substitute case callouts"
+.rs
+.sp
+If the \fBsubstitute_case_callout=<string>\fP modifier is set, a substitution
+case callout function is set up. The callout function is called for each
+substituted character which is to be case-transformed, and the mapping used
+is specified by the modifier's string argument.
+.P
+The string argument is parsed as four-character blocks, with each block
+interpreted as "<input><lower><upper><title>". The input character is used
+to find a matching block, and the corresponding character is then returned.
+For example, to specify a custom uppercasing of the letter "a" to "Z":
+.sp
+  /a/g,replace=\eU$0,substitute_extended,substitute_case_callout=a.Z.
+      a
+   1: Z
+.sp
 .
 .
 .SS "Setting the JIT stack size"

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -480,6 +480,12 @@ For binary compatibility, only add to this list; do not renumber. */
 #define PCRE2_START_OPTIMIZE       68
 #define PCRE2_START_OPTIMIZE_OFF   69
 
+/* Types used in pcre2_set_substitute_case_callout(). */
+
+#define PCRE2_SUBSTITUTE_CASE_LOWER 0
+#define PCRE2_SUBSTITUTE_CASE_UPPER 1
+#define PCRE2_SUBSTITUTE_CASE_TITLE 2
+
 /* Types for code units in patterns and subject strings. */
 
 typedef uint8_t  PCRE2_UCHAR8;
@@ -649,6 +655,9 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_substitute_callout(pcre2_match_context *, \
     int (*)(pcre2_substitute_callout_block *, void *), void *); \
+PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
+  pcre2_set_substitute_case_callout(pcre2_match_context *, \
+    uint32_t (*)(uint32_t, int, void *), void *); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_depth_limit(pcre2_match_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
@@ -931,6 +940,7 @@ pcre2_compile are called by application code. */
 #define pcre2_set_offset_limit                PCRE2_SUFFIX(pcre2_set_offset_limit_)
 #define pcre2_set_optimize                    PCRE2_SUFFIX(pcre2_set_optimize_)
 #define pcre2_set_substitute_callout          PCRE2_SUFFIX(pcre2_set_substitute_callout_)
+#define pcre2_set_substitute_case_callout     PCRE2_SUFFIX(pcre2_set_substitute_case_callout_)
 #define pcre2_substitute                      PCRE2_SUFFIX(pcre2_substitute_)
 #define pcre2_substring_copy_byname           PCRE2_SUFFIX(pcre2_substring_copy_byname_)
 #define pcre2_substring_copy_bynumber         PCRE2_SUFFIX(pcre2_substring_copy_bynumber_)

--- a/src/pcre2_context.c
+++ b/src/pcre2_context.c
@@ -174,6 +174,8 @@ pcre2_match_context PRIV(default_match_context) = {
   NULL,          /* Callout data */
   NULL,          /* Substitute callout function */
   NULL,          /* Substitute callout data */
+  NULL,          /* Substitute case callout function */
+  NULL,          /* Substitute case callout data */
   PCRE2_UNSET,   /* Offset limit */
   HEAP_LIMIT,
   MATCH_LIMIT,
@@ -461,6 +463,16 @@ pcre2_set_substitute_callout(pcre2_match_context *mcontext,
 {
 mcontext->substitute_callout = substitute_callout;
 mcontext->substitute_callout_data = substitute_callout_data;
+return 0;
+}
+
+PCRE2_EXP_DEFN int PCRE2_CALL_CONVENTION
+pcre2_set_substitute_case_callout(pcre2_match_context *mcontext,
+  uint32_t (*substitute_case_callout)(uint32_t, int, void *),
+    void *substitute_case_callout_data)
+{
+mcontext->substitute_case_callout = substitute_case_callout;
+mcontext->substitute_case_callout_data = substitute_case_callout_data;
 return 0;
 }
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -590,10 +590,12 @@ typedef struct pcre2_real_match_context {
   pcre2_jit_callback jit_callback;
   void *jit_callback_data;
 #endif
-  int    (*callout)(pcre2_callout_block *, void *);
-  void    *callout_data;
-  int    (*substitute_callout)(pcre2_substitute_callout_block *, void *);
-  void    *substitute_callout_data;
+  int      (*callout)(pcre2_callout_block *, void *);
+  void      *callout_data;
+  int      (*substitute_callout)(pcre2_substitute_callout_block *, void *);
+  void      *substitute_callout_data;
+  uint32_t (*substitute_case_callout)(uint32_t, int, void *);
+  void      *substitute_case_callout_data;
   PCRE2_SIZE offset_limit;
   uint32_t heap_limit;
   uint32_t match_limit;

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -942,8 +942,17 @@ do
           GETCHARINCTEST(ch, subptr);
           if (forcecase != 0)
             {
+            if (mcontext->substitute_case_callout)
+              {
+              ch = mcontext->substitute_case_callout(
+                ch,
+                forcecase > 0 && forcecasereset < 0 ? PCRE2_SUBSTITUTE_CASE_TITLE
+                  : forcecase > 0 ? PCRE2_SUBSTITUTE_CASE_UPPER
+                  : PCRE2_SUBSTITUTE_CASE_LOWER,
+                mcontext->substitute_case_callout_data);
+              }
 #ifdef SUPPORT_UNICODE
-            if (utf || ucp)
+            else if (utf || ucp)
               {
               uint32_t type = UCD_CHARTYPE(ch);
               if (PRIV(ucp_gentype)[type] == ucp_L &&
@@ -1095,8 +1104,17 @@ do
       LITERAL:
       if (forcecase != 0)
         {
+        if (mcontext->substitute_case_callout)
+          {
+          ch = mcontext->substitute_case_callout(
+            ch,
+            forcecase > 0 && forcecasereset < 0 ? PCRE2_SUBSTITUTE_CASE_TITLE
+              : forcecase > 0 ? PCRE2_SUBSTITUTE_CASE_UPPER
+              : PCRE2_SUBSTITUTE_CASE_LOWER,
+            mcontext->substitute_case_callout_data);
+          }
 #ifdef SUPPORT_UNICODE
-        if (utf || ucp)
+        else if (utf || ucp)
           {
           uint32_t type = UCD_CHARTYPE(ch);
           if (PRIV(ucp_gentype)[type] == ucp_L &&

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -959,8 +959,8 @@ do
                   type != ((forcecase > 0)? ucp_Lu : ucp_Ll))
                 ch = UCD_OTHERCASE(ch);
               }
-            else
 #endif
+            else
               {
               if (((code->tables + cbits_offset +
                   ((forcecase > 0)? cbit_upper:cbit_lower)
@@ -1121,8 +1121,8 @@ do
               type != ((forcecase > 0)? ucp_Lu : ucp_Ll))
             ch = UCD_OTHERCASE(ch);
           }
-        else
 #endif
+        else
           {
           if (((code->tables + cbits_offset +
               ((forcecase > 0)? cbit_upper:cbit_lower)

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -2443,7 +2443,7 @@ the three different cases. */
   pcre2_set_substitute_callout_32(G(a,32), \
     (int (*)(pcre2_substitute_callout_block_32 *, void *))b,c)
 #define PCRE2_SET_SUBSTITUTE_CASE_CALLOUT(a,b,c) \
-  pcre2_set_substitute_case_callout_32(G(a,32)b,c)
+  pcre2_set_substitute_case_callout_32(G(a,32),b,c)
 #define PCRE2_SUBSTITUTE(a,b,c,d,e,f,g,h,i,j,k,l) \
   a = pcre2_substitute_32(G(b,32),(PCRE2_SPTR32)c,d,e,f,G(g,32),h, \
     (PCRE2_SPTR32)i,j,(PCRE2_UCHAR32 *)k,l)

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -6491,7 +6491,7 @@ Each four-character block is parsed as a character list of the form
 like: "aaAA...AaAA...". */
 while ((c = *pr++) != 0)
   {
-  if (HASUTF8EXTRALEN(c)) { --pr; GETUTF8INC(c, pr); }
+  if (HASUTF8EXTRALEN(c)) { GETUTF8INC(c, pr); }
 
   if (skip != 0)
     {
@@ -7830,7 +7830,7 @@ if (dat_datctl.replacement[0] != 0)
 
   else while ((c = *pr++) != 0)
     {
-    if (HASUTF8EXTRALEN(c)) { --pr; GETUTF8INC(c, pr); }
+    if (HASUTF8EXTRALEN(c)) { GETUTF8INC(c, pr); }
 
 #ifdef SUPPORT_PCRE2_8
     if (test_mode == PCRE8_MODE) r8 += ord2utf8(c, r8);

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -6057,6 +6057,15 @@ a)"xI
     XABCY
     XabcY\=replace=  
 
+/abc/replace=\U$0,substitute_extended,substitute_case_callout=a.U.b.V.
+    XabcY
+
+/a/substitute_extended
+    XaY\=replace=\U$0,substitute_case_callout=a.U.
+    XaY\=replace=\L$0,substitute_case_callout=aL..
+    XaY\=replace=\u\L$0,substitute_case_callout=a..T
+    XaY\=replace=\l\U$0,substitute_case_callout=aL..
+
 # Expect non-fixed-length error
 
 "(?<=X(?(DEFINE)(.*))(?1))."

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -18052,6 +18052,20 @@ Failed: error -55 at offset 3 in replacement: requested value is not set
     XabcY\=replace=  
  0: abc
 
+/abc/replace=\U$0,substitute_extended,substitute_case_callout=a.U.b.V.
+    XabcY
+ 1: XUVcY
+
+/a/substitute_extended
+    XaY\=replace=\U$0,substitute_case_callout=a.U.
+ 1: XUY
+    XaY\=replace=\L$0,substitute_case_callout=aL..
+ 1: XLY
+    XaY\=replace=\u\L$0,substitute_case_callout=a..T
+ 1: XTY
+    XaY\=replace=\l\U$0,substitute_case_callout=aL..
+ 1: XLY
+
 # Expect non-fixed-length error
 
 "(?<=X(?(DEFINE)(.*))(?1))."


### PR DESCRIPTION
This arises from the discussion we had a few weeks ago on the Excel call.

We discussed improving the case-handling of the pcre2_substitute function, but in general, Philip seemed not overly-enthusiastic, simply because correct locale-aware handling of user-visible strings is _hard_.

I agree. This PR adds a callout (callback) function to allow a third-party Unicode engine to be used for user-visible string processing. This can be used by applications to do locale-aware case transformations.

It's still a one-char-to-one-char mapping, which is simplistic, but allows support for more locales than the current system.

Aside: PCRE2's current Unicode handling for pattern matching (using CaseFolding.txt data) is really rather good. This should not be locale-aware, since case-equivalence of characters is defined in a locale-independent manner. The uppercasing/lowercasing performed by pcre2_substitute really is a special case.