### PR TITLE
Add a simple .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig helps ensure that files are opened in editors with the correct
+# settings, regardless of the editor or platform. See http://editorconfig.org.
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+
+[Makefile.am]
+indent_style = tab
+
+[*.bat]
+end_of_line = crlf
+
+[testdata/*]
+insert_final_newline = false
+trim_trailing_whitespace = false
+
+[testdata/test{input,output}{1,2,3,3A,3B,3C,6,28,29}]
+charset = latin1

--- a/Makefile.am
+++ b/Makefile.am
@@ -338,13 +338,13 @@ src/config.h.generic: configure.ac
 	cs=$(srcdir)/config.status; test ! -f $$cs.aside || mv -f $$cs.aside $$cs
 	test -f _generic/src/config.h
 	perl -n \
-	  -e 'BEGIN{$$blank=0;}' \
-	  -e 'if(/(.+?)\s*__attribute__ \(\(visibility/){print"$$1\n";$$blank=0;next;}' \
-	  -e 'if(/LT_OBJDIR/){print"/* This is ignored unless you are using libtool. */\n";}' \
-	  -e 'if(/^#define\s((?:HAVE|SUPPORT|STDC)_\w+)/){print"/* #undef $$1 */\n";$$blank=0;next;}' \
-	  -e 'if(/^#define\s(?!PACKAGE|VERSION)(\w+)/){print"#ifndef $$1\n$$_#endif\n";$$blank=0;next;}' \
-	  -e 'if(/^\s*$$/){print unless $$blank; $$blank=1;} else{print;$$blank=0;}' \
-	  _generic/src/config.h >$@
+		-e 'BEGIN{$$blank=0;}' \
+		-e 'if(/(.+?)\s*__attribute__ \(\(visibility/){print"$$1\n";$$blank=0;next;}' \
+		-e 'if(/LT_OBJDIR/){print"/* This is ignored unless you are using libtool. */\n";}' \
+		-e 'if(/^#define\s((?:HAVE|SUPPORT|STDC)_\w+)/){print"/* #undef $$1 */\n";$$blank=0;next;}' \
+		-e 'if(/^#define\s(?!PACKAGE|VERSION)(\w+)/){print"#ifndef $$1\n$$_#endif\n";$$blank=0;next;}' \
+		-e 'if(/^\s*$$/){print unless $$blank; $$blank=1;} else{print;$$blank=0;}' \
+		_generic/src/config.h >$@
 	rm -rf _generic
 
 MAINTAINERCLEANFILES += src/pcre2.h.generic src/config.h.generic
@@ -847,20 +847,20 @@ EXTRA_DIST += \
 # they don't, add their working files to CLEANFILES.
 
 CLEANFILES += \
-        testSinput \
-        testSoutput \
-        test3input \
-        test3output \
-        test3outputA \
-        test3outputB \
-        testtry \
-        teststdout \
-        teststderr \
-        teststderrgrep \
-        testtemp1grep \
-        testtemp2grep \
-        testtrygrep \
-        testNinputgrep
+  testSinput \
+  testSoutput \
+  test3input \
+  test3output \
+  test3outputA \
+  test3outputB \
+  testtry \
+  teststdout \
+  teststderr \
+  teststderrgrep \
+  testtemp1grep \
+  testtemp2grep \
+  testtrygrep \
+  testNinputgrep
 
 testoutput-clean:
 	-rm -rf testoutput8 testoutput8-jit testoutput8-dfa


### PR DESCRIPTION
This fixes some annoyances for me. I need to insert tabs into the makefiles and spaces elsewhere; I don't want trailing whitespace to be stripped when I edit the test files; and I need to open testinput1 in Latin-1 and testinput2 in UTF-8 mode. All this can be automated.

The editorconfig file should work with any text editor - although note that VS Code needs an extension to make use of it.