### PR TITLE
Add Bazel build to CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,0 @@
-common --experimental_enable_bzlmod
-build --incompatible_enable_cc_toolchain_resolution
-build --incompatible_strict_action_env

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -277,11 +277,7 @@ jobs:
   bazel:
     # Tests with: Bazel build system
     name: Bazel
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -279,22 +279,13 @@ jobs:
     name: Bazel
     runs-on: ubuntu-latest
     steps:
-      - name: Setup
-        run: |
-          sudo apt-get -qq install apt-transport-https curl gnupg -y
-          curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
-          sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-
-          sudo apt-get -qq update && sudo apt-get -qq install bazel
-
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
 
       - name: Build
-        run: bazel build :all
+        run: bazelisk build :all
 
       - name: Test
         run: srcdir=`pwd` pcre2test=`pwd`/bazel-bin/pcre2test ./RunTest

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -277,7 +277,11 @@ jobs:
   bazel:
     # Tests with: Bazel build system
     name: Bazel
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -285,10 +289,10 @@ jobs:
           submodules: true
 
       - name: Build
-        run: bazelisk build :all
+        run: bazelisk build //...
 
       - name: Test
-        run: srcdir=`pwd` pcre2test=`pwd`/bazel-bin/pcre2test ./RunTest
+        run: bazelisk test //... --test_output=all
 
   heron:
     # Job to verify that the tasks performed by PrepareRelease have been done. It is

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -210,8 +210,8 @@ jobs:
     steps:
       - name: Setup
         run: |
-          sudo apt-get update
-          sudo apt-get install -y valgrind
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y valgrind
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -273,6 +273,31 @@ jobs:
 
       - name: Test
         run: cd build && ctest -j3 --output-on-failure
+
+  bazel:
+    # Tests with: Bazel build system
+    name: Bazel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: |
+          sudo apt-get -qq install apt-transport-https curl gnupg -y
+          curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
+          sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+
+          sudo apt-get -qq update && sudo apt-get -qq install bazel
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Build
+        run: bazel build :all
+
+      - name: Test
+        run: srcdir=`pwd` pcre2test=`pwd`/bazel-bin/pcre2test ./RunTest
 
   heron:
     # Job to verify that the tasks performed by PrepareRelease have been done. It is

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -285,10 +285,10 @@ jobs:
           submodules: true
 
       - name: Build
-        run: bazelisk build //...
+        run: bazelisk build //... --incompatible_strict_action_env
 
       - name: Test
-        run: bazelisk test //... --test_output=all
+        run: bazelisk test //... --incompatible_strict_action_env --test_output=all
 
   heron:
     # Job to verify that the tasks performed by PrepareRelease have been done. It is

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -277,7 +277,12 @@ jobs:
   bazel:
     # Tests with: Bazel build system
     name: Bazel
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+    runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -285,10 +290,10 @@ jobs:
           submodules: true
 
       - name: Build
-        run: bazelisk build //... --incompatible_strict_action_env
+        run: bazelisk build //... --enable_runfiles --incompatible_strict_action_env
 
       - name: Test
-        run: bazelisk test //... --incompatible_strict_action_env --test_output=all
+        run: bazelisk test //... --enable_runfiles --incompatible_strict_action_env --test_output=all
 
   heron:
     # Job to verify that the tasks performed by PrepareRelease have been done. It is

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ src/pcre2_chartables.c
 src/stamp-h1
 
 /bazel-*
+*.bazel.lock
 
 zig-out/
 zig-cache/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@ cc_library(
         "src/pcre2_error.c",
         "src/pcre2_extuni.c",
         "src/pcre2_find_bracket.c",
+        "src/pcre2_jit_compile.c",
         "src/pcre2_maketables.c",
         "src/pcre2_match.c",
         "src/pcre2_match_data.c",
@@ -53,24 +54,95 @@ cc_library(
         "src/pcre2_valid_utf.c",
         "src/pcre2_xclass.c",
         ":pcre2_chartables_c",
-    ],
-    hdrs = glob(["src/*.h"]) + [
+        "src/pcre2_compile.h",
+        "src/pcre2_internal.h",
+        "src/pcre2_intmodedep.h",
+        "src/pcre2_ucp.h",
+        "src/pcre2_util.h",
         ":config_h_generic",
+    ],
+    textual_hdrs = [
+        "src/pcre2_jit_match.c",
+        "src/pcre2_jit_misc.c",
+        "src/pcre2_ucptables.c",
+    ],
+    hdrs = [
         ":pcre2_h_generic",
     ],
     defines = [
         "HAVE_CONFIG_H",
+        "HAVE_MEMMOVE",
         "PCRE2_CODE_UNIT_WIDTH=8",
         "PCRE2_STATIC",
+        "SUPPORT_UNICODE",
     ],
     includes = ["src"],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
 )
 
