### PR TITLE
Update scorecard-V2 PAT, and tweak workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, "release/**" ]
+  pull_request:
+    branches: [ master ]
 
 permissions:
   contents: read

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,8 @@
 name: CIFuzz
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
 
 permissions:
   contents: read

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -1,5 +1,10 @@
 name: Clang Static Analyzer
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, "release/**" ]
+  pull_request:
+    branches: [ master ]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, "release/**" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,5 +1,10 @@
 name: Dev
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, "release/**" ]
+  pull_request:
+    branches: [ master ]
 
 permissions:
   contents: read

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,5 +1,6 @@
 name: Scorecards supply-chain security
 on:
+  workflow_dispatch:
   # Only the default branch is supported.
   branch_protection_rule:
   schedule:
@@ -7,8 +8,7 @@ on:
   push:
     branches: [ master ]
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   analysis:
@@ -18,6 +18,8 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      # Needed to publish the results to Scorecard's service.
+      id-token: write
       actions: read
       contents: read
 
@@ -33,9 +35,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # Read-only PAT token. To create it,
-          # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          # repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Publish the results to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`,


### PR DESCRIPTION
* Adding `workflow_dispatch` to all workflows lets us manually trigger them if needed
* Added `releases/` branch for creating signed tags for future releases
* Updated Scorecard configuration after V2 update