### PR TITLE
Update libtool version for 10.45

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,10 +14,10 @@ m4_define(pcre2_prerelease, [-DEV])
 m4_define(pcre2_date, [2024-06-09])
 
 # Libtool shared library interface versions (current:revision:age)
-m4_define(libpcre2_8_version,     [13:0:13])
-m4_define(libpcre2_16_version,    [13:0:13])
-m4_define(libpcre2_32_version,    [13:0:13])
-m4_define(libpcre2_posix_version, [3:5:0])
+m4_define(libpcre2_8_version,     [14:0:14])
+m4_define(libpcre2_16_version,    [14:0:14])
+m4_define(libpcre2_32_version,    [14:0:14])
+m4_define(libpcre2_posix_version, [3:6:0])
 
 # NOTE: The CMakeLists.txt file searches for the above variables in the first
 # 50 lines of this file. Please update that if the variables above are moved.

--- a/maint/manifest-cmakeinstall-linux
+++ b/maint/manifest-cmakeinstall-linux
@@ -13,20 +13,20 @@ drwxr-xr-x install-dir/lib/cmake/pcre2
 -rw-r--r-- install-dir/lib/cmake/pcre2/pcre2-config.cmake
 -rw-r--r-- install-dir/lib/libpcre2-16.a
 lrwxrwxrwx install-dir/lib/libpcre2-16.so -> libpcre2-16.so.0
-lrwxrwxrwx install-dir/lib/libpcre2-16.so.0 -> libpcre2-16.so.0.13.0
--rw-r--r-- install-dir/lib/libpcre2-16.so.0.13.0
+lrwxrwxrwx install-dir/lib/libpcre2-16.so.0 -> libpcre2-16.so.0.14.0
+-rw-r--r-- install-dir/lib/libpcre2-16.so.0.14.0
 -rw-r--r-- install-dir/lib/libpcre2-32.a
 lrwxrwxrwx install-dir/lib/libpcre2-32.so -> libpcre2-32.so.0
-lrwxrwxrwx install-dir/lib/libpcre2-32.so.0 -> libpcre2-32.so.0.13.0
--rw-r--r-- install-dir/lib/libpcre2-32.so.0.13.0
+lrwxrwxrwx install-dir/lib/libpcre2-32.so.0 -> libpcre2-32.so.0.14.0
+-rw-r--r-- install-dir/lib/libpcre2-32.so.0.14.0
 -rw-r--r-- install-dir/lib/libpcre2-8.a
 lrwxrwxrwx install-dir/lib/libpcre2-8.so -> libpcre2-8.so.0
-lrwxrwxrwx install-dir/lib/libpcre2-8.so.0 -> libpcre2-8.so.0.13.0
--rw-r--r-- install-dir/lib/libpcre2-8.so.0.13.0
+lrwxrwxrwx install-dir/lib/libpcre2-8.so.0 -> libpcre2-8.so.0.14.0
+-rw-r--r-- install-dir/lib/libpcre2-8.so.0.14.0
 -rw-r--r-- install-dir/lib/libpcre2-posix.a
 lrwxrwxrwx install-dir/lib/libpcre2-posix.so -> libpcre2-posix.so.3
-lrwxrwxrwx install-dir/lib/libpcre2-posix.so.3 -> libpcre2-posix.so.3.0.5
--rw-r--r-- install-dir/lib/libpcre2-posix.so.3.0.5
+lrwxrwxrwx install-dir/lib/libpcre2-posix.so.3 -> libpcre2-posix.so.3.0.6
+-rw-r--r-- install-dir/lib/libpcre2-posix.so.3.0.6
 drwxr-xr-x install-dir/lib/pkgconfig
 -rw-r--r-- install-dir/lib/pkgconfig/libpcre2-16.pc
 -rw-r--r-- install-dir/lib/pkgconfig/libpcre2-32.pc

--- a/maint/manifest-cmakeinstall-macos
+++ b/maint/manifest-cmakeinstall-macos
@@ -11,20 +11,20 @@ drwxr-xr-x install-dir/lib/cmake
 drwxr-xr-x install-dir/lib/cmake/pcre2
 -rw-r--r-- install-dir/lib/cmake/pcre2/pcre2-config-version.cmake
 -rw-r--r-- install-dir/lib/cmake/pcre2/pcre2-config.cmake
--rwxr-xr-x install-dir/lib/libpcre2-16.0.13.0.dylib
-lrwxr-xr-x install-dir/lib/libpcre2-16.0.dylib -> libpcre2-16.0.13.0.dylib
+-rwxr-xr-x install-dir/lib/libpcre2-16.0.14.0.dylib
+lrwxr-xr-x install-dir/lib/libpcre2-16.0.dylib -> libpcre2-16.0.14.0.dylib
 -rw-r--r-- install-dir/lib/libpcre2-16.a
 lrwxr-xr-x install-dir/lib/libpcre2-16.dylib -> libpcre2-16.0.dylib
--rwxr-xr-x install-dir/lib/libpcre2-32.0.13.0.dylib
-lrwxr-xr-x install-dir/lib/libpcre2-32.0.dylib -> libpcre2-32.0.13.0.dylib
+-rwxr-xr-x install-dir/lib/libpcre2-32.0.14.0.dylib
+lrwxr-xr-x install-dir/lib/libpcre2-32.0.dylib -> libpcre2-32.0.14.0.dylib
 -rw-r--r-- install-dir/lib/libpcre2-32.a
 lrwxr-xr-x install-dir/lib/libpcre2-32.dylib -> libpcre2-32.0.dylib
