### PR TITLE
Add additional tests for negated /[^\P{Lu}]/i behaviour

### DIFF
--- a/testdata/testinput4
+++ b/testdata/testinput4
@@ -2913,4 +2913,40 @@
 /c3 b1/hex,utf
     \N{U+00F1}
 
+/[^\P{Lu}1]/i,utf,ucp
+    a
+    A
+    \x{3a3}
+    \x{3c3}
+\= Expect no match
+    1
+    2
+
+/[^\P{Lu}1]/utf,ucp
+    A
+    \x{3a3}
+\= Expect no match
+    1
+    2
+    a
+    \x{3c3}
+
+/[\P{Lu}1]/i,utf,ucp
+    1
+    2
+\= Expect no match
+    a
+    A
+    \x{3a3}
+    \x{3c3}
+
+/[\P{Lu}1]/utf,ucp
+    1
+    2
+    a
+    \x{3c3}
+\= Expect no match
+    A
+    \x{3a3}
+
 # End of testinput4

--- a/testdata/testoutput4
+++ b/testdata/testoutput4
@@ -4662,4 +4662,64 @@ No match
     \N{U+00F1}
  0: \x{f1}
 
+/[^\P{Lu}1]/i,utf,ucp
+    a
+ 0: a
+    A
+ 0: A
+    \x{3a3}
+ 0: \x{3a3}
+    \x{3c3}
+ 0: \x{3c3}
+\= Expect no match
+    1
+No match
+    2
+No match
+
+/[^\P{Lu}1]/utf,ucp
+    A
+ 0: A
+    \x{3a3}
+ 0: \x{3a3}
+\= Expect no match
+    1
+No match
+    2
+No match
+    a
+No match
+    \x{3c3}
+No match
+
+/[\P{Lu}1]/i,utf,ucp
+    1
+ 0: 1
+    2
+ 0: 2
+\= Expect no match
+    a
+No match
+    A
+No match
+    \x{3a3}
+No match
+    \x{3c3}
+No match
+
+/[\P{Lu}1]/utf,ucp
+    1
+ 0: 1
+    2
+ 0: 2
+    a
+ 0: a
+    \x{3c3}
+ 0: \x{3c3}
+\= Expect no match
+    A
+No match
+    \x{3a3}
+No match
+
 # End of testinput4


### PR DESCRIPTION
PCRE2's behaviour matches Perl currently, and Python's regex module (the standard re module doesn't have \P{...}).

However, JavaScript behaviour changed recently (when they added the new 'v' flag; the old 'u' flag's behaviour is unchanged), so this case is worth additional testing.

Raised in issue #497.