### PR TITLE
Fix OP_REFI for caseless_restrict

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -365,8 +365,10 @@ Changeable options
 The /i, /m, or /s options (PCRE2_CASELESS, PCRE2_MULTILINE, PCRE2_DOTALL) and
 some others may be changed in the middle of patterns by items such as (?i).
 Their processing is handled entirely at compile time by generating different
-opcodes for the different settings. The runtime functions do not need to keep
-track of an option's state.
+opcodes for the different settings. Some options are copied into the opcode's
+data, for opcodes such as OP_REFI which depends on the (?r)
+(PCRE2_EXTRA_CASELESS_RESTRICT) option. The runtime functions do not need to
+keep track of an option's state.
 
 PCRE2_DUPNAMES, PCRE2_EXTENDED, PCRE2_EXTENDED_MORE, and PCRE2_NO_AUTO_CAPTURE
 are tracked and processed during the parsing pre-pass. The others are handled
@@ -638,6 +640,9 @@ generates OP_DNREF or OP_DNREFI. These are followed by two counts: the index
 (not the byte offset) in the group name table of the first entry for the
 required name, followed by the number of groups with the same name. The
 matching code can then search for the first one that is set.
+
+OP_REFI and OP_DNREFI are further followed by an item containing any
+case-insensitivity flags.
 
 
 Repeating character classes and back references

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -7188,6 +7188,9 @@ for (;; pptr++)
       *code++ = ((options & PCRE2_CASELESS) != 0)? OP_DNREFI : OP_DNREF;
       PUT2INC(code, 0, index);
       PUT2INC(code, 0, count);
+      if ((options & PCRE2_CASELESS) != 0)
+        *code++ = ((xoptions & PCRE2_EXTRA_CASELESS_RESTRICT) != 0)?
+            REFI_FLAG_CASELESS_RESTRICT : 0;
       }
     break;
 
@@ -8142,6 +8145,9 @@ for (;; pptr++)
     if (firstcuflags == REQ_UNSET) zerofirstcuflags = firstcuflags = REQ_NONE;
     *code++ = ((options & PCRE2_CASELESS) != 0)? OP_REFI : OP_REF;
     PUT2INC(code, 0, meta_arg);
+    if ((options & PCRE2_CASELESS) != 0)
+      *code++ = ((xoptions & PCRE2_EXTRA_CASELESS_RESTRICT) != 0)?
+          REFI_FLAG_CASELESS_RESTRICT : 0;
 
     /* Update the map of back references, and keep the highest one. We
     could do this in parse_regex() for numerical back references, but not

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -1780,9 +1780,9 @@ in UTF-8 mode. The code that uses this table must know about such things. */
   1+(32/sizeof(PCRE2_UCHAR)),    /* NCLASS                                 */ \
   0,                             /* XCLASS - variable length               */ \
   1+IMM2_SIZE,                   /* REF                                    */ \
-  1+IMM2_SIZE,                   /* REFI                                   */ \
+  1+IMM2_SIZE+1,                 /* REFI                                   */ \
   1+2*IMM2_SIZE,                 /* DNREF                                  */ \
-  1+2*IMM2_SIZE,                 /* DNREFI                                 */ \
+  1+2*IMM2_SIZE+1,               /* DNREFI                                 */ \
   1+LINK_SIZE,                   /* RECURSE                                */ \
   1+2*LINK_SIZE+1,               /* CALLOUT                                */ \
   0,                             /* CALLOUT_STR - variable length          */ \
@@ -1828,6 +1828,10 @@ in UTF-8 mode. The code that uses this table must know about such things. */
 /* A magic value for OP_RREF to indicate the "any recursion" condition. */
 
 #define RREF_ANY  0xffff
+
+/* Constants used by OP_REFI and OP_DNREFI to control matching behaviour. */
+
+#define REFI_FLAG_CASELESS_RESTRICT  0x1
 
 
 /* ---------- Private structures that are mode-independent. ---------- */

--- a/src/pcre2_printint.c
+++ b/src/pcre2_printint.c
@@ -633,14 +633,17 @@ for(;;)
 
     case OP_REFI:
     flag = "/i";
+    extra = code[1 + IMM2_SIZE];
     /* Fall through */
     case OP_REF:
     fprintf(f, " %s \\%d", flag, GET2(code,1));
+    if (extra != 0) fprintf(f, " 0x%02x", extra);
     ccode = code + OP_lengths[*code];
     goto CLASS_REF_REPEAT;
 
     case OP_DNREFI:
     flag = "/i";
+    extra = code[1 + 2*IMM2_SIZE];
     /* Fall through */
     case OP_DNREF:
       {
@@ -648,6 +651,7 @@ for(;;)
       fprintf(f, " %s \\k<", flag);
       print_custring(f, entry);
       fprintf(f, ">%d", GET2(code, 1 + IMM2_SIZE));
+      if (extra != 0) fprintf(f, " 0x%02x", extra);
       }
     ccode = code + OP_lengths[*code];
     goto CLASS_REF_REPEAT;

--- a/src/pcre2_study.c
+++ b/src/pcre2_study.c
@@ -540,7 +540,7 @@ for (;;)
         }
       }
     else d = 0;
-    cc += 1 + 2*IMM2_SIZE;
+    cc += PRIV(OP_lengths)[*cc];
     goto REPEAT_BACK_REFERENCE;
 
     /* Single back reference by number. References by name are converted to by
@@ -593,7 +593,7 @@ for (;;)
       backref_cache[0] = recno;
       }
 
-    cc += 1 + IMM2_SIZE;
+    cc += PRIV(OP_lengths)[*cc];
 
     /* Handle repeated back references */
 

