### PR TITLE
Non-recursive scan prefix in JIT

### DIFF
--- a/src/pcre2_jit_test.c
+++ b/src/pcre2_jit_test.c
@@ -286,6 +286,7 @@ static struct regression_test_case regression_test_cases[] = {
 	{ CMU, A, 0, 0, "(a|b)?\?d((?:e)?)", "ABABdx" },
 	{ MU, A, 0, 0, "(a|b)?\?d((?:e)?)", "abcde" },
 	{ MU, A, 0, 0, "((?:ab)?\?g|b(?:g(nn|d)?\?)?)?\?(?:n)?m", "abgnbgnnbgdnmm" },
+	{ M, A, 0, 0, "(?:a?|a)b", "ba" },
 
 	/* Greedy and non-greedy + operators */
 	{ MU, A, 0, 0, "(aa)+aa", "aaaaaaa" },


### PR DESCRIPTION
The algorithm is rewritten. It should cover more cases and non-recursive.

Testing is difficult though. When it covers cases that it should not, the matching should fail, so that can be tested at some level. However, the opposite, when it does not cover cases, that it should, the effect is just slower matching.

Fixes #558 since it is non-recursive.