### PR TITLE
pcre2test: improve `expand` and its use of buffers

### DIFF
--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -563,7 +563,9 @@ part of the file. For example:
   \e[abc]{4}
 .sp
 is converted to "abcabcabcabc". This feature does not support nesting. To
-include a closing square bracket in the characters, code it as \ex5D.
+include a closing square bracket in the characters, code it with \ex followed
+by two hexadecimal digits that represent that letter in the character set used
+(e.g. \ex5D for ASCII or UTF-8).
 .P
 A backslash followed by an equals sign marks the end of the subject string and
 the start of a modifier list. For example:
@@ -1286,7 +1288,7 @@ the subject string. For more detail of REG_STARTEND, see the
 \fBpcre2posix\fP
 .\"
 documentation. If the subject string contains binary zeros (coded as escapes
-such as \ex{00} because \fBpcre2test\fP does not support actual binary zeros in
+such as \ex00 because \fBpcre2test\fP does not support actual binary zeros in
 its input), you must use \fBposix_startend\fP to specify its length.
 .
 .

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -4589,9 +4589,6 @@
 /(abc)*/
     \[abc]{1}
 
-/(abc)*/
-    \[abc]{0}
-
 /^/gm
     \n\n\n
 
@@ -5136,11 +5133,28 @@ a)"xI
 \= Expect no match
     abc
 
+# Expand tests
+
+/(abc)*/
+    \[abc]{0}
+    \[abc]{}
+
 /aaa/
-\[abc]{10000000000000000000000000000}
-\[a]{3}
+    \[X]{-10}
+    \[abc]{10000000000000000000000000000}
+    \[a]{3}
 
 /\[AB]{6000000000000000000000}/expand
+
+/\[AB]{0000000000000000000000}/expand
+
+/a\[b]{-1}/BI,expand
+
+/a\[b]{/BI,expand
+
+/a\[/BI,expand
+
+//BI,expand
 
 # Hex uses pattern length, not zero-terminated. This tests for overrunning
 # the given length of a pattern.
@@ -6324,9 +6338,6 @@ a)"xI
 /[Aa]{2,3}/BI
     aabcd
 
---
-    \[X]{-10}
-    
 # Check imposition of maximum by match_data_create().
 
 /abcd/

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -15177,10 +15177,6 @@ No match
  0: abc
  1: abc
 
-/(abc)*/
-    \[abc]{0}
-** Zero or negative repeat not allowed
-
 /^/gm
     \n\n\n
  0: 
@@ -16358,14 +16354,77 @@ Failed: error 122 at offset 11: unmatched closing parenthesis
   0    ^    0
 No match
 
+# Expand tests
+
+/(abc)*/
+    \[abc]{0}
+** Replication count missing or invalid (1..INT_MAX)
+    \[abc]{}
+** Replication count missing or invalid (1..INT_MAX)
+
 /aaa/
-\[abc]{10000000000000000000000000000}
-** Repeat count too large
-\[a]{3}
+    \[X]{-10}
+** Replication count missing or invalid (1..INT_MAX)
+    \[abc]{10000000000000000000000000000}
+** Replication count missing or invalid (1..INT_MAX)
+    \[a]{3}
  0: aaa
 
 /\[AB]{6000000000000000000000}/expand
-** Pattern repeat count too large
+** Invalid replication count (1..UINT_MAX)
+
+/\[AB]{0000000000000000000000}/expand
+** Invalid replication count (1..UINT_MAX)
+
+/a\[b]{-1}/BI,expand
+Expanded: a\[b]{-1}
+------------------------------------------------------------------
+        Bra
+        a[b]{-1}
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+First code unit = 'a'
+Last code unit = '}'
+Subject length lower bound = 8
+
+/a\[b]{/BI,expand
+Expanded: a\[b]{
+------------------------------------------------------------------
+        Bra
+        a[b]{
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+First code unit = 'a'
+Last code unit = '{'
+Subject length lower bound = 5
+
+/a\[/BI,expand
+Expanded: a\[
+------------------------------------------------------------------
+        Bra
+        a[
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+First code unit = 'a'
+Last code unit = '['
+Subject length lower bound = 2
+
+//BI,expand
+Expanded: 
+------------------------------------------------------------------
+        Bra
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+May match empty string
+Subject length lower bound = 0
 
 # Hex uses pattern length, not zero-terminated. This tests for overrunning
 # the given length of a pattern.
@@ -18979,10 +19038,6 @@ Subject length lower bound = 2
     aabcd
  0: aa
 
---
-    \[X]{-10}
-** Zero or negative repeat not allowed
-    
 # Check imposition of maximum by match_data_create().
 
 /abcd/


### PR DESCRIPTION
Mainly as a way to clean the code and make it more resilient.

It changes the behavior of the pattern `/\[]{-1}/expand` which will now be treated as a literal instead of triggering a bogus syntax error and clarifies that no pattern or buffer could be larger than SIZE_MAX bytes.

Improves error checking for 32-bit platforms and even 64-bit ones that are not LP64. 