### PR TITLE
Pre-compute unicode category list for xclasses

### DIFF
--- a/src/pcre2_compile_class.c
+++ b/src/pcre2_compile_class.c
@@ -116,10 +116,11 @@ while (TRUE)
 
 #ifdef SUPPORT_UNICODE
 
-#define PARSE_CLASS_UTF               0x1
-#define PARSE_CLASS_CASELESS_UTF      0x2
-#define PARSE_CLASS_RESTRICTED_UTF    0x4
-#define PARSE_CLASS_TURKISH_UTF       0x8
+#define PARSE_CLASS_UTF               0x01
+#define PARSE_CLASS_CASELESS_UTF      0x02
+#define PARSE_CLASS_RESTRICTED_UTF    0x04
+#define PARSE_CLASS_TURKISH_UTF       0x08
+#define PARSE_CLASS_COMPUTE_CATLIST   0x10
 
 /* Get the range of nocase characters which includes the
 'c' character passed as argument, or directly follows 'c'. */
@@ -358,6 +359,7 @@ append_non_ascii_range(uint32_t options, uint32_t *buffer)
   return buffer + 2;
 }
 
+/* The buffer may represent the categry list pointer when utf is enabled. */
 static size_t
 parse_class(uint32_t *ptr, uint32_t options, uint32_t *buffer)
 {
@@ -365,6 +367,20 @@ size_t total_size = 0;
 size_t size;
 uint32_t meta_arg;
 uint32_t start_char;
+uint32_t ptype;
+#ifdef SUPPORT_UNICODE
+uint32_t pdata;
+uint32_t category_list;
+uint32_t *pcategory_list = NULL;
+#endif
+
+#ifdef SUPPORT_UNICODE
+if ((options & PARSE_CLASS_COMPUTE_CATLIST) != 0)
+  {
+  pcategory_list = buffer;
+  buffer = NULL;
+  }
+#endif
 
 while (TRUE)
   {
@@ -408,7 +424,8 @@ while (TRUE)
         case ESC_p:
         case ESC_P:
         ptr++;
-        if (meta_arg == ESC_p && (*ptr >> 16) == PT_ANY)
+        ptype = (*ptr >> 16);
+        if (meta_arg == ESC_p && ptype == PT_ANY)
           {
           if (buffer != NULL)
             {
@@ -418,6 +435,43 @@ while (TRUE)
             }
           total_size += 2;
           }
+#ifdef SUPPORT_UNICODE
+        if (pcategory_list == NULL) break;
+
+        category_list = 0;
+
+        switch(ptype)
+          {
+          case PT_LAMP:
+          category_list = UCPCAT3(ucp_Lu, ucp_Ll, ucp_Lt);
+          break;
+
+          case PT_GC:
+          pdata = *ptr & 0xffff;
+          category_list = UCPCAT_RANGE(PRIV(ucp_typerange)[pdata],
+                                       PRIV(ucp_typerange)[pdata + 1] - 1);
+          break;
+
+          case PT_PC:
+          pdata = *ptr & 0xffff;
+          category_list = UCPCAT(pdata);
+          break;
+
+          case PT_WORD:
+          category_list = UCPCAT2(ucp_Mn, ucp_Pc) | UCPCAT_L | UCPCAT_N;
+          break;
+
+          case PT_ALNUM:
+          category_list = UCPCAT_L | UCPCAT_N;
+          break;
+          }
+
+        if (category_list > 0)
+          {
+          if (meta_arg == ESC_P) category_list ^= UCPCAT_ALL;
+          *pcategory_list |= category_list;
+          }
+#endif
         break;
         }
       ptr++;
@@ -512,6 +566,9 @@ const uint32_t *char_list_next;
 uint16_t *next_char;
 uint32_t char_list_start, char_list_end;
 uint32_t range_start, range_end;
+#ifdef SUPPORT_UNICODE
+uint32_t category_list = 0;
+#endif
 
 #ifdef SUPPORT_UNICODE
 if (options & PCRE2_UTF)
@@ -529,10 +586,20 @@ if (xoptions & PCRE2_EXTRA_TURKISH_CASING)
 
 /* Compute required space for the range. */
 
+#ifdef SUPPORT_UNICODE
+range_list_size = parse_class(start_ptr,
+                              class_options | PARSE_CLASS_COMPUTE_CATLIST,
+                              &category_list);
+#else
 range_list_size = parse_class(start_ptr, class_options, NULL);
+#endif
 PCRE2_ASSERT((range_list_size & 0x1) == 0);
 
 /* Allocate buffer. The total_size also represents the end of the buffer. */
+
+#ifdef SUPPORT_UNICODE
+if (category_list == UCPCAT_ALL) range_list_size = 2;
+#endif
 
 total_size = range_list_size +
    ((range_list_size >= 2) ? CHAR_LIST_EXTRA_SIZE : 0);
@@ -548,6 +615,21 @@ cranges->range_list_size = (uint16_t)range_list_size;
 cranges->char_lists_types = 0;
 cranges->char_lists_size = 0;
 cranges->char_lists_start = 0;
+#ifdef SUPPORT_UNICODE
+cranges->category_list = category_list;
+#endif
+
+#ifdef SUPPORT_UNICODE
+if (category_list == UCPCAT_ALL)
+  {
+  /* Replace the xclass with OP_ALLANY. */
+  cranges->category_list = 0;
+  buffer = (uint32_t*)(cranges + 1);
+  buffer[0] = 0;
+  buffer[1] = get_highest_char(options);
+  return cranges;
+  }
+#endif
 
 if (range_list_size == 0) return cranges;
 
@@ -1042,6 +1124,7 @@ BOOL utf = FALSE;
 
 #ifdef SUPPORT_WIDE_CHARS
 uint32_t xclass_props;
+uint32_t category_list;
 PCRE2_UCHAR *class_uchardata;
 class_ranges* cranges;
 #endif
@@ -1058,6 +1141,7 @@ should_flip_negation = FALSE;
 
 #ifdef SUPPORT_WIDE_CHARS
 xclass_props = 0;
+category_list = 0;
 
 #if PCRE2_CODE_UNIT_WIDTH == 8
 cranges = NULL;
@@ -1091,6 +1175,9 @@ if (utf)
     cb->cranges = cranges->next;
     }
 