--rwxr-xr-x install-dir/lib/libpcre2-8.0.13.0.dylib
-lrwxr-xr-x install-dir/lib/libpcre2-8.0.dylib -> libpcre2-8.0.13.0.dylib
+-rwxr-xr-x install-dir/lib/libpcre2-8.0.14.0.dylib
+lrwxr-xr-x install-dir/lib/libpcre2-8.0.dylib -> libpcre2-8.0.14.0.dylib
 -rw-r--r-- install-dir/lib/libpcre2-8.a
 lrwxr-xr-x install-dir/lib/libpcre2-8.dylib -> libpcre2-8.0.dylib
--rwxr-xr-x install-dir/lib/libpcre2-posix.3.0.5.dylib
-lrwxr-xr-x install-dir/lib/libpcre2-posix.3.dylib -> libpcre2-posix.3.0.5.dylib
+-rwxr-xr-x install-dir/lib/libpcre2-posix.3.0.6.dylib
+lrwxr-xr-x install-dir/lib/libpcre2-posix.3.dylib -> libpcre2-posix.3.0.6.dylib
 -rw-r--r-- install-dir/lib/libpcre2-posix.a
 lrwxr-xr-x install-dir/lib/libpcre2-posix.dylib -> libpcre2-posix.3.dylib
 drwxr-xr-x install-dir/lib/pkgconfig

--- a/maint/manifest-makeinstall-freebsd
+++ b/maint/manifest-makeinstall-freebsd
@@ -11,24 +11,24 @@ drwxr-xr-x install-dir/usr/local/include
 drwxr-xr-x install-dir/usr/local/lib
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-16.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-16.la
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so -> libpcre2-16.so.0.13.0
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so.0 -> libpcre2-16.so.0.13.0
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so.0.13.0
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so -> libpcre2-16.so.0.14.0
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so.0 -> libpcre2-16.so.0.14.0
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so.0.14.0
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-32.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-32.la
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so -> libpcre2-32.so.0.13.0
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so.0 -> libpcre2-32.so.0.13.0
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so.0.13.0
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so -> libpcre2-32.so.0.14.0
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so.0 -> libpcre2-32.so.0.14.0
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so.0.14.0
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-8.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-8.la
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so -> libpcre2-8.so.0.13.0
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so.0 -> libpcre2-8.so.0.13.0
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so.0.13.0
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so -> libpcre2-8.so.0.14.0
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so.0 -> libpcre2-8.so.0.14.0
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so.0.14.0
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-posix.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.la
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so -> libpcre2-posix.so.3.0.5
-lrwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so.3 -> libpcre2-posix.so.3.0.5
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so.3.0.5
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so -> libpcre2-posix.so.3.0.6
+lrwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so.3 -> libpcre2-posix.so.3.0.6
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so.3.0.6
 drwxr-xr-x install-dir/usr/local/lib/pkgconfig
 -rw-r--r-- install-dir/usr/local/lib/pkgconfig/libpcre2-16.pc
 -rw-r--r-- install-dir/usr/local/lib/pkgconfig/libpcre2-32.pc

--- a/maint/manifest-makeinstall-linux
+++ b/maint/manifest-makeinstall-linux
@@ -11,24 +11,24 @@ drwxr-xr-x install-dir/usr/local/include
 drwxr-xr-x install-dir/usr/local/lib
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-16.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-16.la
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-16.so -> libpcre2-16.so.0.13.0
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-16.so.0 -> libpcre2-16.so.0.13.0
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so.0.13.0
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-16.so -> libpcre2-16.so.0.14.0
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-16.so.0 -> libpcre2-16.so.0.14.0
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-16.so.0.14.0
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-32.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-32.la
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-32.so -> libpcre2-32.so.0.13.0
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-32.so.0 -> libpcre2-32.so.0.13.0
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so.0.13.0
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-32.so -> libpcre2-32.so.0.14.0
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-32.so.0 -> libpcre2-32.so.0.14.0
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-32.so.0.14.0
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-8.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-8.la
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-8.so -> libpcre2-8.so.0.13.0
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-8.so.0 -> libpcre2-8.so.0.13.0
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so.0.13.0
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-8.so -> libpcre2-8.so.0.14.0
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-8.so.0 -> libpcre2-8.so.0.14.0
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-8.so.0.14.0
 -rw-r--r-- install-dir/usr/local/lib/libpcre2-posix.a
 -rwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.la
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-posix.so -> libpcre2-posix.so.3.0.5
-lrwxrwxrwx install-dir/usr/local/lib/libpcre2-posix.so.3 -> libpcre2-posix.so.3.0.5
--rwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so.3.0.5
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-posix.so -> libpcre2-posix.so.3.0.6
+lrwxrwxrwx install-dir/usr/local/lib/libpcre2-posix.so.3 -> libpcre2-posix.so.3.0.6
+-rwxr-xr-x install-dir/usr/local/lib/libpcre2-posix.so.3.0.6
 drwxr-xr-x install-dir/usr/local/lib/pkgconfig
 -rw-r--r-- install-dir/usr/local/lib/pkgconfig/libpcre2-16.pc
 -rw-r--r-- install-dir/usr/local/lib/pkgconfig/libpcre2-32.pc


### PR DESCRIPTION
I believe this is the correct procedure, based on Philip's documentation.

The `libpcre2-posix` interface is completely unchanged, but the source code has been updated.

The `libpcre2-NN` interface has been extended in backwards-compatible ways, with new enum values and API functions, so callers compiled and linked against the old version may use the newer as a drop-in replacement, but callers compiled against the 10.45 headers will fail when used against the old version (if they require any newly-added functions).