### PR TITLE
A few further tweaks to Zig 0.14 support

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -432,7 +432,7 @@ jobs:
         run: |
           # Zig does something weird with the stack - it uses more space than the
           # equivalent plain C program.
-          ulimit -S -s 16384
+          ulimit -S -s 65536
           srcdir=`pwd` pcre2test=`pwd`/zig-out/bin/pcre2test ./RunTest
 
   bazel:


### PR DESCRIPTION
Followup to #722

* Fix Windows build warning by adding PCRE2_STATIC to pcre2test
* Remove unnecessary `.linkLibc()` command, now that we have `link_libc = true` in the Module declarations
* Update the old `std.Build.Step.Compile.create(...)` calls to the brand-new `b.addLibrary(...)` function. They added this exactly for our use-case, to allow dynamically selecting between `addStaticLibrary/addDynamicLibrary` variants.