### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/libpcre2-16.pc.in
+++ b/libpcre2-16.pc.in
@@ -8,6 +8,7 @@ includedir=@includedir@
 Name: libpcre2-16
 Description: PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support
 Version: @PACKAGE_VERSION@
+License: BSD-3-Clause WITH PCRE2-exception
 Libs: -L${libdir} -lpcre2-16@LIB_POSTFIX@
 Libs.private: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@
 Cflags: -I${includedir} @PCRE2_STATIC_CFLAG@

--- a/libpcre2-32.pc.in
+++ b/libpcre2-32.pc.in
@@ -8,6 +8,7 @@ includedir=@includedir@
 Name: libpcre2-32
 Description: PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support
 Version: @PACKAGE_VERSION@
+License: BSD-3-Clause WITH PCRE2-exception
 Libs: -L${libdir} -lpcre2-32@LIB_POSTFIX@
 Libs.private: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@
 Cflags: -I${includedir} @PCRE2_STATIC_CFLAG@

--- a/libpcre2-8.pc.in
+++ b/libpcre2-8.pc.in
@@ -8,6 +8,7 @@ includedir=@includedir@
 Name: libpcre2-8
 Description: PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support
 Version: @PACKAGE_VERSION@
+License: BSD-3-Clause WITH PCRE2-exception
 Libs: -L${libdir} -lpcre2-8@LIB_POSTFIX@
 Libs.private: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@
 Cflags: -I${includedir} @PCRE2_STATIC_CFLAG@

--- a/libpcre2-posix.pc.in
+++ b/libpcre2-posix.pc.in
@@ -8,6 +8,7 @@ includedir=@includedir@
 Name: libpcre2-posix
 Description: Posix compatible interface to libpcre2-8
 Version: @PACKAGE_VERSION@
+License: BSD-3-Clause WITH PCRE2-exception
 Libs: -L${libdir} -lpcre2-posix@LIB_POSTFIX@
 Cflags: -I${includedir} @PCRE2POSIX_CFLAG@
 Requires.private: libpcre2-8


### PR DESCRIPTION
The pkg-config file has License variable that that sets the software license.
This sets 'BSD-3-Clause WITH PCRE2-exception' as defined in SPDX to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116