### PR TITLE
perltest: add support for locale modifier

### DIFF
--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -720,7 +720,7 @@ static modstruct modlist[] = {
   { "jitstack",                    MOD_PNDP, MOD_INT, 0,                          PO(jitstack) },
   { "jitverify",                   MOD_PAT,  MOD_CTL, CTL_JITVERIFY,              PO(control) },
   { "literal",                     MOD_PAT,  MOD_OPT, PCRE2_LITERAL,              PO(options) },
-  { "locale",                      MOD_PAT,  MOD_STR, LOCALESIZE,                 PO(locale) },
+  { "locale",                      MOD_PATP, MOD_STR, LOCALESIZE,                 PO(locale) },
   { "mark",                        MOD_PNDP, MOD_CTL, CTL_MARK,                   PO(control) },
   { "match_invalid_utf",           MOD_PAT,  MOD_OPT, PCRE2_MATCH_INVALID_UTF,    PO(options) },
   { "match_limit",                 MOD_CTM,  MOD_INT, 0,                          MO(match_limit) },

--- a/testdata/testinput1
+++ b/testdata/testinput1
@@ -5087,6 +5087,15 @@ name)/mark
 \= Expect no match
     D 
 
+/(*COMMIT)ABC/no_start_optimize
+    ABC
+\= Expect no match
+    DEFABC
+
+/(*COMMIT)ABC/
+    ABC
+    DEFABC
+
 # This should fail, as the skip causes a bump to offset 3 (the skip).
 
 /A(*MARK:A)A+(*SKIP)(B|Z) | AC/x,mark

--- a/testdata/testinput3
+++ b/testdata/testinput3
@@ -1,5 +1,5 @@
 # This set of tests checks local-specific features, using the "fr_FR" locale. 
-# It is not Perl-compatible. When run via RunTest, the locale is edited to
+# It is almost Perl-compatible. When run via RunTest, the locale is edited to
 # be whichever of "fr_FR", "french", or "fr" is found to exist. There is
 # different version of this file called wintestinput3 for use on Windows,
 # where the locale is called "french" and the tests are run using
@@ -12,10 +12,6 @@
     École
 
 /^[\w]+/locale=fr_FR
-    École
-
-/^[\w]+/
-\= Expect no match
     École
 
 /^[\W]+/
@@ -79,6 +75,14 @@
     µ
 \= Expect no match
     \x9c
+
+/ÿ/i
+    \xff
+\= Expect no match
+    y
+
+/(.)\1/i
+    \xfe\xde
 
 /\W+/
     >>>\xaa<<<

--- a/testdata/testoutput1
+++ b/testdata/testoutput1
@@ -8174,6 +8174,19 @@ MK: B
     D 
 No match, mark = B
 
+/(*COMMIT)ABC/no_start_optimize
+    ABC
+ 0: ABC
+\= Expect no match
+    DEFABC
+No match
+
+/(*COMMIT)ABC/
+    ABC
+ 0: ABC
+    DEFABC
+ 0: ABC
+
 # This should fail, as the skip causes a bump to offset 3 (the skip).
 
 /A(*MARK:A)A+(*SKIP)(B|Z) | AC/x,mark

--- a/testdata/testoutput3
+++ b/testdata/testoutput3
@@ -1,5 +1,5 @@
 # This set of tests checks local-specific features, using the "fr_FR" locale. 
-# It is not Perl-compatible. When run via RunTest, the locale is edited to
+# It is almost Perl-compatible. When run via RunTest, the locale is edited to
 # be whichever of "fr_FR", "french", or "fr" is found to exist. There is
 # different version of this file called wintestinput3 for use on Windows,
 # where the locale is called "french" and the tests are run using
@@ -15,11 +15,6 @@ No match
 /^[\w]+/locale=fr_FR
     École
  0: École
-
-/^[\w]+/
-\= Expect no match
-    École
-No match
 
 /^[\W]+/
     École
@@ -114,6 +109,18 @@ No match
 \= Expect no match
     \x9c
 No match
+
+/ÿ/i
+    \xff
+ 0: ÿ
+\= Expect no match
+    y
+No match
+
+/(.)\1/i
+    \xfe\xde
+ 0: þÞ
+ 1: þ
 
 /\W+/
     >>>\xaa<<<

--- a/testdata/testoutput3A
+++ b/testdata/testoutput3A
@@ -1,5 +1,5 @@
 # This set of tests checks local-specific features, using the "fr_FR" locale. 
-# It is not Perl-compatible. When run via RunTest, the locale is edited to
+# It is almost Perl-compatible. When run via RunTest, the locale is edited to
 # be whichever of "fr_FR", "french", or "fr" is found to exist. There is
 # different version of this file called wintestinput3 for use on Windows,
 # where the locale is called "french" and the tests are run using
@@ -15,11 +15,6 @@ No match
 /^[\w]+/locale=fr_FR
     École
  0: École
-
-/^[\w]+/
-\= Expect no match
-    École
-No match
 
 /^[\W]+/
     École
@@ -114,6 +109,18 @@ No match
 \= Expect no match
     \x9c
 No match
+
+/ÿ/i
+    \xff
+ 0: ÿ
+\= Expect no match
+    y
+No match
+
+/(.)\1/i
+    \xfe\xde
+ 0: þÞ
+ 1: þ
 
 /\W+/
     >>>\xaa<<<

--- a/testdata/testoutput3B
+++ b/testdata/testoutput3B
@@ -1,5 +1,5 @@
 # This set of tests checks local-specific features, using the "fr_FR" locale. 