+  category_list = cranges->category_list;
+  PCRE2_ASSERT(category_list != UCPCAT_ALL);
+
   if (cranges->range_list_size > 0)
     {
     const uint32_t *ranges = (const uint32_t*)(cranges + 1);
@@ -1105,6 +1192,13 @@ if (utf)
   }
 
 class_uchardata = code + LINK_SIZE + 2;   /* For XCLASS items */
+
+if (cranges != NULL && category_list != 0 &&
+    (xclass_props & XCLASS_HIGH_ANY) == 0)
+  {
+  xclass_props |= XCLASS_REQUIRED | XCLASS_HAS_PROPS;
+  class_uchardata += sizeof(uint32_t) / sizeof(PCRE2_UCHAR);
+  }
 #endif /* SUPPORT_WIDE_CHARS */
 
 /* Initialize the 256-bit (32-byte) bit map to all zeros. We build the map
@@ -1380,7 +1474,9 @@ while (TRUE)
 
         PRIV(update_classbits)(ptype, pdata, (escape == ESC_P), classbits);
 
-        if ((xclass_props & XCLASS_HIGH_ANY) == 0)
+        if ((xclass_props & XCLASS_HIGH_ANY) == 0 &&
+            ptype != PT_LAMP && ptype != PT_GC && ptype != PT_PC &&
+            ptype != PT_WORD && ptype != PT_ALNUM)
           {
           if (lengthptr != NULL)
             *lengthptr += 3;
@@ -1640,6 +1736,12 @@ if ((xclass_props & XCLASS_REQUIRED) != 0)
   code += LINK_SIZE;
   *code = negate_class? XCL_NOT:0;
   if ((xclass_props & XCLASS_HAS_PROPS) != 0) *code |= XCL_HASPROP;
+  /* This should be the last one. */
+  if (category_list != 0)
+    {
+    *code |= XCL_HASCATLIST;
+    memmove(code + 1, &category_list, sizeof(uint32_t));
+    }
 
   /* If the map is required, move up the extra data to make room for it;
   otherwise just move the code pointer to the end of the extra data. */

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -1357,9 +1357,10 @@ table. */
 /* Flag bits and data types for the extended class (OP_XCLASS) for classes that
 contain characters with values greater than 255. */
 
-#define XCL_NOT      0x01  /* Flag: this is a negative class */
-#define XCL_MAP      0x02  /* Flag: a 32-byte map is present */
-#define XCL_HASPROP  0x04  /* Flag: property checks are present. */
+#define XCL_NOT         0x01  /* Flag: this is a negative class */
+#define XCL_MAP         0x02  /* Flag: a 32-byte map is present */
+#define XCL_HASPROP     0x04  /* Flag: property checks are present */
+#define XCL_HASCATLIST  0x08  /* Flag: category list is present */
 
 #define XCL_END      0     /* Marks end of individual items */
 #define XCL_SINGLE   1     /* Single item (one multibyte char) follows */
