### PR TITLE
Add LICENSE file for sljit in the tarball

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -16,7 +16,8 @@ testdata directory is not copyrighted and is in the public domain.
 The basic library functions are written in C and are freestanding. Also
 included in the distribution is a just-in-time compiler that can be used to
 optimize pattern matching. This is an optional feature that can be omitted when
-the library is built.
+the library is built. The just-in-time compiler is separately licensed under the
+"2-clause BSD" licence.
 
 
 COPYRIGHT
@@ -52,6 +53,8 @@ COPYRIGHT
 
     Copyright (c) 2009-2024 Zoltan Herczeg
     All rights reserved.
+
+The code in the `deps/sljit` directory has its own LICENSE file.
 
 ### All other contributions
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -467,6 +467,8 @@ CLEANFILES += src/pcre2_chartables.c
 # when pcre2_jit_compile.c is processed, so they must be distributed.
 
 EXTRA_DIST += \
+  deps/sljit/LICENSE \
+  deps/sljit/README \
   deps/sljit/sljit_src/sljitConfig.h \
   deps/sljit/sljit_src/sljitConfigCPU.h \
   deps/sljit/sljit_src/sljitConfigInternal.h \

--- a/maint/manifest-tarball
+++ b/maint/manifest-tarball
@@ -37,6 +37,8 @@ drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/cmake
 -rwxr-xr-x tarball-dir/pcre2-SNAPSHOT/depcomp
 drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/deps
 drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/deps/sljit
+-rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/LICENSE
+-rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/README
 drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src
 drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/allocator_src
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/allocator_src/sljitExecAllocatorApple.c

--- a/src/pcre2_fuzzsupport.c
+++ b/src/pcre2_fuzzsupport.c
@@ -1,3 +1,44 @@
+/*************************************************
+*      Perl-Compatible Regular Expressions       *
+*************************************************/
+
+/* PCRE is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+
+                       Written by Philip Hazel
+     Original API code Copyright (c) 1997-2012 University of Cambridge
+          New API code Copyright (c) 2016-2023 University of Cambridge
+
+-----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the University of Cambridge nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------------
+*/
+
+
 /***************************************************************************
 Fuzzer driver for PCRE2. Given an arbitrary string of bytes and a length, it
 tries to compile and match it, deriving options from the string itself. If
@@ -10,6 +51,7 @@ Written by Philip Hazel, October 2016
 Updated February 2024 (Addison Crump added 16-bit/32-bit and JIT support)
 Further updates March/April/May 2024 by PH
 ***************************************************************************/
+
 
 #include <errno.h>
 #include <stdarg.h>

--- a/src/pcre2posix_test.c
+++ b/src/pcre2posix_test.c
@@ -1,13 +1,45 @@
 /*************************************************
-*        PCRE2 POSIX interface test program      *
+*      Perl-Compatible Regular Expressions       *
 *************************************************/
 
-/*
-Written by Philip Hazel, December 2022
-Copyright (c) 2022
-File last edited: December 2022
+/* PCRE is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
 
-This program tests the POSIX wrapper to the PCRE2 regular expression library.
+                       Written by Philip Hazel
+     Original API code Copyright (c) 1997-2012 University of Cambridge
+          New API code Copyright (c) 2016-2023 University of Cambridge
+
+-----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the University of Cambridge nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------------
+*/
+
+
+/* This program tests the POSIX wrapper to the PCRE2 regular expression library.
 The main PCRE2 test program is pcre2test, which also tests these function
 calls. This little program is needed to test the case where the client includes
 pcre2posix.h but not pcre2.h, mainly to make sure that it builds successfully.
@@ -21,6 +53,7 @@ zero. If any test fails there is output to stderr, and the return code is 1.
 
 For testing purposes, the "-v" option causes verification output to be written
 to stdout. */
+
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Also, add missing license header to two files in the repo.

Fixes #686