### PR TITLE
Fix null-dereference bug in pcre2_substitute

### DIFF
--- a/doc/html/pcre2api.html
+++ b/doc/html/pcre2api.html
@@ -3808,9 +3808,10 @@ PCRE2_SUBSTITUTE_OVERFLOW_LENGTH changes what happens when the output buffer is
 too small. The default action is to return PCRE2_ERROR_NOMEMORY immediately. If
 this option is set, however, <b>pcre2_substitute()</b> continues to go through
 the motions of matching and substituting (without, of course, writing anything)
-in order to compute the size of buffer that is needed. This value is passed
-back via the <i>outlengthptr</i> variable, with the result of the function still
-being PCRE2_ERROR_NOMEMORY.
+in order to compute the size of buffer that is needed, which will include the
+extra space for the terminating NUL. This value is passed back via the
+<i>outlengthptr</i> variable, with the result of the function still being
+PCRE2_ERROR_NOMEMORY.
 </P>
 <P>
 Passing a buffer size of zero is a permitted way of finding out how much memory
@@ -3944,7 +3945,7 @@ that can be applied to group captures. For example, if group 1 has captured
 <P>
 If either PCRE2_UTF or PCRE2_UCP was set when the pattern was compiled, Unicode
 properties are used for case forcing characters whose code points are greater
