### PR TITLE
Add AM_MAINTAINER_MODE for users checking out a release tag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,15 @@ AC_PREREQ([2.60])
 AC_INIT([PCRE2],pcre2_major.pcre2_minor[]pcre2_prerelease,[],[pcre2])
 AC_CONFIG_SRCDIR([src/pcre2.h.in])
 AM_INIT_AUTOMAKE([dist-bzip2 dist-zip foreign])
+ifelse(pcre2_prerelease, [-DEV],
+  [dnl For development builds, ./configure is not checked in to Git, so we are
+   dnl happy to have it regenerated as needed.
+   AM_MAINTAINER_MODE([enable])],
+  [dnl For a release build (or RC), the ./configure script we ship in the
+   dnl tarball (and check in to the Git tag) should not be regenerated
+   dnl implicitly. This is important if users want to check out a release tag
+   dnl using Git.
+   AM_MAINTAINER_MODE])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_HEADERS(src/config.h)
 


### PR DESCRIPTION
We received the suggestion to use a (signed) Git tag for the 10.45 release. This lets users fetch releases with Git rather than manually downloading, unpacking, and verifying a tarball.

When testing this, I realised there was a problem with the Autoconf setup. The release tag should have the `./configure` script checked in (so that the tag matches the tarball), but, a Git tag is checked out with totally random mtimes set on the files (whereas a tarball unpacks with mtimes preserved). This leads to the `./configure` script being regenerated, which is a different behaviour.

The fix is to disable automake's "maintainer mode" on release branches.

For discussion, see for example https://github.com/libexpat/libexpat/issues/726, or https://autotools.info/automake/maintainer.html.