### PR TITLE
Add CI for MSYS2

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -291,6 +291,49 @@ jobs:
       - name: Test
         run: cd build && ctest -j3 --output-on-failure
 
+  msys2:
+    # Tests with: MSYS2 unix-on-Windows environment
+    name: MSYS2
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        # UCRT64 is the new default MSYS2 runtime, which builds native 64-bit
+        # binaries which can then be shipped and run on systems without MSYS2
+        # installed (using MinGW-x64 + the UCRT).
+        # MSYS is the Unix-variant runtime, which builds binaries that have a
+        # dependency on MSYS2 being installed, but those binaries then use a
+        # full emulated Unix environment at runtime.
+        msystem: ["UCRT64", "MSYS"]
+    steps:
+      - name: Pre-checkout
+        run: git config --global core.autocrlf input
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Setup
+        uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2.26.0
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          pacboy: diffutils gcc:p cmake:p ninja:p ${{ matrix.msystem == 'MSYS' && 'libreadline:p' || 'readline:p' }}
+
+      - name: Configure
+        shell: msys2 {0}
+        run: cmake -G Ninja -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
+
+      - name: Build
+        shell: msys2 {0}
+        run: ninja -C build
+
+      - name: Test
+        shell: msys2 {0}
+        run: cd build && ctest -j3 --output-on-failure
+
   zebrilus:
     # Tests with: Zig compiler
     name: Zig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1216,7 +1216,7 @@ echo RunGrepTest.bat tests successfully completed
       )
     endif()
 
-    if("$ENV{OSTYPE}" STREQUAL "msys")
+    if("$ENV{OSTYPE}" STREQUAL "msys" OR MSYS2)
       # Both the sh and bat file versions of RunTest are run if make test is used
       # in msys
       add_test(pcre2_test_sh sh.exe ${PROJECT_BINARY_DIR}/pcre2_test.sh)

--- a/RunTest
+++ b/RunTest
@@ -334,7 +334,7 @@ fi
 # If it is possible to set the system stack size and -bigstack was given,
 # set up a large stack.
 
-$sim $pcre2test -S 32 /dev/null /dev/null
+$sim $pcre2test -S 32 /dev/null /dev/null >/dev/null 2>&1
 support_setstack=$?
 if [ $support_setstack -eq 0 -a "$bigstack" != "" ] ; then
   setstack="-S 32"
@@ -562,15 +562,18 @@ for bmode in "$test8" "$test16" "$test32"; do
             outfile=$testdata/testoutput3
             outfile2=$testdata/testoutput3A
             outfile3=$testdata/testoutput3B
+            outfile4=$testdata/testoutput3C
           else
             infile=test3input
             outfile=test3output
             outfile2=test3outputA
             outfile3=test3outputB
+            outfile4=test3outputC
             sed "s/fr_FR/$loc/" $testdata/testinput3 >test3input
             sed "s/fr_FR/$loc/" $testdata/testoutput3 >test3output
             sed "s/fr_FR/$loc/" $testdata/testoutput3A >test3outputA
             sed "s/fr_FR/$loc/" $testdata/testoutput3B >test3outputB
+            sed "s/fr_FR/$loc/" $testdata/testoutput3C >test3outputC
           fi
           break
         fi
@@ -588,12 +591,13 @@ for bmode in "$test8" "$test16" "$test32"; do
           esac
           if $cf $outfile testtry >teststdout || \
              $cf $outfile2 testtry >teststdout || \
-             $cf $outfile3 testtry >teststdout
+             $cf $outfile3 testtry >teststdout || \
+             $cf $outfile4 testtry >teststdout
           then
             echo "  OK$with"
           else
             echo "** Locale test did not run successfully$with. The output did not match"
-            echo "   $outfile, $outfile2 or $outfile3."
+            echo "   $outfile, $outfile2, $outfile3 or $outfile4."
             echo "   This may mean that there is a problem with the locale settings rather"
             echo "   than a bug in PCRE2."
             exit 1

--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -860,7 +860,9 @@ native z/OS, and "no support". */
 
 /************* Directory scanning Unix-style and z/OS ***********/
 
-#if (defined HAVE_SYS_STAT_H && defined HAVE_DIRENT_H && defined HAVE_SYS_TYPES_H) || defined NATIVE_ZOS
+#if !defined WIN32 && \
+  (defined HAVE_SYS_STAT_H && defined HAVE_DIRENT_H && defined HAVE_SYS_TYPES_H) || \
+  defined NATIVE_ZOS
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>

