### PR TITLE
Fix the -O0 configuration and its warnings

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,7 +21,7 @@ jobs:
         run: ./autogen.sh
 
       - name: Configure
-        run: ./configure CC='gcc -O0 -fsanitize=undefined,address -fsanitize-undefined-trap-on-error' CPPFLAGS='-Wall -Wextra -Werror -Wno-error=unused-but-set-parameter' --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --with-link-size=4
+        run: ./configure CC='gcc' CFLAGS='-O0 -fsanitize=undefined,address -fsanitize-undefined-trap-on-error' CPPFLAGS='-Wall -Wextra -Werror -Wno-error=unused-but-set-parameter' --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --with-link-size=4
 
       - name: Build
         run: make -j3

--- a/src/pcre2_auto_possess.c
+++ b/src/pcre2_auto_possess.c
@@ -1144,6 +1144,7 @@ for(;;)
   }
 
 PCRE2_DEBUG_UNREACHABLE(); /* Control should never reach here */
+return FALSE;              /* Avoid compiler warnings */
 }
 
 

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -7891,6 +7891,7 @@ for (;; pptr++)
   }           /* End of big loop */
 
 PCRE2_DEBUG_UNREACHABLE(); /* Control should never reach here */
+return 0;                  /* Avoid compiler warnings */
 }
 
 
@@ -8197,6 +8198,7 @@ for (;;)
   }
 
 PCRE2_DEBUG_UNREACHABLE(); /* Control should never reach here */
+return 0;                  /* Avoid compiler warnings */
 }
 
 

--- a/src/pcre2_study.c
+++ b/src/pcre2_study.c
@@ -761,6 +761,7 @@ for (;;)
   }
 
 PCRE2_DEBUG_UNREACHABLE(); /* Control should never reach here */
+return -3;                 /* Avoid compiler warnings */
 }
 
 


### PR DESCRIPTION
The CI configuration was using `CC='gcc -O0`. However, this doesn't work! Because CFLAGS was unset, `./configure` would set CFLAGS to `-O2`, resulting in a commandline of `gcc -O0 ... -O2 ...`.

Fixing this reveals that GCC generates additional warnings when in `-O0` mode. Presumably it doesn't do dead-code pruning, and so generates additional areas in provable-unreachable sections of code (which would be pruned in `-O2`).