### PR TITLE
Stop leaking internal headers to other libraries.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,16 +71,16 @@ cc_library(
     hdrs = [
         ":pcre2_h_generic",
     ],
+    copts = [
+        "-I%s/src" % (INCLUDE_PREFIX,),
+         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
+    ],
     local_defines = [
         "HAVE_CONFIG_H",
         "HAVE_MEMMOVE",
         "PCRE2_CODE_UNIT_WIDTH=8",
         "PCRE2_STATIC",
         "SUPPORT_UNICODE",
-    ],
-    copts = [
-        "-I%s/src" % (INCLUDE_PREFIX,),
-         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
     ],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
@@ -95,6 +95,9 @@ cc_library(
     hdrs = [
         "src/pcre2posix.h",
     ],
+    copts = [
+         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
+    ],
     local_defines = [
         "HAVE_CONFIG_H",
         "HAVE_MEMMOVE",
@@ -102,7 +105,6 @@ cc_library(
         "PCRE2_STATIC",
         "SUPPORT_UNICODE",
     ],
-    includes = ["src"],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [":pcre2"],
@@ -135,6 +137,9 @@ cc_binary(
     srcs = [
         "src/pcre2test.c",
         ":config_h_generic",
+    ],
+    copts = [
+         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
     ],
     local_defines = [
         "HAVE_CONFIG_H",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,6 +20,10 @@ copy_file(
     out = "src/pcre2_chartables.c",
 )
 
+REPO_ROOT = package_relative_label(":BUILD.bazel").workspace_root
+
+INCLUDE_PREFIX = REPO_ROOT if REPO_ROOT else "."
+
 cc_library(
     name = "pcre2",
     srcs = [
@@ -64,8 +68,6 @@ cc_library(
         "src/pcre2_util.h",
         ":config_h_generic",
     ],
-    textual_hdrs = [
-    ],
     hdrs = [
         ":pcre2_h_generic",
     ],
@@ -76,7 +78,10 @@ cc_library(
         "PCRE2_STATIC",
         "SUPPORT_UNICODE",
     ],
-    includes = ["src"],
+    copts = [
+        "-I%s/src" % (INCLUDE_PREFIX,),
+         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
+    ],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,12 +20,16 @@ copy_file(
     out = "src/pcre2_chartables.c",
 )
 
-REPO_ROOT = package_relative_label(":BUILD.bazel").workspace_root
-
-INCLUDE_PREFIX = REPO_ROOT if REPO_ROOT else "."
+LOCAL_DEFINES = [
+    "HAVE_CONFIG_H",
+    "HAVE_MEMMOVE",
+    "PCRE2_CODE_UNIT_WIDTH=8",
+    "PCRE2_STATIC",
+    "SUPPORT_UNICODE",
+]
 
 cc_library(
-    name = "pcre2",
+    name = "pcre2_impl",
     srcs = [
         "src/pcre2_auto_possess.c",
         "src/pcre2_chkdint.c",
@@ -40,15 +44,12 @@ cc_library(
         "src/pcre2_extuni.c",
         "src/pcre2_find_bracket.c",
         "src/pcre2_jit_compile.c",
-        "src/pcre2_jit_match_inc.h",
-        "src/pcre2_jit_misc_inc.h",
         "src/pcre2_maketables.c",
         "src/pcre2_match.c",
         "src/pcre2_match_data.c",
         "src/pcre2_newline.c",
         "src/pcre2_ord2utf.c",
         "src/pcre2_pattern_info.c",
-        "src/pcre2_printint_inc.h",
         "src/pcre2_script_run.c",
         "src/pcre2_serialize.c",
         "src/pcre2_string_utils.c",
@@ -60,52 +61,39 @@ cc_library(
         "src/pcre2_valid_utf.c",
         "src/pcre2_xclass.c",
         ":pcre2_chartables_c",
+    ],
+    hdrs = [
         "src/pcre2_compile.h",
         "src/pcre2_internal.h",
         "src/pcre2_intmodedep.h",
+        "src/pcre2_jit_match_inc.h",
+        "src/pcre2_jit_misc_inc.h",
+        "src/pcre2_printint_inc.h",
         "src/pcre2_ucp.h",
         "src/pcre2_ucptables_inc.h",
         "src/pcre2_util.h",
         ":config_h_generic",
-    ],
-    hdrs = [
         ":pcre2_h_generic",
     ],
-    copts = [
-        "-I%s/src" % (INCLUDE_PREFIX,),
-         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
-    ],
-    local_defines = [
-        "HAVE_CONFIG_H",
-        "HAVE_MEMMOVE",
-        "PCRE2_CODE_UNIT_WIDTH=8",
-        "PCRE2_STATIC",
-        "SUPPORT_UNICODE",
-    ],
+    local_defines = LOCAL_DEFINES,
     strip_include_prefix = "src",
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "pcre2",
+    hdrs = [":pcre2_h_generic"],
+    implementation_deps = [":pcre2_impl"],
+    local_defines = LOCAL_DEFINES,
     visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "pcre2-posix",
-    srcs = [
-        "src/pcre2posix.c",
-        ":config_h_generic",
-    ],
-    hdrs = [
-        "src/pcre2posix.h",
-    ],
-    copts = [
-         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
-    ],
-    local_defines = [
-        "HAVE_CONFIG_H",
-        "HAVE_MEMMOVE",
-        "PCRE2_CODE_UNIT_WIDTH=8",
-        "PCRE2_STATIC",
-        "SUPPORT_UNICODE",
-    ],
-    strip_include_prefix = "src",
+    srcs = ["src/pcre2posix.c"],
+    hdrs = ["src/pcre2posix.h"],
+    implementation_deps = [":pcre2_impl"],
+    local_defines = LOCAL_DEFINES,
     visibility = ["//visibility:public"],
     deps = [":pcre2"],
 )
@@ -128,36 +116,30 @@ cc_library(
         "src/pcre2_ucd.c",
         "src/pcre2_valid_utf.c",
     ],
-    strip_include_prefix = "src",
+    local_defines = LOCAL_DEFINES,
     visibility = ["//visibility:private"],
 )
 
 cc_binary(
     name = "pcre2test",
-    srcs = [
-        "src/pcre2test.c",
-        ":config_h_generic",
-    ],
-    copts = [
-         "-I$(BINDIR)/%s/src" % (INCLUDE_PREFIX,),
-    ],
-    local_defines = [
-        "HAVE_CONFIG_H",
-        "HAVE_MEMMOVE",
+    srcs = ["src/pcre2test.c"],
+    linkopts = select({
+        "@platforms//os:windows": ["-STACK:2500000"],
+        "//conditions:default": [],
+    }),
+    local_defines = LOCAL_DEFINES + [
         "HAVE_STRERROR",
-        "PCRE2_STATIC",
-        "SUPPORT_UNICODE",
         "SUPPORT_PCRE2_8",
     ] + select({
         "@platforms//os:windows": [],
         "//conditions:default": ["HAVE_UNISTD_H"],
     }),
-    linkopts = select({
-        "@platforms//os:windows": ["-STACK:2500000"],
-        "//conditions:default": [],
-    }),
     visibility = ["//visibility:public"],
-    deps = [":pcre2test_dotc_headers", ":pcre2", ":pcre2-posix"],
+    deps = [
+        ":pcre2-posix",
+        ":pcre2_impl",
+        ":pcre2test_dotc_headers",
+    ],
 )
 
 filegroup(
@@ -167,6 +149,7 @@ filegroup(
 
 native_test(
     name = "pcre2_test",
+    size = "small",
     src = select({
         "@platforms//os:windows": "RunTest.bat",
         "//conditions:default": "RunTest",
@@ -175,6 +158,8 @@ native_test(
         "@platforms//os:windows": "RunTest.bat",
         "//conditions:default": "RunTest",
     }),
-    data = [":pcre2test", ":testdata"],
-    size = "small",
+    data = [
+        ":pcre2test",
+        ":testdata",
+    ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -139,7 +139,7 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":pcre2-posix",
-        # ":pcre2_impl",
+        ":pcre2_impl",
         ":pcre2test_dotc_headers",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,13 +23,46 @@ copy_file(
 LOCAL_DEFINES = [
     "HAVE_CONFIG_H",
     "HAVE_MEMMOVE",
+    "HAVE_STRERROR",
     "PCRE2_CODE_UNIT_WIDTH=8",
     "PCRE2_STATIC",
+    "SUPPORT_PCRE2_8",
     "SUPPORT_UNICODE",
-]
+] + select({
+    "@platforms//os:windows": [],
+    "//conditions:default": ["HAVE_UNISTD_H"],
+})
+
+# Workaround for a Bazel quirk. It is extremely strict about the #include path
+# used for internal headers. We have our headers inside src/, but we #include
+# them as '#include "pcre2_internal.h"', assuming that src/ is added to the
+# compiler's include path. Unfortunately, that violates the conventions used by
+# Bazel.
+#
+# This is a workaround. Note that we can't use the "include = [...]" property
+# to add the src/ directory, since that pollutes the include path for projects
+# depending on PCRE2 (we must not make our config.h file visible to consumers
+# of PCRE2).
+cc_library(
+    name = "pcre2_internal_headers",
+    hdrs = [
+        "src/pcre2_jit_match_inc.h",
+        "src/pcre2_jit_misc_inc.h",
+        "src/pcre2_printint_inc.h",
+        "src/pcre2_compile.h",
+        "src/pcre2_internal.h",
+        "src/pcre2_intmodedep.h",
+        "src/pcre2_ucp.h",
+        "src/pcre2_ucptables_inc.h",
+        "src/pcre2_util.h",
+        ":config_h_generic",
+    ],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:private"],
+)
 
 cc_library(
-    name = "pcre2_impl",
+    name = "pcre2",
     srcs = [
         "src/pcre2_auto_possess.c",
         "src/pcre2_chkdint.c",
@@ -62,42 +95,22 @@ cc_library(
         "src/pcre2_xclass.c",
         ":pcre2_chartables_c",
     ],
-    hdrs = [
-        "src/pcre2_compile.h",
-        "src/pcre2_internal.h",
-        "src/pcre2_intmodedep.h",
-        "src/pcre2_jit_match_inc.h",
-        "src/pcre2_jit_misc_inc.h",
-        "src/pcre2_printint_inc.h",
-        "src/pcre2_ucp.h",
-        "src/pcre2_ucptables_inc.h",
-        "src/pcre2_util.h",
-        ":config_h_generic",
-        ":pcre2_h_generic",
-    ],
-    local_defines = LOCAL_DEFINES,
-    strip_include_prefix = "src",
-    visibility = ["//visibility:private"],
-)
-
-cc_library(
-    name = "pcre2",
     hdrs = [":pcre2_h_generic"],
-    implementation_deps = [":pcre2_impl"],
     local_defines = LOCAL_DEFINES,
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
+    implementation_deps = [":pcre2_internal_headers"],
 )
 
 cc_library(
     name = "pcre2-posix",
     srcs = ["src/pcre2posix.c"],
     hdrs = ["src/pcre2posix.h"],
-    implementation_deps = [":pcre2_impl"],
     local_defines = LOCAL_DEFINES,
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [":pcre2"],
+    implementation_deps = [":pcre2_internal_headers"],
 )
 
 # Totally weird issue in Bazel. It won't let you #include any files unless they
@@ -118,7 +131,7 @@ cc_library(
         "src/pcre2_ucd.c",
         "src/pcre2_valid_utf.c",
     ],
-    local_defines = LOCAL_DEFINES,
+    strip_include_prefix = "src",
     visibility = ["//visibility:private"],
 )
 
@@ -129,18 +142,13 @@ cc_binary(
         "@platforms//os:windows": ["-STACK:2500000"],
         "//conditions:default": [],
     }),
-    local_defines = LOCAL_DEFINES + [
-        "HAVE_STRERROR",
-        "SUPPORT_PCRE2_8",
-    ] + select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["HAVE_UNISTD_H"],
-    }),
+    local_defines = LOCAL_DEFINES,
     visibility = ["//visibility:public"],
     deps = [
         ":pcre2-posix",
-        ":pcre2_impl",
+        ":pcre2",
         ":pcre2test_dotc_headers",
+        ":pcre2_internal_headers",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -85,6 +85,7 @@ cc_library(
     hdrs = [":pcre2_h_generic"],
     implementation_deps = [":pcre2_impl"],
     local_defines = LOCAL_DEFINES,
+    strip_include_prefix = "src",
     visibility = ["//visibility:public"],
 )
 
@@ -94,6 +95,7 @@ cc_library(
     hdrs = ["src/pcre2posix.h"],
     implementation_deps = [":pcre2_impl"],
     local_defines = LOCAL_DEFINES,
+    strip_include_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [":pcre2"],
 )
@@ -137,7 +139,7 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":pcre2-posix",
-        ":pcre2_impl",
+        # ":pcre2_impl",
         ":pcre2test_dotc_headers",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,12 +46,12 @@ LOCAL_DEFINES = [
 cc_library(
     name = "pcre2_internal_headers",
     hdrs = [
-        "src/pcre2_jit_match_inc.h",
-        "src/pcre2_jit_misc_inc.h",
-        "src/pcre2_printint_inc.h",
         "src/pcre2_compile.h",
         "src/pcre2_internal.h",
         "src/pcre2_intmodedep.h",
+        "src/pcre2_jit_match_inc.h",
+        "src/pcre2_jit_misc_inc.h",
+        "src/pcre2_printint_inc.h",
         "src/pcre2_ucp.h",
         "src/pcre2_ucptables_inc.h",
         "src/pcre2_util.h",
@@ -96,21 +96,21 @@ cc_library(
         ":pcre2_chartables_c",
     ],
     hdrs = [":pcre2_h_generic"],
+    implementation_deps = [":pcre2_internal_headers"],
     local_defines = LOCAL_DEFINES,
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
-    implementation_deps = [":pcre2_internal_headers"],
 )
 
 cc_library(
     name = "pcre2-posix",
     srcs = ["src/pcre2posix.c"],
     hdrs = ["src/pcre2posix.h"],
+    implementation_deps = [":pcre2_internal_headers"],
     local_defines = LOCAL_DEFINES,
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [":pcre2"],
-    implementation_deps = [":pcre2_internal_headers"],
 )
 
 # Totally weird issue in Bazel. It won't let you #include any files unless they
@@ -145,10 +145,10 @@ cc_binary(
     local_defines = LOCAL_DEFINES,
     visibility = ["//visibility:public"],
     deps = [
-        ":pcre2-posix",
         ":pcre2",
-        ":pcre2test_dotc_headers",
+        ":pcre2-posix",
         ":pcre2_internal_headers",
+        ":pcre2test_dotc_headers",
     ],
 )
 


### PR DESCRIPTION
This is important for e.g. glib/gio, which also
has an internal config.h, and fails to compile, as it often picks up the pcre2 config.h first.