### PR TITLE
Fix warning about signed/unsigned mismatch

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -1767,7 +1767,7 @@ switch(*cc)
   if (max == 0)
     return (*cc == OP_CRRANGE) ? 2 : 1;
   max -= min;
-  if (max > (*cc == OP_CRRANGE ? 0 : 1))
+  if (max > (sljit_u32)(*cc == OP_CRRANGE ? 0 : 1))
     max = 2;
   return max;
 


### PR DESCRIPTION
Congrats on the RC1 🙂 

I've got the following warning when trying to compile it with MSVC though, which is a problem when you turn warning as errors on:

> Warning C4018 : '>': signed/unsigned mismatch

(I supposed the PR should target the master branch)