--- a/testdata/testoutput3C
+++ b/testdata/testoutput3C
@@ -1,0 +1,177 @@
+# This set of tests checks local-specific features, using the "fr_FR" locale. 
+# It is almost Perl-compatible. When run via RunTest, the locale is edited to
+# be whichever of "fr_FR", "french", or "fr" is found to exist. There is
+# different version of this file called wintestinput3 for use on Windows,
+# where the locale is called "french" and the tests are run using
+# RunTest.bat. 
+
+#forbid_utf
+
+/^[\w]+/
+\= Expect no match
+    École
+No match
+
+/^[\w]+/locale=fr_FR
+    École
+ 0: École
+
+/^[\W]+/
+    École
+ 0: \xc9
+
+/^[\W]+/locale=fr_FR
+\= Expect no match
+    École
+No match
+
+/[\b]/
+    \b
+ 0: \x08
+\= Expect no match
+    a
+No match
+
+/[\b]/locale=fr_FR
+    \b
+ 0: \x08
+\= Expect no match
+    a
+No match
+
+/^\w+/
+\= Expect no match
+    École
+No match
+
+/^\w+/locale=fr_FR
+    École
+ 0: École
+
+/(.+)\b(.+)/
+    École
+ 0: \xc9cole
+ 1: \xc9
+ 2: cole
+
+/(.+)\b(.+)/locale=fr_FR
+\= Expect no match
+    École
+No match
+
+/École/i
+    École
+ 0: \xc9cole
+\= Expect no match
+    école
+No match
+
+/École/i,locale=fr_FR
+    École
+ 0: École
+    école
+ 0: école
+
+/\w/I
+Capture group count = 0
+Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
+  Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
+Subject length lower bound = 1
+
+/\w/I,locale=fr_FR
+Capture group count = 0
+Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
+  Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
+  À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ð Ñ Ò Ó Ô Õ Ö Ø Ù Ú Û Ü Ý Þ ß à á â ã ä å
+  æ ç è é ê ë ì í î ï ð ñ ò ó ô õ ö ø ù ú û ü ý þ ÿ
+Subject length lower bound = 1
+
+# All remaining tests are in the fr_FR locale, so set the default.
+
+#pattern locale=fr_FR
+
+/^[\xc8-\xc9]/i
+    École
+ 0: É
+    école
+ 0: é
+
+/^[\xc8-\xc9]/
+    École
+ 0: É
+\= Expect no match
+    école
+No match
+
+/\xb5/i
+    µ
+ 0: µ
+\= Expect no match
+    \x9c
+No match
+
+/ÿ/i
+    \xff
+ 0: ÿ
+\= Expect no match
+    y
+No match
+
+/(.)\1/i
+    \xfe\xde
+ 0: þÞ
+ 1: þ
+
+/\W+/
+    >>>\xaa<<<
+ 0: >>>ª<<<
+    >>>\xba<<< 
+ 0: >>>º<<<
+
+/[\W]+/
+    >>>\xaa<<<
+ 0: >>>ª<<<
+    >>>\xba<<< 
+ 0: >>>º<<<
+
+/[^[:alpha:]]+/
+    >>>\xaa<<<
+ 0: >>>ª<<<
+    >>>\xba<<< 
+ 0: >>>º<<<
+
+/\w+/
+    >>>\xaa<<<
+No match
+    >>>\xba<<< 
+No match
+
+/[\w]+/
+    >>>\xaa<<<
+No match
+    >>>\xba<<< 
+No match
+
+/[[:alpha:]]+/
+    >>>\xaa<<<
+No match
+    >>>\xba<<< 
+No match
+    
+/[[:alpha:]][[:lower:]][[:upper:]]/IB
+------------------------------------------------------------------
+        Bra
+        [A-Za-z\xc0-\xd6\xd8-\xf6\xf8-\xff]
+        [a-z\xdf-\xf6\xf8-\xff]
+        [A-Z\xc0-\xd6\xd8-\xde]
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Starting code units: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+  a b c d e f g h i j k l m n o p q r s t u v w x y z À Á Â Ã Ä Å Æ Ç È É Ê
+  Ë Ì Í Î Ï Ð Ñ Ò Ó Ô Õ Ö Ø Ù Ú Û Ü Ý Þ ß à á â ã ä å æ ç è é ê ë ì í î ï ð
+  ñ ò ó ô õ ö ø ù ú û ü ý þ ÿ
+Subject length lower bound = 3
+
+# End of testinput3 


### PR DESCRIPTION
Also fix a few minor portability issues.

- The unix "MSYS" environment has an usual (but sane) French locale, requiring a test update
- pcre2grep needs a fix to use the WIN32 when both WIN32 and sys/stat.h are available

Fixes #127