### PR TITLE
Add Codecov.io integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload report to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e # v5.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,9 +175,17 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload report
+      - name: Upload report to GitHub artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: "Coverage report"
           path: './build/coverage-report'
           if-no-files-found: error
+
+      - name: Upload report to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          disable_search: true
+          files: ./build/coverage-lcov.info


### PR DESCRIPTION
This will help us with issue #601 

I don't know how good the Codecov.io service is. Let's just give it a go, and see if it helps us at all.

In theory, it should be able to tell us how well-covered by tests our code is, specific to each PR.