--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -2289,6 +2289,52 @@
     s\x{212a}s
     K\x{17f}K
 
+/(.) \1/i,utf,caseless_restrict
+    s S
+    k K
+\= Expect no match
+    s \x{17f}
+    k \x{212a}
+
+/(.) (?r:\1)/i,utf
+    s S
+    k K
+\= Expect no match
+    s \x{17f}
+    k \x{212a}
+
+/(.) \1/i,utf
+    s S
+    k K
+    s \x{17f}
+    k \x{212a}
+
+/(?:(?<A>ss)|(?<A>kk)) \k<A>/i,utf,dupnames,caseless_restrict
+    sS Ss
+    kK Kk
+\= Expect no match
+    sS \x{17f}s
+    kK \x{212a}k
+
+/(?:(?<A>ss)|(?<A>kk)) \k<A>/i,utf,dupnames
+    sS Ss
+    kK Kk
+    sS \x{17f}s
+    kK \x{212a}k
+
+/(?:(?<A>s)|(?<A>k)) \k<A>{3,}!/i,utf,dupnames,caseless_restrict
+    s SsSs!
+    k KkKk!
+\= Expect no match
+    s \x{17f}sSs\x{17f}!
+    k \x{212a}kKk\x{212a}!
+
+/(?:(?<A>s)|(?<A>k)) \k<A>{3,}!/i,utf,dupnames
+    s SsSs!
+    k KkKk!
+    s \x{17f}sSs\x{17f}!
+    k \x{212a}kKk\x{212a}!
+
 # End caseless restrict tests
 
 # TESTS for PCRE2_EXTRA_ASCII_xxx - again, tests with and without.

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -5210,6 +5210,106 @@ No match
     K\x{17f}K
 No match
 
+/(.) \1/i,utf,caseless_restrict
+    s S
+ 0: s S
+ 1: s
+    k K
+ 0: k K
+ 1: k
+\= Expect no match
+    s \x{17f}
+No match
+    k \x{212a}
+No match
+
+/(.) (?r:\1)/i,utf
+    s S
+ 0: s S
+ 1: s
+    k K
+ 0: k K
+ 1: k
+\= Expect no match
+    s \x{17f}
+No match
+    k \x{212a}
+No match
+
+/(.) \1/i,utf
+    s S
+ 0: s S
+ 1: s
+    k K
+ 0: k K
+ 1: k
+    s \x{17f}
+ 0: s \x{17f}
+ 1: s
+    k \x{212a}
+ 0: k \x{212a}
+ 1: k
+
+/(?:(?<A>ss)|(?<A>kk)) \k<A>/i,utf,dupnames,caseless_restrict
+    sS Ss
+ 0: sS Ss
+ 1: sS
+    kK Kk
+ 0: kK Kk
+ 1: <unset>
+ 2: kK
+\= Expect no match
+    sS \x{17f}s
+No match
+    kK \x{212a}k
+No match
+
+/(?:(?<A>ss)|(?<A>kk)) \k<A>/i,utf,dupnames
+    sS Ss
+ 0: sS Ss
+ 1: sS
+    kK Kk
+ 0: kK Kk
+ 1: <unset>
+ 2: kK
+    sS \x{17f}s
+ 0: sS \x{17f}s
+ 1: sS
+    kK \x{212a}k
+ 0: kK \x{212a}k
+ 1: <unset>
+ 2: kK
+
+/(?:(?<A>s)|(?<A>k)) \k<A>{3,}!/i,utf,dupnames,caseless_restrict
+    s SsSs!
+ 0: s SsSs!
+ 1: s
+    k KkKk!
+ 0: k KkKk!
+ 1: <unset>
+ 2: k
+\= Expect no match
+    s \x{17f}sSs\x{17f}!
+No match
+    k \x{212a}kKk\x{212a}!
+No match
+
+/(?:(?<A>s)|(?<A>k)) \k<A>{3,}!/i,utf,dupnames
+    s SsSs!
+ 0: s SsSs!
+ 1: s
+    k KkKk!
+ 0: k KkKk!
+ 1: <unset>
+ 2: k
+    s \x{17f}sSs\x{17f}!
+ 0: s \x{17f}sSs\x{17f}!
+ 1: s
+    k \x{212a}kKk\x{212a}!
+ 0: k \x{212a}kKk\x{212a}!
+ 1: <unset>
+ 2: k
+
 # End caseless restrict tests
 
 # TESTS for PCRE2_EXTRA_ASCII_xxx - again, tests with and without.


### PR DESCRIPTION
When you introduced caseless_restrict earlier in the year, it looks like you forgot to add it to the `OP_REFI` (and `OP_DNREFI`) comparison.

It's actually a bit tricky to add, because it seems the "flags" that are tracked during compile are not written out to the bytecode.

So, I added one extra field to `OP_REFI` to record the caseless flag. (Currently, it's just "caseless_restrict", but as I mentioned, I'll be adding "turkish_casing" in a future PR.)

I _think_ there's no other way to do it? I hope the flags aren't stored in the bytecode already and I just missed it.

It seems a bit wasteful, perhaps, to spend a uint8 (or uint32 in the case of the 32-bit library), but I think you basically forced this outcome back when you added the `(?r)` flag allowing caseless_restrict to be varied through the pattern.