### PR TITLE
pcre2_match_data: allow pcre2_match_data_create_from_pattern() with a NULL as the first parameter

### DIFF
--- a/doc/pcre2_match_data_create_from_pattern.3
+++ b/doc/pcre2_match_data_create_from_pattern.3
@@ -15,19 +15,19 @@ PCRE2 - Perl-compatible regular expressions (revised API)
 .rs
 .sp
 This function creates a new match data block for holding the result of a match.
-The first argument points to a compiled pattern. The number of capturing
-parentheses within the pattern is used to compute the number of pairs of
-offsets that are required in the match data block. These form the "output
-vector" (ovector) within the match data block, and are used to identify the
-matched string and any captured substrings when matching with
-\fBpcre2_match()\fP. If you are using \fBpcre2_dfa_match()\fP, which uses the
-output vector in a different way, you should use \fBpcre2_match_data_create()\fP
-instead of this function.
+If the first argument is NULL, this function returns NULL, otherwise the first
+argument points to a compiled pattern. The number of capturing parentheses
+within the pattern is used to compute the number of pairs of offsets that are
+required in the match data block. These form the "output vector" (ovector)
+within the match data block, and are used to identify the matched string and
+any captured substrings when matching with \fBpcre2_match()\fP. If you are
+using \fBpcre2_dfa_match()\fP, which uses the output vector in a different way,
+you should use \fBpcre2_match_data_create()\fP instead of this function.
 .P
 The second argument points to a general context, for custom memory management,
-or is NULL to use the same memory allocator as was used for the compiled
+or is NULL to use the same memory allocator that was used for the compiled
 pattern. The result of the function is NULL if the memory for the block could
-not be obtained.
+not be obtained or if NULL was provided as the first argument.
 .P
 There is a complete description of the PCRE2 native API in the
 .\" HREF

--- a/src/pcre2_match_data.c
+++ b/src/pcre2_match_data.c
@@ -81,6 +81,7 @@ PCRE2_EXP_DEFN pcre2_match_data * PCRE2_CALL_CONVENTION
 pcre2_match_data_create_from_pattern(const pcre2_code *code,
   pcre2_general_context *gcontext)
 {
+if (code == NULL) return NULL;
 if (gcontext == NULL) gcontext = (pcre2_general_context *)code;
 return pcre2_match_data_create(((const pcre2_real_code *)code)->top_bracket + 1,
   gcontext);


### PR DESCRIPTION
would allow something like:

```c
re = pcre2_compile(...);
can_jit = !pcre2_jit_compile(re, PCRE2_JIT_TEST_ALLOC);
md = pcre2_match_data_create_from_pattern(re, ...);
if (re != NULL && md != NULL) do {
  /* do some work here, including matches and maybe even some on demand JIT compilation */
} while (!done_matching_or_replacing)
/* do some cleanup here, no need to check for NULL when calling the corresponding `_free()` functions */
```

which matches a similar construct that uses pcre2_match_data_create() instead.