### PR TITLE
Add Solaris and FreeBSD to our CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
         run: ./autogen.sh
 
       - name: Build & test
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@debf37ca7b7fa40e19c542ef7ba30d6054a706a4 # v1.1.5
         with:
           usesh: true
           run: |
@@ -156,7 +156,7 @@ jobs:
         run: ./autogen.sh
 
       - name: Build & test
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@a89b9438868c70db27e41625f0a5de6ff5e90809 # v1.1.0
         with:
           usesh: true
           prepare: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
   freebsd:
     name: FreeBSD
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request"
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -145,12 +145,20 @@ jobs:
   solaris:
     name: Solaris
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request"
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+
+      - name: Transfer Oracle Studio certificates
+        env:
+          PKG_ORACLE_COM_CERTIFICATE_PEM: ${{ secrets.PKG_ORACLE_COM_CERTIFICATE_PEM }}
+          PKG_ORACLE_COM_KEY_PEM: ${{ secrets.PKG_ORACLE_COM_KEY_PEM }}
+        run: |
+          printenv PKG_ORACLE_COM_CERTIFICATE_PEM > pkg.oracle.com.certificate.pem
+          printenv PKG_ORACLE_COM_KEY_PEM > pkg.oracle.com.key.pem
 
       - name: Prepare
         run: ./autogen.sh
@@ -159,14 +167,30 @@ jobs:
         uses: vmactions/solaris-vm@a89b9438868c70db27e41625f0a5de6ff5e90809 # v1.1.0
         with:
           usesh: true
+          # Seriously! Solaris is the only OS to actually ship without a C
+          # compiler, and not even to provide a simple download to get one!
+          # You have to actually register with Oracle to get an X.509
+          # certificate before you can even download their compiler. Whatever.
           prepare: |
-            pkg install developer/gcc system/header
+            cp "$GITHUB_WORKSPACE/pkg.oracle.com.key.pem" /root/pkg.oracle.com.key.pem
+            cp "$GITHUB_WORKSPACE/pkg.oracle.com.certificate.pem" /root/pkg.oracle.com.certificate.pem
+            sudo pkg set-publisher \
+              -k /root/pkg.oracle.com.key.pem \
+              -c /root/pkg.oracle.com.certificate.pem \
+              -G "*" -g https://pkg.oracle.com/solarisstudio/release solarisstudio
+            pkg install developer/build/make system/header
+            pkg install --accept developerstudio-126/cc
 
           run: |
             set -e
+            PATH=/opt/developerstudio12.6/bin:"$PATH"
+            export PATH
+            CC=cc
+            export CC
+
             ./configure --enable-jit --enable-pcre2-16 --enable-pcre2-32
-            gmake -j3 CPPFLAGS='-Wall -Wextra -Werror'
-            gmake check
+            make CPPFLAGS='-Wall -Wextra -Werror'
+            make check
 
   coverage:
     name: Code coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,55 @@ jobs:
       - name: Test
         run: cd build && ctest -C Release -j3 --output-on-failure
 
+  freebsd:
+    name: FreeBSD
+    runs-on: ubuntu-latest
+    if: github.event_name != "pull_request"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Prepare
+        run: ./autogen.sh
+
+      - name: Build & test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          run: |
+            set -e
+            ./configure --enable-jit --enable-pcre2-16 --enable-pcre2-32
+            make -j3 CPPFLAGS='-Wall -Wextra -Werror'
+            make check
+
+  solaris:
+    name: Solaris
+    runs-on: ubuntu-latest
+    if: github.event_name != "pull_request"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Prepare
+        run: ./autogen.sh
+
+      - name: Build & test
+        uses: vmactions/solaris-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install developer/gcc system/header
+
+          run: |
+            set -e
+            ./configure --enable-jit --enable-pcre2-16 --enable-pcre2-32
+            gmake -j3 CPPFLAGS='-Wall -Wextra -Werror'
+            gmake check
+
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
These are only run after a PR is merged, not every time you push to a PR.

They use a third-party GitHub Action that starts up a VM using Qemu.

The Solaris one is cheating a little - I'm using GCC rather than Oracle Developer Studio's `cc` compiler, because that's a real pain to install. On the other hand, most people probably use GCC on Solaris now anyway, so maybe it is a fair test of whether our Solaris support is OK.