### PR TITLE
Fix a build issue due to previous CMake change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ endif()
 # setting CMAKE_MODULE_PATH on the command line.
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-include_directories(${PROJECT_BINARY_DIR}/src ${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_BINARY_DIR}/interface ${PROJECT_BINARY_DIR}/src ${PROJECT_SOURCE_DIR}/src)
 
 # external packages
 find_package(BZip2)


### PR DESCRIPTION
The problem is that the Readline/zlib include paths were being included before our own include path (wrong import order). This caused a problem if the zlib include path was /usr/local/include, and that directory happened to unfortunately contain a pcre2.h file for an (older) version of PCRE2.