### PR TITLE
Improve coverage of escapes in character classes

### DIFF
--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -541,38 +541,46 @@ For hard partial matching, we immediately return a partial match. Otherwise,
 carrying on means that a complete match on the current subject will be sought.
 A partial match is returned only if no complete match can be found. */
 
-#define CHECK_PARTIAL()\
-  if (Feptr >= mb->end_subject) \
-    { \
-    SCHECK_PARTIAL(); \
-    }
+#define CHECK_PARTIAL() \
+  do { \
+     if (Feptr >= mb->end_subject) \
+       { \
+       SCHECK_PARTIAL(); \
+       } \
+     } \
+  while (0)
 
-#define SCHECK_PARTIAL()\
-  if (mb->partial != 0 && \
-      (Feptr > mb->start_used_ptr || mb->allowemptypartial)) \
-    { \
-    mb->hitend = TRUE; \
-    if (mb->partial > 1) return PCRE2_ERROR_PARTIAL; \
-    }
+#define SCHECK_PARTIAL() \
+  do { \
+     if (mb->partial != 0 && \
+         (Feptr > mb->start_used_ptr || mb->allowemptypartial)) \
+       { \
+       mb->hitend = TRUE; \
+       if (mb->partial > 1) return PCRE2_ERROR_PARTIAL; \
+       } \
+     } \
+  while (0)
 
 
 /* These macros are used to implement backtracking. They simulate a recursive
 call to the match() function by means of a local vector of frames which
 remember the backtracking points. */
 
-#define RMATCH(ra,rb)\
-  {\
-  start_ecode = ra;\
-  Freturn_id = rb;\
-  goto MATCH_RECURSE;\
-  L_##rb:;\
-  }
+#define RMATCH(ra,rb) \
+  do { \
+     start_ecode = ra; \
+     Freturn_id = rb; \
+     goto MATCH_RECURSE; \
+     L_##rb:; \
+     } \
+  while (0)
 
-#define RRETURN(ra)\
-  {\
-  rrc = ra;\
-  goto RETURN_SWITCH;\
-  }
+#define RRETURN(ra) \
+  do { \
+     rrc = ra; \
+     goto RETURN_SWITCH; \
+     } \
+  while (0)
 
 
 

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -7255,4 +7255,35 @@ a)"xI
 
 /[A-\\]/B
 
+/[\A]/
+
+/[\Z]/
+
+/[\z]/
+
+/[\G]/
+
+/[\K]/
+
+/[\g<1>]/
+    <
+    g
+\= Expect no match
+    \\
+
+/[\k<1>]/
+    <
+    k
+\= Expect no match
+    \\
+
+/[\u{ 1z}]/alt_bsux,extra_alt_bsux
+    u
+    {
+    }
+    \x20
+    1
+\= Expect no match
+    \\
+
 # End of testinput2

--- a/testdata/testinput21
+++ b/testdata/testinput21
@@ -13,4 +13,6 @@
 /(?<=ab\Cde)X/
     abZdeX
 
+/[\C]/
+
 # End of testinput21

--- a/testdata/testinput23
+++ b/testdata/testinput23
@@ -4,4 +4,6 @@
 
 /a\Cb/
 
+/a[\C]b/
+
 # End of testinput23

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -20933,6 +20933,54 @@ Failed: error 106 at offset 3: missing terminating ] for character class
         End
 ------------------------------------------------------------------
 
+/[\A]/
+Failed: error 107 at offset 2: escape sequence is invalid in character class
+
+/[\Z]/
+Failed: error 107 at offset 2: escape sequence is invalid in character class
+
+/[\z]/
+Failed: error 107 at offset 2: escape sequence is invalid in character class
+
+/[\G]/
+Failed: error 107 at offset 2: escape sequence is invalid in character class
+
+/[\K]/
+Failed: error 107 at offset 2: escape sequence is invalid in character class
+
+/[\g<1>]/
+    <
+ 0: <
+    g
+ 0: g
+\= Expect no match
+    \\
+No match
+
+/[\k<1>]/
+    <
+ 0: <
+    k
+ 0: k
+\= Expect no match
+    \\
+No match
+
+/[\u{ 1z}]/alt_bsux,extra_alt_bsux
+    u
+ 0: u
+    {
+ 0: {
+    }
+ 0: }
+    \x20
+ 0:  
+    1
+ 0: 1
+\= Expect no match
+    \\
+No match
+
 # End of testinput2
 Error -70: PCRE2_ERROR_BADDATA (unknown error number)
 Error -62: bad serialized data

--- a/testdata/testoutput21
+++ b/testdata/testoutput21
@@ -91,4 +91,7 @@ Subject length lower bound = 5
     abZdeX
  0: X
 
+/[\C]/
+Failed: error 107 at offset 2: escape sequence is invalid in character class
+
 # End of testinput21

--- a/testdata/testoutput23
+++ b/testdata/testoutput23
@@ -5,4 +5,7 @@
 /a\Cb/
 Failed: error 185 at offset 3: using \C is disabled in this PCRE2 library
 
+/a[\C]b/
+Failed: error 107 at offset 3: escape sequence is invalid in character class
+
 # End of testinput23


### PR DESCRIPTION
One switch case in pcre2_compile.c is not covered by any tests (the ERR7 default).

Add tests covering all the possible escapes, and fix a couple that weren't working (ESC_k and ESC_ub).

Also fix some empty statements causing coverage failures in pcre2_match.c.