### PR TITLE
Even in 8-bit mode, perform range computation for char classes if UCP flag is set

### DIFF
--- a/src/pcre2_compile_class.c
+++ b/src/pcre2_compile_class.c
@@ -125,7 +125,7 @@ const uint32_t *skip_range = get_nocase_range(c);
 uint32_t skip_start = skip_range[0];
 
 #if PCRE2_CODE_UNIT_WIDTH == 8
-PCRE2_ASSERT(options & PARSE_CLASS_UTF);
+PCRE2_ASSERT(options & (PARSE_CLASS_UTF | PARSE_CLASS_CASELESS_UTF));
 #endif
 
 #if PCRE2_CODE_UNIT_WIDTH == 32

--- a/testdata/testinput10
+++ b/testdata/testinput10
@@ -623,6 +623,9 @@
 /X(\x{e1})Y/i,ucp,replace=>\L$1<,substitute_extended
     X\x{c1}Y
 
+/[a\x{c1}]/iI,ucp
+    \x{e1}
+
 # Without UTF or UCP characters > 127 have only one case in the default locale.
 
 /X(\x{e1})Y/replace=>\U$1<,substitute_extended

--- a/testdata/testoutput10
+++ b/testdata/testoutput10
@@ -1883,6 +1883,14 @@ Subject length lower bound = 1
     X\x{c1}Y
  1: >\xe1<
 
+/[a\x{c1}]/iI,ucp
+Capture group count = 0
+Options: caseless ucp
+Starting code units: A a \xc1 \xe1
+Subject length lower bound = 1
+    \x{e1}
+ 0: \xe1
+
 # Without UTF or UCP characters > 127 have only one case in the default locale.
 
 /X(\x{e1})Y/replace=>\U$1<,substitute_extended


### PR DESCRIPTION
When testing another patch, I discovered that #474 caused a small change in the behavior of character classes when caseless mode and UCP were enabled.

Thank you to Zoltan Herczeg for suggesting a fix.

Closes GH-526.