@@ -2030,6 +2031,18 @@ typedef struct {
 #define UCD_FOLD_I_TURKISH(ch) \
   ((uint32_t)(ch) == 0x0130u ?   0x69u : \
    (uint32_t)(ch) ==   0x49u ? 0x0131u : (uint32_t)(ch))
+
+/* UCP bitset manipulating macros. */
+
+#ifdef SUPPORT_UNICODE
+#define UCPCAT(bit) (1 << (bit))
+#define UCPCAT2(bit1, bit2) (UCPCAT(bit1) | UCPCAT(bit2))
+#define UCPCAT3(bit1, bit2, bit3) (UCPCAT(bit1) | UCPCAT(bit2) | UCPCAT(bit3))
+#define UCPCAT_RANGE(start, end) (((1 << ((end) + 1)) - 1) - ((1 << (start)) - 1))
+#define UCPCAT_L UCPCAT_RANGE(ucp_Ll, ucp_Lu)
+#define UCPCAT_N UCPCAT_RANGE(ucp_Nd, ucp_No)
+#define UCPCAT_ALL ((1 << (ucp_Zs + 1)) - 1)
+#endif
 
 /* The "scriptx" and bprops fields contain offsets into vectors of 32-bit words
 that form a bitmap representing a list of scripts or boolean properties. These

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -733,6 +733,9 @@ typedef struct class_ranges {
   struct class_ranges *next;       /* Next class ranges */
   size_t char_lists_size;          /* Total size of encoded char lists */
   size_t char_lists_start;         /* Start offset of encoded char lists */
+#ifdef SUPPORT_UNICODE
+  uint32_t category_list;          /* Bitset of matching unicode categories. */
+#endif
   uint16_t range_list_size;        /* Size of ranges array */
   uint16_t char_lists_types;       /* The XCL_LIST header of char lists */
   /* Followed by the list of ranges (start/end pairs) */

--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -7007,16 +7007,6 @@ else
 JUMPTO(SLJIT_JUMP, mainloop);
 }
 
