### PR TITLE
Remove duplicated scan substring captures

### DIFF
--- a/src/pcre2_compile.h
+++ b/src/pcre2_compile.h
@@ -274,6 +274,7 @@ typedef struct {
 #define _pcre2_compile_find_named_group        PCRE2_SUFFIX(_pcre2_compile_find_named_group)
 #define _pcre2_compile_find_dupname_details    PCRE2_SUFFIX(_pcre2_compile_find_dupname_details)
 #define _pcre2_compile_add_name_to_table       PCRE2_SUFFIX(_pcre2_compile_add_name_to_table)
+#define _pcre2_compile_parse_scan_substr_args  PCRE2_SUFFIX(_pcre2_compile_parse_scan_substr_args)
 #define _pcre2_compile_parse_recurse_args      PCRE2_SUFFIX(_pcre2_compile_parse_recurse_args)
 
 
@@ -339,6 +340,11 @@ in indexptr and countptr. */
 
 BOOL PRIV(compile_find_dupname_details)(PCRE2_SPTR name, uint32_t length,
   int *indexptr, int *countptr, int *errorcodeptr, compile_block *cb);
+
+/* Parse the arguments of recurse operations. */
+
+uint32_t * PRIV(compile_parse_scan_substr_args)(uint32_t *pptr,
+  int *errorcodeptr, compile_block *cb, PCRE2_SIZE *lengthptr);
 
 /* Parse the arguments of recurse operations. */
 

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -6710,6 +6710,16 @@ a)"xI
     abxyz
     efgxyz
 
+# Duplicated capture references
+
+/(a)(b)(c)(d)(*scs:(4,3,1,2,2,1,3,3,4,4)x)/B
+
+/(?<n>a)(?<n>b)(?<n>c)(d)(*scs:(2,3,1,1,<n>,<n>)abc)/B,dupnames
+
+/(?<n>a)(?<n>b)(?<n>c)(d)(*scs:(2,1,1,<n>,<n>)abc)/B,dupnames
+
+/(?<n>a)(?<n>b)(?<n>c)(d)(?<m>e)(?<m>f)(*scs:(<n>,5,3,2,1,4,1,4,<m>,6,<n>,<m>)abc)/B,dupnames
+
 # Tests for pcre2_set_optimize()
 
 /abc/I,optimization_none

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -19668,9 +19668,6 @@ No match
         Ket
         Scan substring
       1 Capture ref
-      1 Capture ref
-      1 Capture ref
-      1 Capture ref
         a
         Ket
         b
@@ -19701,6 +19698,116 @@ No match
  1: 
  2: 
  3: 
+
+# Duplicated capture references
+
+/(a)(b)(c)(d)(*scs:(4,3,1,2,2,1,3,3,4,4)x)/B
+------------------------------------------------------------------
+        Bra
+        CBra 1
+        a
+        Ket
+        CBra 2
+        b
+        Ket
+        CBra 3
+        c
+        Ket
+        CBra 4
+        d
+        Ket
+        Scan substring
+      4 Capture ref
+      3 Capture ref
+      1 Capture ref
+      2 Capture ref
+        x
+        Ket
+        Ket
+        End
+------------------------------------------------------------------
+
+/(?<n>a)(?<n>b)(?<n>c)(d)(*scs:(2,3,1,1,<n>,<n>)abc)/B,dupnames
+------------------------------------------------------------------
+        Bra
+        CBra 1
+        a
+        Ket
+        CBra 2
+        b
+        Ket
+        CBra 3
+        c
+        Ket
+        CBra 4
+        d
+        Ket
+        Scan substring
+      2 Capture ref
+      3 Capture ref
+      1 Capture ref
+        abc
+        Ket
+        Ket
+        End
+------------------------------------------------------------------
+
+/(?<n>a)(?<n>b)(?<n>c)(d)(*scs:(2,1,1,<n>,<n>)abc)/B,dupnames
+------------------------------------------------------------------
+        Bra
+        CBra 1
+        a
+        Ket
+        CBra 2
+        b
+        Ket
+        CBra 3
+        c
+        Ket
+        CBra 4
+        d
+        Ket
+        Scan substring
+      2 Capture ref
+      1 Capture ref
+        Capture ref <n>3
+        abc
+        Ket
+        Ket
+        End
+------------------------------------------------------------------
+
+/(?<n>a)(?<n>b)(?<n>c)(d)(?<m>e)(?<m>f)(*scs:(<n>,5,3,2,1,4,1,4,<m>,6,<n>,<m>)abc)/B,dupnames
+------------------------------------------------------------------
+        Bra
+        CBra 1
+        a
+        Ket
+        CBra 2
+        b
+        Ket
+        CBra 3
+        c
+        Ket
+        CBra 4
+        d
+        Ket
+        CBra 5
+        e
+        Ket
+        CBra 6
+        f
+        Ket
+        Scan substring
+        Capture ref <n>3
+      5 Capture ref
+      4 Capture ref
+        Capture ref <m>2
+        abc
+        Ket
+        Ket
+        End
+------------------------------------------------------------------
 
 # Tests for pcre2_set_optimize()
 


### PR DESCRIPTION
This patch optimizes the argument list of scan substring by removing duplications. Multinames are only removed if all corresponding captures are removed as well.

Not a simple patch unfortunately.

It would not be bad, if equality here could be checked somehow:
https://github.com/PCRE2Project/pcre2/blob/master/src/pcre2_compile.c#L10854

The greater case is only needed for a few patterns. Don't know how to do this. Maybe tests should contain a `#` option to enforce equality, and that could be disabled for specific patterns.
