### PR TITLE
perltest: add support for hex modifier

### DIFF
--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -1,4 +1,4 @@
-.TH PCRE2TEST 1 "04 October 2024" "PCRE 10.45"
+.TH PCRE2TEST 1 "16 October 2024" "PCRE 10.45"
 .SH NAME
 pcre2test - a program for testing Perl-compatible regular expressions.
 .SH SYNOPSIS
@@ -511,7 +511,9 @@ means of encoding non-printing characters in a visible way:
 .sp
 Invoking \eN{U+hh...} or \ex{hh...} doesn't require the use of the \fButf\fP
 modifier on the pattern. It is always recognized. There may be any number of
-hexadecimal digits inside the braces; invalid values provoke error messages.
+hexadecimal digits inside the braces; invalid values provoke error messages
+but when using \eN{U+hh...} with some invalid unicode characters they will
+be accepted with a warning instead.
 .P
 Note that even in UTF-8 mode, \exhh (and depending of how large, \eddd)
 describe one byte rather than one character; this makes it possible to
@@ -526,7 +528,7 @@ When testing te 16-bit library, not in UTF-16 mode, all 4-digit \ex{hhhh}
 values are accepted. This makes it possible to construct invalid UTF-16
 sequences for testing purposes.
 .P
-When testing the 32-bit library, not In UTF-32 mode, all 4 to 8-digit \ex{...}
+When testing the 32-bit library, not in UTF-32 mode, all 4 to 8-digit \ex{...}
 values are accepted. This makes it possible to construct invalid UTF-32
 sequences for testing purposes.
 .P
@@ -2243,6 +2245,6 @@ Cambridge, England.
 .rs
 .sp
 .nf
-Last updated: 04 October 2024
+Last updated: 16 October 2024
 Copyright (c) 1997-2024 University of Cambridge.
 .fi

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -1940,7 +1940,7 @@ else
       cc = *ptr++;
       if (c == 0 && cc == CHAR_0) continue;     /* Leading zeroes */
 #if PCRE2_CODE_UNIT_WIDTH == 32