-than 127. However, only basic case folding, as determined by the Unicode file
+than 127. However, only simple case folding, as determined by the Unicode file
 <b>CaseFolding.txt</b> is supported. PCRE2 does not support language-specific
 special casing rules such as using different lower case Greek sigmas in the
 middle and ends of words (as defined in the Unicode file

--- a/doc/pcre2.txt
+++ b/doc/pcre2.txt
@@ -3669,9 +3669,9 @@ CREATING A NEW STRING WITH SUBSTITUTIONS
        ORY  immediately.  If  this  option is set, however, pcre2_substitute()
        continues to go through the motions of matching and substituting (with-
        out, of course, writing anything) in  order  to  compute  the  size  of
-       buffer  that  is needed. This value is passed back via the outlengthptr
-       variable, with  the  result  of  the  function  still  being  PCRE2_ER-
-       ROR_NOMEMORY.
+       buffer  that is needed, which will include the extra space for the ter-
+       minating NUL. This value is passed back via the outlengthptr  variable,
+       with the result of the function still being PCRE2_ERROR_NOMEMORY.
 
        Passing  a  buffer  size  of zero is a permitted way of finding out how
        much memory is needed for given substitution. However, this  does  mean
@@ -3798,7 +3798,7 @@ CREATING A NEW STRING WITH SUBSTITUTIONS
 
        If either PCRE2_UTF or PCRE2_UCP was set when the pattern was compiled,
        Unicode  properties  are  used  for  case forcing characters whose code
-       points are greater than 127. However, only basic case folding,  as  de-
+       points are greater than 127. However, only simple case folding, as  de-
        termined  by  the Unicode file CaseFolding.txt is supported. PCRE2 does
        not support language-specific special casing rules such as  using  dif-
        ferent  lower case Greek sigmas in the middle and ends of words (as de-

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -3815,9 +3815,10 @@ PCRE2_SUBSTITUTE_OVERFLOW_LENGTH changes what happens when the output buffer is
 too small. The default action is to return PCRE2_ERROR_NOMEMORY immediately. If
 this option is set, however, \fBpcre2_substitute()\fP continues to go through
 the motions of matching and substituting (without, of course, writing anything)
-in order to compute the size of buffer that is needed. This value is passed
-back via the \fIoutlengthptr\fP variable, with the result of the function still
-being PCRE2_ERROR_NOMEMORY.
+in order to compute the size of buffer that is needed, which will include the
+extra space for the terminating NUL. This value is passed back via the
+\fIoutlengthptr\fP variable, with the result of the function still being
+PCRE2_ERROR_NOMEMORY.
 .P
 Passing a buffer size of zero is a permitted way of finding out how much memory
 is needed for given substitution. However, this does mean that the entire
@@ -3938,7 +3939,7 @@ that can be applied to group captures. For example, if group 1 has captured
 .P
 If either PCRE2_UTF or PCRE2_UCP was set when the pattern was compiled, Unicode
 properties are used for case forcing characters whose code points are greater
-than 127. However, only basic case folding, as determined by the Unicode file
+than 127. However, only simple case folding, as determined by the Unicode file
 \fBCaseFolding.txt\fP is supported. PCRE2 does not support language-specific
 special casing rules such as using different lower case Greek sigmas in the
 middle and ends of words (as defined in the Unicode file

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -943,7 +943,7 @@ do
           GETCHARINCTEST(ch, subptr);
           if (forcecase != 0)
             {
-            if (mcontext->substitute_case_callout)
+            if (mcontext != NULL && mcontext->substitute_case_callout != NULL)
               {
               ch = mcontext->substitute_case_callout(
                 ch,
@@ -1105,7 +1105,7 @@ do
       LITERAL:
       if (forcecase != 0)
         {
-        if (mcontext->substitute_case_callout)
+        if (mcontext != NULL && mcontext->substitute_case_callout != NULL)
           {
           ch = mcontext->substitute_case_callout(
             ch,

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -7500,6 +7500,13 @@ if (pat_patctl.replacement[0] != 0)
     return PR_OK;
     }
 
+  if (pat_patctl.replacement_case[0] != 0 &&
+      (dat_datctl.control & CTL_NULLCONTEXT) != 0)
+    {
+    fprintf(outfile, "** Replacement case callouts are not supported with null_context.\n");
+    return PR_OK;
+    }
+
   if ((dat_datctl.control & CTL_ALLCAPTURES) != 0)
     fprintf(outfile, "** Ignored with replacement text: allcaptures\n");
   }

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4226,6 +4226,37 @@
     apple lemon blackberry
 
 /abc/
+    123abc123\=replace=XYZ
+    123abc123\=replace=[10]XYZ
+\= Expect error
+    123abc123\=replace=[9]XYZ
+    123abc123\=substitute_overflow_length,replace=[9]XYZ
+    123abc123\=substitute_overflow_length,replace=[6]XYZ
+    123abc123\=substitute_overflow_length,replace=[1]XYZ
+    123abc123\=substitute_overflow_length,replace=[0]XYZ
+
+/abc/
+    123abc123\=replace=XY
+    123abc123\=replace=[9]XY
+    123abc123\=replace=[9]XY,substitute_literal
+\= Expect error
+    123abc123\=replace=[8]XY,substitute_overflow_length
+    123abc123\=replace=[8]XY,substitute_overflow_length,substitute_literal
+    123abc123\=replace=[6]XY,substitute_overflow_length
+    123abc123\=replace=[6]XY,substitute_overflow_length,substitute_literal
+    123abc123\=replace=[5]XY,substitute_overflow_length
+    123abc123\=replace=[5]XY,substitute_overflow_length,substitute_literal
+    123abc123\=replace=[4]XY,substitute_overflow_length
+    123abc123\=replace=[4]XY,substitute_overflow_length,substitute_literal
+    123abc123\=replace=[3]XY,substitute_overflow_length
+    123abc123\=replace=[3]XY,substitute_overflow_length,substitute_literal
+    123abc123\=replace=[2]XY,substitute_overflow_length
+    123abc123\=replace=[2]XY,substitute_overflow_length,substitute_literal
+
+/abc/substitute_literal
+    123abc123\=replace=XYZ
+    123abc123\=replace=[10]XYZ
+\= Expect error
     123abc123\=replace=[9]XYZ
     123abc123\=substitute_overflow_length,replace=[9]XYZ
     123abc123\=substitute_overflow_length,replace=[6]XYZ
@@ -4720,7 +4751,7 @@ B)x/alt_verbnames,mark
 
 /abcd/null_context
     abcd\=null_context
-\= Expect error - not allowed together
+\= Expect not allowed together
     abcd\=null_context,find_limits
     abcd\=allusedtext,startchar
 
@@ -6067,6 +6098,8 @@ a)"xI
 
 /abc/replace=\U$0,substitute_extended,substitute_case_callout=a.U.b.V.
     XabcY
+\= Expect not supported
+    XabcY\=null_context
 
 /a/substitute_extended
     XaY\=replace=\U$0,substitute_case_callout=a.U.

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13907,6 +13907,61 @@ Failed: error -48: no more memory: 23 code units are needed
  1: fruit\x00juice lemon blackberry
 
 /abc/
+    123abc123\=replace=XYZ
+ 1: 123XYZ123
+    123abc123\=replace=[10]XYZ
+ 1: 123XYZ123
+\= Expect error
+    123abc123\=replace=[9]XYZ
+Failed: error -48: no more memory
+    123abc123\=substitute_overflow_length,replace=[9]XYZ
+Failed: error -48: no more memory: 10 code units are needed
+    123abc123\=substitute_overflow_length,replace=[6]XYZ
+Failed: error -48: no more memory: 10 code units are needed
+    123abc123\=substitute_overflow_length,replace=[1]XYZ
+Failed: error -48: no more memory: 10 code units are needed
+    123abc123\=substitute_overflow_length,replace=[0]XYZ
+Failed: error -48: no more memory: 10 code units are needed
+
+/abc/
+    123abc123\=replace=XY
+ 1: 123XY123
+    123abc123\=replace=[9]XY
+ 1: 123XY123
+    123abc123\=replace=[9]XY,substitute_literal
+ 1: 123XY123
+\= Expect error
+    123abc123\=replace=[8]XY,substitute_overflow_length
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[8]XY,substitute_overflow_length,substitute_literal
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[6]XY,substitute_overflow_length
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[6]XY,substitute_overflow_length,substitute_literal
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[5]XY,substitute_overflow_length
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[5]XY,substitute_overflow_length,substitute_literal
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[4]XY,substitute_overflow_length
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[4]XY,substitute_overflow_length,substitute_literal
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[3]XY,substitute_overflow_length
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[3]XY,substitute_overflow_length,substitute_literal
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[2]XY,substitute_overflow_length
+Failed: error -48: no more memory: 9 code units are needed
+    123abc123\=replace=[2]XY,substitute_overflow_length,substitute_literal
+Failed: error -48: no more memory: 9 code units are needed
+
+/abc/substitute_literal
+    123abc123\=replace=XYZ
+ 1: 123XYZ123
+    123abc123\=replace=[10]XYZ
+ 1: 123XYZ123
+\= Expect error
     123abc123\=replace=[9]XYZ
 Failed: error -48: no more memory
     123abc123\=substitute_overflow_length,replace=[9]XYZ
@@ -15154,7 +15209,7 @@ No match
 /abcd/null_context
     abcd\=null_context
  0: abcd
-\= Expect error - not allowed together
+\= Expect not allowed together
     abcd\=null_context,find_limits
 ** Not allowed together: find_limits null_context
     abcd\=allusedtext,startchar
@@ -18088,6 +18143,9 @@ Failed: error -55 at offset 3 in replacement: requested value is not set
 /abc/replace=\U$0,substitute_extended,substitute_case_callout=a.U.b.V.
     XabcY
  1: XUVcY
+\= Expect not supported
+    XabcY\=null_context
+** Replacement case callouts are not supported with null_context.
 
 /a/substitute_extended
     XaY\=replace=\U$0,substitute_case_callout=a.U.


### PR DESCRIPTION
Avoid one crash introduced with recent changes to substitute code as well as clarify what the expected offset value should be when overflowing the provided buffer.