-cc_binary(
-    name = "pcre2demo",
-    srcs = ["src/pcre2demo.c"],
+cc_library(
+    name = "pcre2-posix",
+    srcs = [
+        "src/pcre2posix.c",
+        ":config_h_generic",
+    ],
+    hdrs = [
+        "src/pcre2posix.h",
+    ],
+    defines = [
+        "HAVE_CONFIG_H",
+        "HAVE_MEMMOVE",
+        "PCRE2_CODE_UNIT_WIDTH=8",
+        "PCRE2_STATIC",
+        "SUPPORT_UNICODE",
+    ],
+    includes = ["src"],
+    strip_include_prefix = "src",
     visibility = ["//visibility:public"],
-    deps = [":pcre2"],
+    deps = [":pcre2"]
+)
+
+# Totally weird issue in Bazel. It won't let you #include any files unless they
+# are declared to the build system. OK, fair enough. But - for a cc_binary it
+# uses the file extension to determine whether it's a header or a compilation
+# unit. But... we have several .c files which are #included, rather than treated
+# as a compilation unit.
+#
+# For cc_library() above, we can overcome this with textual_hdrs. But that
+# doesn't work for cc_binary(). Here's our workaround.
+#
+# https://github.com/bazelbuild/bazel/issues/680
+cc_library(
+    name = "pcre2test_dotc_headers",
+    hdrs = [
+        "src/pcre2_chkdint.c",
+        "src/pcre2_printint.c",
+        "src/pcre2_tables.c",
+        "src/pcre2_ucd.c",
+        "src/pcre2_valid_utf.c",
+    ],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:private"],
+)
+
+cc_binary(
+    name = "pcre2test",
+    srcs = [
+        "src/pcre2test.c",
+        ":config_h_generic",
+    ],
+    defines = [
+        "HAVE_CONFIG_H",
+        "HAVE_MEMMOVE",
+        "HAVE_STRERROR",
+        "PCRE2_STATIC",
+        "SUPPORT_UNICODE",
+        "SUPPORT_PCRE2_8",
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["HAVE_UNISTD_H"]
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":pcre2test_dotc_headers", ":pcre2", ":pcre2-posix"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 copy_file(
     name = "config_h_generic",
@@ -100,7 +100,7 @@ cc_library(
     includes = ["src"],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
-    deps = [":pcre2"]
+    deps = [":pcre2"],
 )
 
 # Totally weird issue in Bazel. It won't let you #include any files unless they
@@ -141,8 +141,35 @@ cc_binary(
         "SUPPORT_PCRE2_8",
     ] + select({
         "@platforms//os:windows": [],
-        "//conditions:default": ["HAVE_UNISTD_H"]
+        "//conditions:default": ["HAVE_UNISTD_H"],
     }),
     visibility = ["//visibility:public"],
     deps = [":pcre2test_dotc_headers", ":pcre2", ":pcre2-posix"],
+)
+
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/*"]),
+)
+
+sh_test(
+    name = "test_posix",
+    srcs = ["RunTest"],
+    data = [":pcre2test", ":testdata"],
+    env = {"pcre2test": "$(location :pcre2test)"},
+    target_compatible_with = select({
+        "//conditions:default": [],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+    }),
+)
+
+sh_test(
+    name = "test_windows",
+    srcs = ["RunTest.bat"],
+    data = [":pcre2test", ":testdata"],
+    env = {"pcre2test": "$(location :pcre2test)"},
+    target_compatible_with = select({
+        "//conditions:default": ["@platforms//:incompatible"],
+        "@platforms//os:windows": [],
+    }),
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -159,17 +159,8 @@ sh_test(
     env = {"pcre2test": "$(location :pcre2test)"},
     target_compatible_with = select({
         "//conditions:default": [],
+        # cannot use sh_test on windows
+        # https://github.com/bazelbuild/bazel/issues/20345
         "@platforms//os:windows": ["@platforms//:incompatible"],
-    }),
-)
-
-sh_test(
-    name = "test_windows",
-    srcs = ["RunTest.bat"],
-    data = [":pcre2test", ":testdata"],
-    env = {"pcre2test": "$(location :pcre2test)"},
-    target_compatible_with = select({
-        "//conditions:default": ["@platforms//:incompatible"],
-        "@platforms//os:windows": [],
     }),
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:native_binary.bzl", "native_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 copy_file(
@@ -143,6 +144,10 @@ cc_binary(
         "@platforms//os:windows": [],
         "//conditions:default": ["HAVE_UNISTD_H"],
     }),
+    linkopts = select({
+        "@platforms//os:windows": ["-STACK:2500000"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [":pcre2test_dotc_headers", ":pcre2", ":pcre2-posix"],
 )
@@ -152,16 +157,16 @@ filegroup(
     srcs = glob(["testdata/*"]),
 )
 
-sh_test(
-    name = "test_posix",
-    srcs = ["RunTest"],
-    data = [":pcre2test", ":testdata"],
-    env = {"pcre2test": "$(location :pcre2test)"},
-    size = "small",
-    target_compatible_with = select({
-        "//conditions:default": [],
-        # cannot use sh_test on windows
-        # https://github.com/bazelbuild/bazel/issues/20345
-        "@platforms//os:windows": ["@platforms//:incompatible"],
+native_test(
+    name = "pcre2_test",
+    src = select({
+        "@platforms//os:windows": "RunTest.bat",
+        "//conditions:default": "RunTest",
     }),
+    out = select({
+        "@platforms//os:windows": "RunTest.bat",
+        "//conditions:default": "RunTest",
+    }),
+    data = [":pcre2test", ":testdata"],
+    size = "small",
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,6 +157,7 @@ sh_test(
     srcs = ["RunTest"],
     data = [":pcre2test", ":testdata"],
     env = {"pcre2test": "$(location :pcre2test)"},
+    size = "small",
     target_compatible_with = select({
         "//conditions:default": [],
         # cannot use sh_test on windows

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -69,7 +69,7 @@ cc_library(
     hdrs = [
         ":pcre2_h_generic",
     ],
-    defines = [
+    local_defines = [
         "HAVE_CONFIG_H",
         "HAVE_MEMMOVE",
         "PCRE2_CODE_UNIT_WIDTH=8",
@@ -90,7 +90,7 @@ cc_library(
     hdrs = [
         "src/pcre2posix.h",
     ],
-    defines = [
+    local_defines = [
         "HAVE_CONFIG_H",
         "HAVE_MEMMOVE",
         "PCRE2_CODE_UNIT_WIDTH=8",
@@ -132,7 +132,7 @@ cc_binary(
         "src/pcre2test.c",
         ":config_h_generic",
     ],
-    defines = [
+    local_defines = [
         "HAVE_CONFIG_H",
         "HAVE_MEMMOVE",
         "HAVE_STRERROR",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,3 +6,4 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.1")
 bazel_dep(name = "bazel_skylib", version = "1.2.1")
+bazel_dep(name = "platforms", version = "0.0.4")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "pcre2",
-    version = "10.40",
+    version = "10.45-DEV",
     compatibility_level = 1,
 )
 

--- a/RunTest.bat
+++ b/RunTest.bat
@@ -39,7 +39,7 @@ if exist ..\testdata\ set srcdir=..)
 if [%srcdir%]==[] (
 if exist ..\..\testdata\ set srcdir=..\..)
 if NOT exist %srcdir%\testdata\ (
-Error: echo distribution testdata folder not found!
+echo Error: distribution testdata folder not found!
 call :conferror
 exit /b 1
 goto :eof


### PR DESCRIPTION
I know absolutely no Bazel!

The existing Bazel build isn't implementing any of the Autoconf/CMake at all - not testing for header files, or setting any of the platform-specific macros.

That seems... less than ideal. But anyway, if users really want to use Bazel, then can do so. But perhaps the Bazel file should instead shell out to a "proper" build system like CMake, if that's what is required for actually performing system-specific configuration?

I have attempted to update the Bazel file the minimal amount that enables us to at least run the unit tests, and confirm that the build was successful.