-      if (c >= 0x20000000l) { overflow = TRUE; break; }
+      if (c >= 0x20000000u) { overflow = TRUE; break; }
 #endif
       c = (c << 3) + (cc - CHAR_0);
 #if PCRE2_CODE_UNIT_WIDTH == 8

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -713,7 +713,7 @@ static modstruct modlist[] = {
   { "global",                      MOD_PNDP, MOD_CTL, CTL_GLOBAL,                 PO(control) },
   { "heap_limit",                  MOD_CTM,  MOD_INT, 0,                          MO(heap_limit) },
   { "heapframes_size",             MOD_PND,  MOD_CTL, CTL2_HEAPFRAMES_SIZE,       PO(control2) },
-  { "hex",                         MOD_PAT,  MOD_CTL, CTL_HEXPAT,                 PO(control) },
+  { "hex",                         MOD_PATP, MOD_CTL, CTL_HEXPAT,                 PO(control) },
   { "info",                        MOD_PAT,  MOD_CTL, CTL_INFO,                   PO(control) },
   { "jit",                         MOD_PAT,  MOD_IND, 7,                          PO(jit) },
   { "jitfast",                     MOD_PAT,  MOD_CTL, CTL_JITFAST,                PO(control) },

--- a/testdata/testinput1
+++ b/testdata/testinput1
@@ -6709,4 +6709,7 @@ $/x
 \= Expect no match
     .a.b.c.
 
+/65 00 64/hex
+    e\0d
+
 # End of testinput1 

--- a/testdata/testinput11
+++ b/testdata/testinput11
@@ -356,12 +356,18 @@
 # We can use pcre2test's utf8_input modifier to create wide pattern characters,
 # even though this test is run when UTF is not supported.
 
+/a\x{d800}b/utf8_input
+    aí €b
+    a\x{d800}b
+    a\o{154000}b
+\= Expect warning unless 32bit
+    a\N{U+d800}b
+
 /a\x{ffff}b/utf8_input
     aï¿¿b
     a\x{ffff}b
     a\o{177777}b
-\= Expect no match
-    a\N{U+ffff}z
+    a\N{U+ffff}b
 
 /abý¿¿¿¿¿z/utf8_input
     abý¿¿¿¿¿z

--- a/testdata/testinput4
+++ b/testdata/testinput4
@@ -2908,4 +2908,9 @@
 /\p{  ^ L u }/
     AbCd
 
+# hex
+
+/c3 b1/hex,utf
+    \N{U+00F1}
+
 # End of testinput4

--- a/testdata/testinput9
+++ b/testdata/testinput9
@@ -12,6 +12,7 @@
     a\443b
 
 /fd bf bf bf bf bf/I,hex
+\= Expect warning
     \N{U+7fffffff}
 \= Expect no match # error message (too big char)
     \x{7fffffff}

--- a/testdata/testoutput1
+++ b/testdata/testoutput1
@@ -10580,4 +10580,8 @@ No match
     .a.b.c.
 No match
 
+/65 00 64/hex
+    e\0d
+ 0: e\x00d
+
 # End of testinput1 

--- a/testdata/testoutput11-16
+++ b/testdata/testoutput11-16
@@ -646,6 +646,18 @@ Subject length lower bound = 1
 # We can use pcre2test's utf8_input modifier to create wide pattern characters,
 # even though this test is run when UTF is not supported.
 
+/a\x{d800}b/utf8_input
+    aí €b
+ 0: a\x{d800}b
+    a\x{d800}b
+ 0: a\x{d800}b
+    a\o{154000}b
+ 0: a\x{d800}b
+\= Expect warning unless 32bit
+    a\N{U+d800}b
+** Warning: character \N{U+d800} is a surrogate and should not be encoded as UTF-16
+ 0: a\x{d800}b
+
 /a\x{ffff}b/utf8_input
     aï¿¿b
  0: a\x{ffff}b
@@ -653,9 +665,8 @@ Subject length lower bound = 1
  0: a\x{ffff}b
     a\o{177777}b
  0: a\x{ffff}b
-\= Expect no match
-    a\N{U+ffff}z
-No match
+    a\N{U+ffff}b
+ 0: a\x{ffff}b
 
 /abý¿¿¿¿¿z/utf8_input
 ** Failed: character value greater than 0xffff cannot be converted to 16-bit in non-UTF mode

--- a/testdata/testoutput11-32
+++ b/testdata/testoutput11-32
@@ -649,6 +649,17 @@ Subject length lower bound = 1
 # We can use pcre2test's utf8_input modifier to create wide pattern characters,
 # even though this test is run when UTF is not supported.
 
+/a\x{d800}b/utf8_input
+    aí €b
+ 0: a\x{d800}b
+    a\x{d800}b
+ 0: a\x{d800}b
+    a\o{154000}b
+ 0: a\x{d800}b
+\= Expect warning unless 32bit
+    a\N{U+d800}b
+ 0: a\x{d800}b
+
 /a\x{ffff}b/utf8_input
     aï¿¿b
  0: a\x{ffff}b
@@ -656,9 +667,8 @@ Subject length lower bound = 1
  0: a\x{ffff}b
     a\o{177777}b
  0: a\x{ffff}b
-\= Expect no match
-    a\N{U+ffff}z
-No match
+    a\N{U+ffff}b
+ 0: a\x{ffff}b
 
 /abý¿¿¿¿¿z/utf8_input
     abý¿¿¿¿¿z
@@ -668,6 +678,7 @@ No match
     ab\o{17777777777}z
  0: ab\x{7fffffff}z
     ab\N{U+7fffffff}z
+** Warning: character \N{U+7fffffff} is greater than 0x10ffff and should not be encoded as UTF-32
  0: ab\x{7fffffff}z
 
 /abÿý¿¿¿¿¿z/utf8_input

--- a/testdata/testoutput4
+++ b/testdata/testoutput4
@@ -4656,4 +4656,10 @@ No match
     AbCd
  0: b
 
+# hex
+
+/c3 b1/hex,utf
+    \N{U+00F1}
+ 0: \x{f1}
+
 # End of testinput4

--- a/testdata/testoutput9
+++ b/testdata/testoutput9
@@ -26,7 +26,9 @@ Capture group count = 0
 First code unit = \xfd
 Last code unit = \xbf
 Subject length lower bound = 6
+\= Expect warning
     \N{U+7fffffff}
+** Warning: character \N{U+7fffffff} is greater than 0x10ffff and should not be encoded as UTF-8
  0: \xfd\xbf\xbf\xbf\xbf\xbf
 \= Expect no match # error message (too big char)
     \x{7fffffff}


### PR DESCRIPTION
First patch is really a fixup for #528 with the second patch being the real meat.

Posted separately so it is easier to see the independent changes, but will squash them otherwise.