### PR TITLE
Improve non-greedy repeat support

### DIFF
--- a/testdata/testinput1
+++ b/testdata/testinput1
@@ -7056,9 +7056,20 @@ $/x
   abcdefghbijb
   abcdefghbij
   abcdeb
+  abcdefghijx
 \= Expect no match
   abcdb
   abcdefghijk
+
+/[a-z]{1,6}?s|x/
+  asbs
+  abcdefs
+  abcdefghijkss
+  abcdefghijkx
+  ss
+\= Expect no match
+  s
+  aaa
 
 # --------------
 

--- a/testdata/testinput4
+++ b/testdata/testinput4
@@ -1869,6 +1869,15 @@
     ab\x{600}\x{700}ijklh
     ab\x{600}h\x{700}ijklmh
 
+/([a-z\x{1000}\x{2000}]{1,2}?u)+$/utf
+    \x{1000}uu\x{2000}u
+    \x{1001}uuuu
+    \x{2001}uuuuu
+    uuuu\x{1fff}#u#\x{2000}\x{1000}u\x{2000}u
+\= Expect no match
+    abuabuabuabu!
+    uuuuuuuuuuuu#
+
 # --------------------------------------
 
 /(ΣΆΜΟΣ) \1/i,utf

--- a/testdata/testoutput1
+++ b/testdata/testoutput1
@@ -11095,10 +11095,29 @@ No match
  0: abcdefghb
   abcdeb
  0: abcdeb
+  abcdefghijx
+ 0: x
 \= Expect no match
   abcdb
 No match
   abcdefghijk
+No match
+
+/[a-z]{1,6}?s|x/
+  asbs
+ 0: as
+  abcdefs
+ 0: abcdefs
+  abcdefghijkss
+ 0: fghijks
+  abcdefghijkx
+ 0: x
+  ss
+ 0: ss
+\= Expect no match
+  s
+No match
+  aaa
 No match
 
 # --------------

--- a/testdata/testoutput4
+++ b/testdata/testoutput4
@@ -3055,6 +3055,25 @@ No match
     ab\x{600}h\x{700}ijklmh
 No match
 
+/([a-z\x{1000}\x{2000}]{1,2}?u)+$/utf
+    \x{1000}uu\x{2000}u
+ 0: \x{1000}uu\x{2000}u
+ 1: u\x{2000}u
+    \x{1001}uuuu
+ 0: uuuu
+ 1: uu
+    \x{2001}uuuuu
+ 0: uuuuu
+ 1: uuu
+    uuuu\x{1fff}#u#\x{2000}\x{1000}u\x{2000}u
+ 0: \x{2000}\x{1000}u\x{2000}u
+ 1: \x{2000}u
+\= Expect no match
+    abuabuabuabu!
+No match
+    uuuuuuuuuuuu#
+No match
+
 # --------------------------------------
 
 /(ΣΆΜΟΣ) \1/i,utf


### PR DESCRIPTION
This should be the last patch of this work. All `[class]{a,b}+/?/nothing` now compiles `[class]` once. In the past a `[class]+` may compiled three times, which consumed a large space for some eclasses.