### PR TITLE
Run build on deprecated Ubuntu 20.04 in a container

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -91,8 +91,15 @@ jobs:
   greatawk:
     # Tests with: GCC, -O3, oldest supported Ubuntu (in non-extended support)
     name: GCC -O3
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     steps:
+      - name: Setup
+        run: |
+          export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
+          apt-get -qq update
+          apt-get -qq install -y git build-essential cmake
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -117,8 +124,15 @@ jobs:
   dodo:
     # Tests with: Autconf on oldest supported Ubuntu (in non-extended support)
     name: GCC -Os, old Autotools
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     steps:
+      - name: Setup
+        run: |
+          export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
+          apt-get -qq update
+          apt-get -qq install -y git build-essential autoconf automake libtool
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
The `ubuntu-20.04` GitHub runner will be discontinued in around a month.

We can still test on this OS, by running these jobs in a container.