### PR TITLE
Address most implicit 64-to-32-bit conversion warnings.

### DIFF
--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -667,7 +667,7 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_depth_limit(pcre2_match_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
-  pcre2_set_heap_limit(pcre2_match_context *, uint32_t); \
+  pcre2_set_heap_limit(pcre2_match_context *, PCRE2_SIZE); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_match_limit(pcre2_match_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -667,7 +667,7 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_depth_limit(pcre2_match_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
-  pcre2_set_heap_limit(pcre2_match_context *, uint32_t); \
+  pcre2_set_heap_limit(pcre2_match_context *, PCRE2_SIZE); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_match_limit(pcre2_match_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \

--- a/src/pcre2_chkdint.c
+++ b/src/pcre2_chkdint.c
@@ -63,7 +63,7 @@ The INT64_OR_DOUBLE type is a 64-bit integer type when available,
 otherwise double. */
 
 BOOL
-PRIV(ckd_smul)(PCRE2_SIZE *r, int a, int b)
+PRIV(ckd_smul)(PCRE2_SIZE *r, ptrdiff_t a, ptrdiff_t b)
 {
 #ifdef HAVE_BUILTIN_MUL_OVERFLOW
 PCRE2_SIZE m;

--- a/src/pcre2_context.c
+++ b/src/pcre2_context.c
@@ -477,7 +477,7 @@ return 0;
 }
 
 PCRE2_EXP_DEFN int PCRE2_CALL_CONVENTION
-pcre2_set_heap_limit(pcre2_match_context *mcontext, uint32_t limit)
+pcre2_set_heap_limit(pcre2_match_context *mcontext, PCRE2_SIZE limit)
 {
 mcontext->heap_limit = limit;
 return 0;

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -2116,7 +2116,7 @@ extern void *       _pcre2_memmove(void *, const void *, size_t);
 
 #endif  /* PCRE2_CODE_UNIT_WIDTH */
 
-extern BOOL         PRIV(ckd_smul)(PCRE2_SIZE *, int, int);
+extern BOOL         PRIV(ckd_smul)(PCRE2_SIZE *, ptrdiff_t, ptrdiff_t);
 
 #include "pcre2_util.h"
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -597,7 +597,7 @@ typedef struct pcre2_real_match_context {
   uint32_t (*substitute_case_callout)(uint32_t, int, void *);
   void      *substitute_case_callout_data;
   PCRE2_SIZE offset_limit;
-  uint32_t heap_limit;
+  PCRE2_SIZE heap_limit;
   uint32_t match_limit;
   uint32_t depth_limit;
 } pcre2_real_match_context;
@@ -889,7 +889,7 @@ doing traditional NFA matching (pcre2_match() and friends). */
 
 typedef struct match_block {
   pcre2_memctl memctl;            /* For general use */
-  uint32_t heap_limit;            /* As it says */
+  PCRE2_SIZE heap_limit;          /* As it says */
   uint32_t match_limit;           /* As it says */
   uint32_t match_limit_depth;     /* As it says */
   uint32_t match_call_count;      /* Number of times a new frame is created */
@@ -943,7 +943,7 @@ typedef struct dfa_match_block {
   PCRE2_SPTR last_used_ptr;       /* Latest consulted character */
   const uint8_t *tables;          /* Character tables */
   PCRE2_SIZE start_offset;        /* The start offset value */
-  uint32_t heap_limit;            /* As it says */
+  PCRE2_SIZE heap_limit;          /* As it says */
   PCRE2_SIZE heap_used;           /* As it says */
   uint32_t match_limit;           /* As it says */
   uint32_t match_limit_depth;     /* As it says */

--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -2362,7 +2362,7 @@ SLJIT_ASSERT(stackpos == STACK(stacktop));
 typedef struct delayed_mem_copy_status {
   struct sljit_compiler *compiler;
   int store_bases[RECURSE_TMP_REG_COUNT];
-  int store_offsets[RECURSE_TMP_REG_COUNT];
+  sljit_sw store_offsets[RECURSE_TMP_REG_COUNT];
   int tmp_regs[RECURSE_TMP_REG_COUNT];
   int saved_tmp_regs[RECURSE_TMP_REG_COUNT];
   int next_tmp_reg;
@@ -3302,7 +3302,8 @@ OP2(SLJIT_SUB | SLJIT_SET_Z, COUNT_MATCH, 0, COUNT_MATCH, 0, SLJIT_IMM, 1);
 add_jump(compiler, &common->calllimit, JUMP(SLJIT_ZERO));
 }
 
-static SLJIT_INLINE void allocate_stack(compiler_common *common, int size)
+static SLJIT_INLINE void allocate_stack(compiler_common *common,
+                                        PCRE2_SIZE size)
 {
 /* May destroy all locals and registers except TMP2. */
 DEFINE_COMPILER;
@@ -3319,7 +3320,7 @@ OP1(SLJIT_MOV, SLJIT_MEM1(SLJIT_SP), LOCALS1, TMP1, 0);
 add_stub(common, CMP(SLJIT_LESS, STACK_TOP, 0, STACK_LIMIT, 0));
 }
 
-static SLJIT_INLINE void free_stack(compiler_common *common, int size)
+static SLJIT_INLINE void free_stack(compiler_common *common, PCRE2_SIZE size)
 {
 DEFINE_COMPILER;
 
@@ -4064,7 +4065,7 @@ if (common->invalid_utf)
 #define READ_CHAR_NEWLINE (READ_CHAR_UPDATE_STR_PTR | READ_CHAR_UTF8_NEWLINE)
 #define READ_CHAR_VALID_UTF 0x4
 
-static void read_char(compiler_common *common, sljit_u32 min, sljit_u32 max,
+static void read_char(compiler_common *common, sljit_uw min, sljit_uw max,
   jump_list **backtracks, sljit_u32 options)
 {
 /* Reads the precise value of a character into TMP1, if the character is

--- a/src/pcre2_jit_neon_inc.h
+++ b/src/pcre2_jit_neon_inc.h
@@ -87,7 +87,7 @@ POSSIBILITY OF SUCH DAMAGE.
 	&& ((__clang_major__ == 3 && __clang_minor__ >= 3) || (__clang_major__ > 3)))
 __attribute__((no_sanitize_address))
 #endif
-static sljit_u8* SLJIT_FUNC FF_FUN(sljit_u8 *str_end, sljit_u8 **str_ptr, sljit_uw offs1, sljit_uw offs2, sljit_uw chars)
+static sljit_u8* SLJIT_FUNC FF_FUN(sljit_u8 *str_end, sljit_u8 **str_ptr, sljit_uw offs1, sljit_uw offs2, sljit_u32 chars)
 #undef FF_FUN
 {
 quad_word qw;
@@ -119,7 +119,7 @@ vect_t vmask = VDUPQ(mask);
 compare_type compare1_type = compare_match1;
 compare_type compare2_type = compare_match1;
 vect_t cmp1a, cmp1b, cmp2a, cmp2b;
-const sljit_u32 diff = IN_UCHARS(offs1 - offs2);
+const sljit_uw diff = IN_UCHARS(offs1 - offs2);
 PCRE2_UCHAR char1a = ic.c.c1;
 PCRE2_UCHAR char2a = ic.c.c3;
 

--- a/src/pcre2posix.c
+++ b/src/pcre2posix.c
@@ -345,7 +345,8 @@ PCRE2POSIX_EXP_DEFN int PCRE2_CALL_CONVENTION
 pcre2_regexec(const regex_t *preg, const char *string, size_t nmatch,
   regmatch_t pmatch[], int eflags)
 {
-int rc, so, eo;
+int rc;
+regoff_t so, eo;
 int options = 0;
 pcre2_match_data *md = (pcre2_match_data *)preg->re_match_data;
 

--- a/src/pcre2posix.h
+++ b/src/pcre2posix.h
@@ -43,8 +43,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef PCRE2POSIX_H_IDEMPOTENT_GUARD
 #define PCRE2POSIX_H_IDEMPOTENT_GUARD
 
-/* Have to include stdlib.h in order to ensure that size_t is defined. */
+/* Respectively ensure that ptrdiff_t and size_t are defined. */
 
+#include <stddef.h>
 #include <stdlib.h>
 
 /* Allow for C++ users */
@@ -111,7 +112,7 @@ typedef struct {
 
 /* The structure in which a captured offset is returned. */
 
-typedef int regoff_t;
+typedef ptrdiff_t regoff_t;
 
 typedef struct {
   regoff_t rm_so;

--- a/src/pcre2posix_test.c
+++ b/src/pcre2posix_test.c
@@ -181,11 +181,11 @@ for (int i = 0; i < count; i++)
           fprintf(stderr, "Mismatched results for successful match\n");
           fprintf(stderr, "Pattern is: %s\n", pattern);
           fprintf(stderr, "Subject is: %s\n", *subjects);
-          fprintf(stderr, "Result %d: expected %d %d received %d %d\n",
+          fprintf(stderr, "Result %d: expected %d %d received %zd %zd\n",
             j, rd[-1], rd[0], m->rm_so, m->rm_eo);
           return 1;
           }
-        PRINTF(" (%d %d %d)", j, m->rm_so, m->rm_eo);
+        PRINTF(" (%d %zd %zd)", j, m->rm_so, m->rm_eo);
         }
       }
 


### PR DESCRIPTION
Visual Studio and Xcode both issue such warnings by default, and Clang also offers a `-Wshorten-64-to-32` option to expose them elsewhere.  To address them, harmonize types where practical and add casts as appropriate (first formally capping executables' read request sizes as necessary).  NB: `detect_repeat` in `pcre2_jit_compile.c` still yields two such warnings that look plausibly legitimate but not so easy to fix. :-/
