### PR TITLE
Add CI job and fix for CMake Unity build

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -226,3 +226,21 @@ jobs:
           cd ..
           perl -v
           maint/RunPerlTest
+
+  chaffinch:
+    name: CMake unity build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Configure
+        run: cmake -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DPCRE2_DEBUG=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
+
+      - name: Build
+        run: cd build && make -j3
+
+      - name: Test
+        run: cd build && make test

--- a/src/pcre2_compile_class.c
+++ b/src/pcre2_compile_class.c
@@ -485,7 +485,7 @@ static const uint32_t char_list_starts[] = {
 };
 
 static class_ranges *
-optimize_class(uint32_t *start_ptr, uint32_t options,
+compile_optimize_class(uint32_t *start_ptr, uint32_t options,
   uint32_t xoptions, compile_block *cb)
 {
 class_ranges* cranges;
@@ -1047,7 +1047,7 @@ if (utf)
   {
   if (lengthptr != NULL)
     {
-    cranges = optimize_class(pptr, options, xoptions, cb);
+    cranges = compile_optimize_class(pptr, options, xoptions, cb);
 
     if (cranges == NULL)
       {

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -197,7 +197,7 @@ Returns:    TRUE if a name was read
 */
 
 static BOOL
-read_name(PCRE2_SPTR *ptrptr, PCRE2_SPTR ptrend, BOOL utf,
+read_name_subst(PCRE2_SPTR *ptrptr, PCRE2_SPTR ptrend, BOOL utf,
     const uint8_t* ctypes)
 {
 PCRE2_SPTR ptr = *ptrptr;
@@ -758,7 +758,7 @@ do
         {
         PCRE2_SIZE name_len;
         PCRE2_SPTR name_start = ptr;
-        if (!read_name(&ptr, repend, utf, code->tables + ctypes_offset))
+        if (!read_name_subst(&ptr, repend, utf, code->tables + ctypes_offset))
           goto BAD;
         name_len = ptr - name_start;
         memcpy(name, name_start, CU2BYTES(name_len));
@@ -1068,7 +1068,7 @@ do
           ++ptr;
 
           name_start = ptr;
-          if (!read_name(&ptr, repend, utf, code->tables + ctypes_offset))
+          if (!read_name_subst(&ptr, repend, utf, code->tables + ctypes_offset))
             goto BADESCAPE;
           name_len = ptr - name_start;
 


### PR DESCRIPTION
In the `maint` directory, Philip says he checks the CMake Unity build before doing a release.

I gave it a go... and it's been broken by recent changes (file-static functions with colliding names: `read_name` and `optimize_class`).