### PR TITLE
Fix some incompatible pointer casts

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -10179,8 +10179,9 @@ pcre2_real_code *re = NULL;           /* What we will return */
 compile_block cb;                     /* "Static" compile-time data */
 const uint8_t *tables;                /* Char tables base pointer */
 
+PCRE2_UCHAR null_str[1] = { 0xcd };   /* Dummy for handling null inputs */
 PCRE2_UCHAR *code;                    /* Current pointer in compiled code */
-PCRE2_UCHAR * codestart;              /* Start of compiled code */
+PCRE2_UCHAR *codestart;               /* Start of compiled code */
 PCRE2_SPTR ptr;                       /* Current pointer in pattern */
 uint32_t *pptr;                       /* Current pointer in parsed pattern */
 
@@ -10235,7 +10236,9 @@ if (errorptr == NULL || erroroffset == NULL) return NULL;
 
 if (pattern == NULL)
   {
-  if (patlen == 0) pattern = (PCRE2_SPTR)""; else
+  if (patlen == 0)
+    pattern = null_str;
+  else
     {
     *errorptr = ERR16;
     return NULL;

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -3346,6 +3346,7 @@ int was_zero_terminated = 0;
 
 const pcre2_real_code *re = (const pcre2_real_code *)code;
 
+PCRE2_UCHAR null_str[1] = { 0xcd };
 PCRE2_SPTR start_match;
 PCRE2_SPTR end_subject;
 PCRE2_SPTR bumpalong_limit;
@@ -3387,7 +3388,7 @@ rws->free = RWS_BASE_SIZE - RWS_ANCHOR_SIZE;
 
 /* Recognize NULL, length 0 as an empty string. */
 
-if (subject == NULL && length == 0) subject = (PCRE2_SPTR)"";
+if (subject == NULL && length == 0) subject = null_str;
 
 /* Plausibility checks */
 

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -6939,6 +6939,7 @@ PCRE2_UCHAR first_cu2 = 0;
 PCRE2_UCHAR req_cu = 0;
 PCRE2_UCHAR req_cu2 = 0;
 
+PCRE2_UCHAR null_str[1] = { 0xcd };
 PCRE2_SPTR bumpalong_limit;
 PCRE2_SPTR end_subject;
 PCRE2_SPTR true_end_subject;
@@ -6977,7 +6978,7 @@ match_block *mb = &actual_match_block;
 
 /* Recognize NULL, length 0 as an empty string. */
 
-if (subject == NULL && length == 0) subject = (PCRE2_SPTR)"";
+if (subject == NULL && length == 0) subject = null_str;
 
 /* Plausibility checks */
 

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -749,6 +749,7 @@ BOOL use_existing_match;
 BOOL replacement_only;
 BOOL utf = (code->overall_options & PCRE2_UTF) != 0;
 PCRE2_UCHAR temp[6];
+PCRE2_UCHAR null_str[1] = { 0xcd };
 PCRE2_SPTR ptr;
 PCRE2_SPTR repend = NULL;
 PCRE2_SIZE extra_needed = 0;
@@ -786,7 +787,7 @@ zero length is interpreted as an empty string. */
 if (replacement == NULL)
   {
   if (rlength != 0) return PCRE2_ERROR_NULL;
-  replacement = (PCRE2_SPTR)"";
+  replacement = null_str;
   }
 
 if (rlength == PCRE2_ZERO_TERMINATED) rlength = PRIV(strlen)(replacement);
@@ -859,7 +860,7 @@ scb.ovector = ovector;
 if (subject == NULL)
   {
   if (length != 0) return PCRE2_ERROR_NULL;
-  subject = (PCRE2_SPTR)"";
+  subject = null_str;
   }
 
 /* Find length of zero-terminated subject */


### PR DESCRIPTION
The value `""` is a `char[1]` array with a single zero byte. It should not be cast to a PCRE2_SPTR, which is a pointer to an array of 1/2/4-byte values. It may not even have the required pointer alignment for a PCRE2_SPTR (in 16 or 32 bit mode).

The pointer is never dereferenced anyway, since the length is zero.

Reported by Microsoft's OACR linter.

As a quick and easy fix, I'll just set it a non-null value with the shortest possible length (no zero-length arrays allowed in C).

This has the best chance of silencing linters that want us to have a non-NULL value for the zero-length pointer.