### PR TITLE
Add maint scripts for checking and updating library version & updated dates

### DIFF
--- a/maint/PrepareRelease
+++ b/maint/PrepareRelease
@@ -34,6 +34,12 @@
 # "HYPHEN" if the system is using a UTF-8 locale (like "C.UTF-8").
 export LANG=C
 
+# Extract the current release version from configure.ac.
+CURRENT_RELEASE=`grep -E 'm4_define\(pcre2_(major|minor|prerelease)' configure.ac | \
+    grep -E -o '\[.*\]' | \
+    sed -E -e '1s/$/./' | \
+    tr -d '[]\n'`
+
 # First, sort out the documentation. Remove pcre2demo.3 first because it won't
 # pass the markup check (it is created below, using markup that none of the
 # other pages use).
@@ -47,6 +53,15 @@ echo Processing documentation
 
 perl ../maint/CheckMan *.1 *.3
 if [ $? != 0 ] ; then exit 1; fi
+
+# Verify the version number in the man pages
+
+for file in *.1 *.3 ; do
+  if ! grep -E ".TH.*\"PCRE2 $CURRENT_RELEASE\"" "$file" >/dev/null ; then
+    echo "Version number in $file does not match current release"
+    exit 1
+  fi
+done
 
 # Make Text form of the documentation. It needs some mangling to make it
 # tidy for online reading. Concatenate all the .3 stuff, but omit the
@@ -292,6 +307,12 @@ echo Validating all text
 perl maint/CheckTxt "${files[@]}"
 perl maint/CheckTxt -ascii "${c_files[@]}"
 perl maint/CheckTxt -crlf "${crlf_files[@]}"
+
+# Verify the version number in the Bazel file
+if ! grep -E "version = \"$CURRENT_RELEASE\"" MODULE.bazel >/dev/null ; then
+  echo "Version number in MODULE.bazel does not match current release"
+  exit 1
+fi
 
 echo Done
 

--- a/maint/UpdateCommon.py
+++ b/maint/UpdateCommon.py
@@ -1,0 +1,28 @@
+# Common helpers for UpdateRelease.py and UpdateDates.py.
+
+import re
+
+def get_current_release():
+    with open('configure.ac', 'r') as file:
+        content = file.read()
+
+    matches = [match[1] for match in re.findall(r"m4_define\(pcre2_(major|minor|prerelease), \[(.*?)\]\)", content)]
+    current_release = '%s.%s%s' % tuple(matches)
+
+    return current_release
+
+CURRENT_RELEASE = get_current_release()
+
+# Update a file, using a pattern. Verify that it matches the file, and perform
+# the replacement.
+def update_file(filename, pattern, replacement):
+    with open(filename, 'r') as file:
+        content = file.read()
+
+    if not re.search(pattern, content):
+        raise Exception('Pattern not found in %s' % filename)
+
+    content = re.sub(pattern, replacement, content)
+
+    with open(filename, 'w') as file:
+        file.write(content)

--- a/maint/UpdateDates.py
+++ b/maint/UpdateDates.py
@@ -1,0 +1,57 @@
+#! /usr/bin/env python3
+
+# Script to update all the hardcoded dates in the source tree.
+#  - Documentation manpages have a "last updated" header and footer.
+#  - So do the READMEs.
+#  - The source files have copyright headers.
+
+# This script should be run in the main PCRE2 directory.
+
+import glob
+import re
+import subprocess
+
+from UpdateCommon import update_file
+
+date_regex = r'\d+ (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w* \d+'
+header_regex = r'(?m)^(.TH.*? )"%s"' % date_regex
+last_updated_regex = r'(?m)^Last updated: %s' % date_regex
+
+def get_last_date(filename):
+    result = subprocess.run(['git', 'log', '-n1', '--date=format:%d %B %Y', '--format=%cd', '--grep', '#noupdate', '--invert-grep', filename], capture_output=True, text=True)
+    return result.stdout.strip()
+
+def check_no_match(filename, pattern):
+    with open(filename, 'r') as file:
+        content = file.read()
+
+    if re.search(pattern, content):
+        raise Exception('Pattern unexpectedly found in %s' % filename)
+
+def update_man_date(filename):
+    print('  Updating %s' % filename)
+    file_date = get_last_date(filename)
+
+    update_file(filename, header_regex, '\\1"%s"' % file_date)
+
+    if filename.startswith('doc/pcre2_') or filename == 'doc/pcre2demo.3':
+        check_no_match(filename, last_updated_regex)
+    else:
+        update_file(filename, last_updated_regex, 'Last updated: %s' % file_date)
+
+print('Updating man pages')
+
+# doc/*.1
+for filename in glob.glob('doc/*.1'):
+    update_man_date(filename)
+
+# doc/*.3
+for filename in glob.glob('doc/*.3'):
+    update_man_date(filename)
+
+# README, NON-AUTOTOOLS-BUILD
+print('Updating README and NON-AUTOTOOLS-BUILD')
+for filename in ['README', 'NON-AUTOTOOLS-BUILD']:
+    line = 'Last updated: %s' % get_last_date(filename)
+    padding = '=' * len(line)
+    update_file(filename, r'(?i)=+\nLast updated: .*?\n=+', '%s\n%s\n%s' % (padding, line, padding))

--- a/maint/UpdateRelease.py
+++ b/maint/UpdateRelease.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python3
+
+# Script to update all the hardcoded release numbers in the source tree.
+#  - Documentation manpages.
+#  - Bazel MODULE file.
+
+# This script should be run in the main PCRE2 directory.
+
+import glob
+
+from UpdateCommon import update_file, CURRENT_RELEASE
+
+def update_man_version(filename):
+    print('  Updating %s' % filename)
+    update_file(filename, r'(.TH.*? )"PCRE2 .*?"', '\\1"PCRE2 %s"' % CURRENT_RELEASE)
+
+print('Updating man pages')
+
+# doc/*.1
+for filename in glob.glob('doc/*.1'):
+    update_man_version(filename)
+
+# doc/*.3
+for filename in glob.glob('doc/*.3'):
+    update_man_version(filename)
+
+# MODULE.bazel
+print('Updating MODULE.bazel')
+update_file('MODULE.bazel', r'(?m)^    version = ".*?"', '    version = "%s"' % CURRENT_RELEASE)


### PR DESCRIPTION
The workflow shall be:
* When the release number is bumped, all references to that release number need to be bumped immediately. (For example, when the source code moves from 10.45 → 10.46, the man pages must do so as well.)
* When documentation is updated, there's no need to update the "last modified" dates by hand. We can sweep those all up during the release process. Or update them immediately - there's no harm in it; we simply aren't obliged to.