### PR TITLE
pcre2grep.1 - fix warning about undefined macro 0

### DIFF
--- a/doc/pcre2grep.1
+++ b/doc/pcre2grep.1
@@ -947,7 +947,7 @@ Any substring (including the executable name) may contain escape sequences
 started by a dollar character. These are the same as for the \fB--output\fP
 (\fB-O\fP) option documented above, except that $0 or $& cannot insert the
 matched string because the match is still in progress. Instead, the character
-'0' is inserted. If you need a literal dollar or pipe character in any
+\&'0' is inserted. If you need a literal dollar or pipe character in any
 substring, use $$ or $| respectively. Here is an example:
 .sp
   echo -e "abcde\en12345" | pcre2grep \e

--- a/maint/132html
+++ b/maint/132html
@@ -14,6 +14,7 @@ $s =~ s"\\fI(.*?)\\f[RP]"<i>$1</i>"g;
 $s =~ s"\\fB(.*?)\\f[RP]"<b>$1</b>"g;
 $s =~ s"\\e"\\"g;
 $s =~ s/(?<=Copyright )\(c\)/&copy;/g;
+$s =~ s/\\&//g;                     # Deal with the \& 0-width space
 $s;
 }
 

--- a/maint/CheckMan
+++ b/maint/CheckMan
@@ -51,7 +51,7 @@ while (scalar(@ARGV) > 0)
         $yield = 1;
         }
       }
-    elsif (/\\[^ef]|\\f[^IBP]/)
+    elsif (/\\[^ef&]|\\f[^IBP]/)
       {
       printf "Bad backslash in line $line of $file\n";
       $yield = 1;

--- a/maint/PrepareRelease
+++ b/maint/PrepareRelease
@@ -161,6 +161,17 @@ END
 if [ $? != 0 ] ; then exit 1; fi
 
 
+# Verify that `man` can process the pages without warnings.
+
+for file in *.1 *.3 ; do
+  MAN_OUT=`MANROFFSEQ='' MANWIDTH=80 man --warnings=w,all -E UTF-8 -l -Tutf8 -Z "$file" 2>&1 >/dev/null`
+  if [ "$MAN_OUT" != "" ]; then
+    printf "Running man generated warnings:\n%s\n" "$MAN_OUT"
+    exit 1
+  fi
+done
+
+
 # Make HTML form of the documentation.
 
 echo "Making HTML documentation"


### PR DESCRIPTION
Debian's "lintian" picked this up - line 950 in the man page starts with a `'` which is how you start a roff request. You can reproduce the warning thus:

```
LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
man --warnings -E UTF-8 -l -Tutf8 -Z doc/pcre2grep.1 >/dev/null
```

The fix is to add a zero-width space (`\&`) to the start of the relevant line (indeed `groff_man(7)` suggests exactly this use for `\&`).

This is obviously not a critical issue, but it'd be nice if it made it into 10.45 please :)