### PR TITLE
Suppress some minor analysis warnings

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -7285,7 +7285,6 @@ for (;; pptr++)
     single-char opcodes. */
 
     reqvary = (repeat_min == repeat_max)? 0 : REQ_VARY;
-    op_type = 0;
 
     /* Adjust first and required code units for a zero repeat. */
 
@@ -7848,7 +7847,8 @@ for (;; pptr++)
           }
         else
           {
-          /* Come here from just above with a character in mcbuffer/mclength. */
+          /* Come here from just above with a character in mcbuffer/mclength.
+          You must also set op_type before the jump. */
           OUTPUT_SINGLE_REPEAT:
           prop_type = prop_value = -1;
           }

--- a/src/pcre2_compile_class.c
+++ b/src/pcre2_compile_class.c
@@ -245,6 +245,7 @@ while (c <= end)
     buffer[0] = new_start;
     buffer[1] = new_end;
     buffer += 2;
+    (void)buffer;
     }
   return result;
 }
@@ -330,6 +331,7 @@ while (*p != NOTACHAR)
     buffer[0] = start;
     buffer[1] = get_highest_char(options);
     buffer += 2;
+    (void)buffer;
     }
 
   return result;
@@ -745,6 +747,7 @@ for (c = 0; c < 256; c++)
   {
   prop = GET_UCD(c);
   set_bit = FALSE;
+  (void)set_bit;
 
   switch (ptype)
     {

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -3070,7 +3070,7 @@ for (;;)
         if (codevalue == OP_BRAPOSZERO)
           {
           allow_zero = TRUE;
-          codevalue = *(++code);  /* Codevalue will be one of above BRAs */
+          ++code;  /* The following opcode will be one of the above BRAs */
           }
         else allow_zero = FALSE;
 

--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -3059,7 +3059,6 @@ while (ptr < endptr)
         if (group_separator != NULL)
           fprintf(stdout, "%s%s", group_separator, STDOUT_NL);
         hyphenpending = FALSE;
-        hyphenprinted = TRUE;
         }
 
       /* Now print the matching line(s); ensure we set hyphenpending at the end
@@ -3874,8 +3873,12 @@ else
   filename = name;
   }
 
-while ((patlen = sizeof(buffer)) && read_pattern(buffer, &patlen, f))
+while (TRUE)
   {
+  patlen = sizeof(buffer);
+  if (!read_pattern(buffer, &patlen, f))
+    break;
+
   if (!posix_pattern_file)
    {
    while (patlen > 0 && isspace((unsigned char)(buffer[patlen-1]))) patlen--;

--- a/src/pcre2posix.c
+++ b/src/pcre2posix.c
@@ -94,6 +94,7 @@ changed. This #define is a copy of the one in pcre2_internal.h. */
 
 #include "pcre2.h"
 #include "pcre2posix.h"
+#include "pcre2_util.h"
 
 /* Table to translate PCRE2 compile time error codes into POSIX error codes.
 Only a few PCRE2 errors with a value greater than 23 turn into special POSIX
@@ -194,7 +195,7 @@ if (preg != NULL && (int)preg->re_erroffset != -1)
   /* no need to deal with UB in snprintf */
   if (errbuf_size > INT_MAX) errbuf_size = INT_MAX;
 
-  /* there are 11 charactes between message and offset,
+  /* there are 11 characters between message and offset;
      update message_len() if changed */
   ret = snprintf(errbuf, errbuf_size, "%s at offset %d", message,
                  (int)preg->re_erroffset);
@@ -209,6 +210,8 @@ else
     }
   ret = (int)len;
   }
+
+PCRE2_ASSERT(len > 0 || preg != NULL);
 
 do {
   if (ret < 0)


### PR DESCRIPTION
One of these appears in Coverity's dashboard; the rest are from clang-scan.

See #576