-#ifdef SUPPORT_UNICODE
-#define UCPCAT(bit) (1 << (bit))
-#define UCPCAT2(bit1, bit2) (UCPCAT(bit1) | UCPCAT(bit2))
-#define UCPCAT3(bit1, bit2, bit3) (UCPCAT(bit1) | UCPCAT(bit2) | UCPCAT(bit3))
-#define UCPCAT_RANGE(start, end) (((1 << ((end) + 1)) - 1) - ((1 << (start)) - 1))
-#define UCPCAT_L UCPCAT_RANGE(ucp_Ll, ucp_Lu)
-#define UCPCAT_N UCPCAT_RANGE(ucp_Nd, ucp_No)
-#define UCPCAT_ALL ((1 << (ucp_Zs + 1)) - 1)
-#endif
-
 static void check_wordboundary(compiler_common *common, BOOL ucp)
 {
 DEFINE_COMPILER;

--- a/src/pcre2_tables.c
+++ b/src/pcre2_tables.c
@@ -209,20 +209,19 @@ const uint32_t PRIV(ucp_gbtable)[] = {
 
 #undef ESZ
 
-#ifdef SUPPORT_JIT
 /* This table reverses PRIV(ucp_gentype). We can save the cost
 of a memory load. */
 
 const int PRIV(ucp_typerange)[] = {
-  ucp_Cc, ucp_Cs,
-  ucp_Ll, ucp_Lu,
-  ucp_Mc, ucp_Mn,
-  ucp_Nd, ucp_No,
-  ucp_Pc, ucp_Ps,
-  ucp_Sc, ucp_So,
-  ucp_Zl, ucp_Zs,
+  ucp_Cc,
+  ucp_Ll,
+  ucp_Mc,
+  ucp_Nd,
+  ucp_Pc,
+  ucp_Sc,
+  ucp_Zl,
+  ucp_Zs + 1, /* Terminator, not part of the list. */
 };
-#endif /* SUPPORT_JIT */
 
 /* Finally, include the tables that are auto-generated from the Unicode data
 files. */

--- a/src/pcre2_xclass.c
+++ b/src/pcre2_xclass.c
@@ -70,7 +70,8 @@ PRIV(xclass)(uint32_t c, PCRE2_SPTR data, const uint8_t *char_lists_end, BOOL ut
 {
 /* Update PRIV(update_classbits) when this function is changed. */
 PCRE2_UCHAR t;
-BOOL not_negated = (*data & XCL_NOT) == 0;
+PCRE2_UCHAR flags = *data++;
+BOOL not_negated = (flags & XCL_NOT) == 0;
 uint32_t type, max_index, min_index, value;
 const uint8_t *next_char;
 
@@ -81,7 +82,7 @@ utf = TRUE;
 
 /* Code points < 256 are matched against a bitmap, if one is present. */
 
-if ((*data++ & XCL_MAP) != 0)
+if ((flags & XCL_MAP) != 0)
   {
   if (c < 256)
     return (((const uint8_t *)data)[c/8] & (1u << (c&7))) != 0;
@@ -92,12 +93,26 @@ if ((*data++ & XCL_MAP) != 0)
 /* Match against the list of Unicode properties. We won't ever
 encounter XCL_PROP or XCL_NOTPROP when UTF support is not compiled. */
 #ifdef SUPPORT_UNICODE
-if (*data == XCL_PROP || *data == XCL_NOTPROP)
+if ((flags & XCL_HASPROP) != 0)
   {
   /* The UCD record is the same for all properties. */
   const ucd_record *prop = GET_UCD(c);
 
-  do
+  PCRE2_ASSERT(*data == XCL_PROP || *data == XCL_NOTPROP ||
+               (flags & XCL_HASCATLIST) != 0);
+
+  if ((flags & XCL_HASCATLIST) != 0)
+    {
+    uint32_t category_list;
+    memcpy(&category_list, data, sizeof(uint32_t));
+
+    if (category_list & (1 << prop->chartype)) return not_negated;
+
+    /* Skip bitmap. */
+    data += sizeof(uint32_t) / sizeof(PCRE2_UCHAR);
+    }
+
+  while (*data == XCL_PROP || *data == XCL_NOTPROP)
     {
     int chartype;
     BOOL isprop = (*data++) == XCL_PROP;
@@ -105,21 +120,6 @@ if (*data == XCL_PROP || *data == XCL_NOTPROP)
 
     switch(*data)
       {
-      case PT_LAMP:
-      chartype = prop->chartype;
-      if ((chartype == ucp_Lu || chartype == ucp_Ll ||
-           chartype == ucp_Lt) == isprop) return not_negated;
-      break;
-
-      case PT_GC:
-      if ((data[1] == PRIV(ucp_gentype)[prop->chartype]) == isprop)
-        return not_negated;
-      break;
-
-      case PT_PC:
-      if ((data[1] == prop->chartype) == isprop) return not_negated;
-      break;
-
       case PT_SC:
       if ((data[1] == prop->script) == isprop) return not_negated;
       break;
@@ -128,13 +128,6 @@ if (*data == XCL_PROP || *data == XCL_NOTPROP)
       ok = (data[1] == prop->script ||
             MAPBIT(PRIV(ucd_script_sets) + UCD_SCRIPTX_PROP(prop), data[1]) != 0);
       if (ok == isprop) return not_negated;
-      break;
-
-      case PT_ALNUM:
-      chartype = prop->chartype;
-      if ((PRIV(ucp_gentype)[chartype] == ucp_L ||
-           PRIV(ucp_gentype)[chartype] == ucp_N) == isprop)
-        return not_negated;
       break;
 
       /* Perl space used to exclude VT, but from Perl 5.18 it is included,
@@ -155,14 +148,6 @@ if (*data == XCL_PROP || *data == XCL_NOTPROP)
           return not_negated;
         break;
         }
-      break;
-
-      case PT_WORD:
-      chartype = prop->chartype;
-      if ((PRIV(ucp_gentype)[chartype] == ucp_L ||
-           PRIV(ucp_gentype)[chartype] == ucp_N ||
-           chartype == ucp_Mn || chartype == ucp_Pc) == isprop)
-        return not_negated;
       break;
 
       case PT_UCNC:
@@ -259,7 +244,6 @@ if (*data == XCL_PROP || *data == XCL_NOTPROP)
 
     data += 2;
     }
-  while (*data == XCL_PROP || *data == XCL_NOTPROP);
   }
 #else
   (void)utf;  /* Avoid compiler warning */


### PR DESCRIPTION
This patch moves a jit optimization to compiler optimization. The unicode categories (there are 30 of them) are combined into a 32 bit bitset, and stored in xclass, instead of a list of properties. This 32 bits, if present, follows the bitset for the first 256 characters. If the value of categories is 0, it is not stored in the xclass.

The patch is working, but the debug (`/B`) output is changed for 8-bit ucp case, because the bitset is stored in cranges, and the 8 bit ucp has no cranges.

When all 30 category bits are present, the xclass is converted to allany or nothing (negated case).

What do you think about this optimization?