-# It is not Perl-compatible. When run via RunTest, the locale is edited to
+# It is almost Perl-compatible. When run via RunTest, the locale is edited to
 # be whichever of "fr_FR", "french", or "fr" is found to exist. There is
 # different version of this file called wintestinput3 for use on Windows,
 # where the locale is called "french" and the tests are run using
@@ -15,11 +15,6 @@ No match
 /^[\w]+/locale=fr_FR
     École
  0: École
-
-/^[\w]+/
-\= Expect no match
-    École
-No match
 
 /^[\W]+/
     École
@@ -114,6 +109,18 @@ No match
 \= Expect no match
     \x9c
 No match
+
+/ÿ/i
+    \xff
+ 0: ÿ
+\= Expect no match
+    y
+No match
+
+/(.)\1/i
+    \xfe\xde
+ 0: þÞ
+ 1: þ
 
 /\W+/
     >>>\xaa<<<

--- a/testdata/wintestinput3
+++ b/testdata/wintestinput3
@@ -1,5 +1,5 @@
 # This set of tests checks local-specific features, using the "fr_FR" locale. 
-# It is not Perl-compatible. When run via RunTest, the locale is edited to
+# It is almost Perl-compatible. When run via RunTest, the locale is edited to
 # be whichever of "fr_FR", "french", or "fr" is found to exist. There is
 # different version of this file called wintestinput3 for use on Windows,
 # where the locale is called "french" and the tests are run using
@@ -12,10 +12,6 @@
     École
 
 /^[\w]+/locale=french
-    École
-
-/^[\w]+/
-    *** Failers
     École
 
 /^[\W]+/
@@ -74,6 +70,16 @@
     École
     *** Failers 
     école
+
+/\xb5/i
+    µ
+    *** Failers
+    \x9c
+
+/ÿ/i
+    \xff
+    *** Failers
+    y
 
 /\W+/
     >>>\xaa<<<

--- a/testdata/wintestoutput3
+++ b/testdata/wintestoutput3
@@ -1,5 +1,5 @@
 # This set of tests checks local-specific features, using the "fr_FR" locale. 
-# It is not Perl-compatible. When run via RunTest, the locale is edited to
+# It is almost Perl-compatible. When run via RunTest, the locale is edited to
 # be whichever of "fr_FR", "french", or "fr" is found to exist. There is
 # different version of this file called wintestinput3 for use on Windows,
 # where the locale is called "french" and the tests are run using
@@ -16,12 +16,6 @@ No match
 /^[\w]+/locale=french
     École
  0: École
-
-/^[\w]+/
-    *** Failers
-No match
-    École
-No match
 
 /^[\W]+/
     École
@@ -89,17 +83,17 @@ No match
 
 /\w/I
 Capture group count = 0
-Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P 
-  Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z 
+Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
+  Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
 Subject length lower bound = 1
 
 /\w/I,locale=french
 Capture group count = 0
-Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P 
-  Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z 
-  ƒ Š Œ Ž š œ ž Ÿ ª ² ³ µ ¹ º À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ð Ñ Ò Ó Ô Õ Ö 
-  Ø Ù Ú Û Ü Ý Þ ß à á â ã ä å æ ç è é ê ë ì í î ï ð ñ ò ó ô õ ö ø ù ú û ü ý 
-  þ ÿ 
+Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
+  Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
+  ƒ Š Œ Ž š œ ž Ÿ ª ² ³ µ ¹ º À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ð Ñ Ò Ó Ô Õ Ö
+  Ø Ù Ú Û Ü Ý Þ ß à á â ã ä å æ ç è é ê ë ì í î ï ð ñ ò ó ô õ ö ø ù ú û ü ý
+  þ ÿ
 Subject length lower bound = 1
 
 # All remaining tests are in the french locale, so set the default.
@@ -118,6 +112,22 @@ Subject length lower bound = 1
     *** Failers 
 No match
     école
+No match
+
+/\xb5/i
+    µ
+ 0: µ
+    *** Failers
+No match
+    \x9c
+No match
+
+/ÿ/i
+    \xff
+ 0: ÿ
+    *** Failers
+No match
+    y
 No match
 
 /\W+/
@@ -166,10 +176,10 @@ No match
         End
 ------------------------------------------------------------------
 Capture group count = 0
-Starting code units: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z 
-  a b c d e f g h i j k l m n o p q r s t u v w x y z ƒ Š Œ Ž š œ ž Ÿ ª µ º 
-  À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ð Ñ Ò Ó Ô Õ Ö Ø Ù Ú Û Ü Ý Þ ß à á â ã ä å 
-  æ ç è é ê ë ì í î ï ð ñ ò ó ô õ ö ø ù ú û ü ý þ ÿ 
+Starting code units: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+  a b c d e f g h i j k l m n o p q r s t u v w x y z ƒ Š Œ Ž š œ ž Ÿ ª µ º
+  À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ð Ñ Ò Ó Ô Õ Ö Ø Ù Ú Û Ü Ý Þ ß à á â ã ä å
+  æ ç è é ê ë ì í î ï ð ñ ò ó ô õ ö ø ù ú û ü ý þ ÿ
 Subject length lower bound = 3
 
 # End of testinput3 


### PR DESCRIPTION
Make comparing behaviour between Perl and PCRE2 easier when locale is involved (almost making test3 Perl compatible), plus cleaning test3 so it is again working on Windows as well as other fixes.