### PR TITLE
pcre2_config: address inconsistency with the linksize reported in non 8-bit libraries

### DIFF
--- a/RunTest
+++ b/RunTest
@@ -337,15 +337,6 @@ while [ $# -gt 0 ] ; do
   shift
 done
 
-# Find which optional facilities are available.
-
-$sim $pcre2test -C linksize >/dev/null
-link_size=$?
-if [ $link_size -lt 2 ] || [ $link_size -gt 4 ] ; then
-  echo "RunTest: Failed to find internal link size"
-  exit 1
-fi
-
 # If it is possible to set the system stack size and -bigstack was given,
 # set up a large stack.
 

--- a/RunTest
+++ b/RunTest
@@ -341,11 +341,7 @@ done
 
 $sim $pcre2test -C linksize >/dev/null
 link_size=$?
-if [ $link_size -lt 2 ] ; then
-  echo "RunTest: Failed to find internal link size"
-  exit 1
-fi
-if [ $link_size -gt 4 ] ; then
+if [ $link_size -lt 2 ] || [ $link_size -gt 4 ] ; then
   echo "RunTest: Failed to find internal link size"
   exit 1
 fi
@@ -725,12 +721,8 @@ for bmode in "$test8" "$test16" "$test32"; do
 
   if [ $do8 = yes ] ; then
     echo $title8
-    bits_link_size=$link_size
-    if [ $bits = "16" -a $link_size = "3" ] ; then
-      bits_link_size=4
-    elif [ $bits = "32" ] ; then
-      bits_link_size=4
-    fi
+    $sim $pcre2test -$bits -C linksize >/dev/null
+    bits_link_size=$?
     if [ $utf -eq 0 ] ; then
       echo "  Skipped because UTF-$bits support is not available"
     else

--- a/RunTest.bat
+++ b/RunTest.bat
@@ -1,8 +1,7 @@
 @echo off
 @rem
 @rem MS Windows batch file to run pcre2test on testfiles with the correct
-@rem options. This file must use CRLF linebreaks to function properly,
-@rem and requires both pcre2test and pcre2grep.
+@rem options. This file must use CRLF linebreaks to function properly.
 @rem
 @rem ------------------------ HISTORY ----------------------------------
 @rem This file was originally contributed to PCRE1 by Ralf Junker, and touched
@@ -14,7 +13,7 @@
 @rem
 @rem Sheri Pierce added logic to skip feature dependent tests
 @rem tests 4 5 7 10 12 14 19 22 25 and 26 require Unicode support
-@rem 8 requires Unicode and link size 2
+@rem 8 requires Unicode
 @rem 16 requires absence of jit support
 @rem 17 requires presence of jit support
 @rem Sheri P also added override tests for study and jit testing
@@ -57,8 +56,6 @@ call :conferror
 exit /b 1
 )
 
-%pcre2test% -C linksize >NUL
-set link_size=%ERRORLEVEL%
 %pcre2test% -C pcre2-8 >NUL
 set support8=%ERRORLEVEL%
 %pcre2test% -C pcre2-16 >NUL
@@ -269,9 +266,8 @@ if [%3] == [] (
 )
 
 if %1 == 8 (
-  set bits_link_size=%link_size%
-  if %bits% EQU 16 if %link_size% EQU 3 set bits_link_size=4
-  if %bits% EQU 32 set bits_link_size=4
+  %pcre2test% -%bits% -C linksize >NUL
+  set bits_link_size=!ERRORLEVEL!
   set outnum=%1-%bits%-!bits_link_size!
 ) else if %1 == 11 (
   set outnum=%1-%bits%
@@ -379,10 +375,6 @@ if %unicode% EQU 0 (
   goto :eof
 
 :do8
-if NOT %link_size% EQU 2 (
-  echo Test 8 Skipped because link size is not 2.
-  goto :eof
-)
 if %unicode% EQU 0 (
   echo Test 8 Skipped due to absence of Unicode support.
   goto :eof

--- a/doc/index.html.src
+++ b/doc/index.html.src
@@ -129,7 +129,7 @@ in the library.
     <td>Free a compile context</td></tr>
 
 <tr><td><a href="pcre2_config.html">pcre2_config</a></td>
-    <td>Show build-time configuration options</td></tr>
+    <td>Show build-time related configuration options</td></tr>
 
 <tr><td><a href="pcre2_convert_context_copy.html">pcre2_convert_context_copy</a></td>
     <td>Copy a convert context</td></tr>

--- a/doc/pcre2_config.3
+++ b/doc/pcre2_config.3
@@ -29,36 +29,37 @@ PCRE2_CONFIG_UNICODE_VERSION, and PCRE2_CONFIG_VERSION it must point to a
 buffer that is large enough to hold the string. For all other codes it must
 point to a uint32_t integer variable. The available codes are:
 .sp
-  PCRE2_CONFIG_BSR             Indicates what \eR matches by default:
-                                 PCRE2_BSR_UNICODE
-                                 PCRE2_BSR_ANYCRLF
-  PCRE2_CONFIG_COMPILED_WIDTHS Which of 8/16/32 support was compiled
-  PCRE2_CONFIG_DEPTHLIMIT      Default backtracking depth limit
-  PCRE2_CONFIG_HEAPLIMIT       Default heap memory limit
+  PCRE2_CONFIG_BSR                Indicates what \eR matches by default:
+                                    PCRE2_BSR_UNICODE
+                                    PCRE2_BSR_ANYCRLF
+  PCRE2_CONFIG_COMPILED_WIDTHS    Which of 8/16/32 support was compiled
+  PCRE2_CONFIG_DEPTHLIMIT         Default backtracking depth limit
+  PCRE2_CONFIG_EFFECTIVE_LINKSIZE How many bytes are used for link size
+  PCRE2_CONFIG_HEAPLIMIT          Default heap memory limit
 .\" JOIN
-  PCRE2_CONFIG_JIT             Availability of just-in-time compiler
-                                support (1=yes 0=no)
+  PCRE2_CONFIG_JIT                Availability of just-in-time compiler
+                                   support (1=yes 0=no)
 .\" JOIN
-  PCRE2_CONFIG_JITTARGET       Information (a string) about the target
-                                 architecture for the JIT compiler
-  PCRE2_CONFIG_LINKSIZE        Configured internal link size (2, 3, 4)
-  PCRE2_CONFIG_MATCHLIMIT      Default internal resource limit
+  PCRE2_CONFIG_JITTARGET          Information (a string) about the target
+                                   architecture for the JIT compiler
+  PCRE2_CONFIG_LINKSIZE           Configured internal link size (2, 3, 4)
+  PCRE2_CONFIG_MATCHLIMIT         Default internal resource limit
   PCRE2_CONFIG_NEVER_BACKSLASH_C  Whether or not \eC is disabled
-  PCRE2_CONFIG_NEWLINE         Code for the default newline sequence:
-                                 PCRE2_NEWLINE_CR
-                                 PCRE2_NEWLINE_LF
-                                 PCRE2_NEWLINE_CRLF
-                                 PCRE2_NEWLINE_ANY
-                                 PCRE2_NEWLINE_ANYCRLF
-                                 PCRE2_NEWLINE_NUL
-  PCRE2_CONFIG_PARENSLIMIT     Default parentheses nesting limit
-  PCRE2_CONFIG_RECURSIONLIMIT  Obsolete: use PCRE2_CONFIG_DEPTHLIMIT
-  PCRE2_CONFIG_STACKRECURSE    Obsolete: always returns 0
+  PCRE2_CONFIG_NEWLINE            Code for the default newline sequence:
+                                    PCRE2_NEWLINE_CR
+                                    PCRE2_NEWLINE_LF
+                                    PCRE2_NEWLINE_CRLF
+                                    PCRE2_NEWLINE_ANY
+                                    PCRE2_NEWLINE_ANYCRLF
+                                    PCRE2_NEWLINE_NUL
+  PCRE2_CONFIG_PARENSLIMIT        Default parentheses nesting limit
+  PCRE2_CONFIG_RECURSIONLIMIT     Obsolete: use PCRE2_CONFIG_DEPTHLIMIT
+  PCRE2_CONFIG_STACKRECURSE       Obsolete: always returns 0
 .\" JOIN
-  PCRE2_CONFIG_UNICODE         Availability of Unicode support (1=yes
-                                 0=no)
-  PCRE2_CONFIG_UNICODE_VERSION The Unicode version (a string)
-  PCRE2_CONFIG_VERSION         The PCRE2 version (a string)
+  PCRE2_CONFIG_UNICODE            Availability of Unicode support
+                                   (1=yes 0=no)
+  PCRE2_CONFIG_UNICODE_VERSION    The Unicode version (a string)
+  PCRE2_CONFIG_VERSION            The PCRE2 version (a string)
 .sp
 The function yields a non-negative value on success or the negative value
 PCRE2_ERROR_BADOPTION otherwise. This is also the result for the

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -497,7 +497,7 @@ compiled patterns on disc or elsewhere, and reloading them later.
 .P
 Finally, there are functions for finding out information about a compiled
 pattern (\fBpcre2_pattern_info()\fP) and about the configuration with which
-PCRE2 was built (\fBpcre2_config()\fP).
+PCRE2 was built (\fBpcre2_config()\fP) and that it is using.
 .P
 Functions with names ending with \fB_free()\fP are used for freeing memory
 blocks of various sorts. In all cases, if one of these functions is called with
@@ -1266,6 +1266,13 @@ nested backtracking in \fBpcre2_match()\fP or the depth of nested recursions,
 lookarounds, and atomic groups in \fBpcre2_dfa_match()\fP. Further details are
 given with \fBpcre2_set_depth_limit()\fP above.
 .sp
+  PCRE2_CONFIG_EFFECTIVE_LINKSIZE
+.sp
+The output is a uint32_t integer that contains the number of bytes the library
+uses for internal linkage in compiled regular expressions. Its value is derived
+from the value that was provided at build time and that is described below by
+PCRE2_CONFIG_LINKSIZE.
+.sp
   PCRE2_CONFIG_HEAPLIMIT
 .sp
 The output is a uint32_t integer that gives, in kibibytes, the default limit
@@ -1300,13 +1307,14 @@ for the terminating zero.
 .sp
   PCRE2_CONFIG_LINKSIZE
 .sp
-The output is a uint32_t integer that contains the number of bytes used for
-internal linkage in compiled regular expressions. When PCRE2 is configured, the
-value can be set to 2, 3, or 4, with the default being 2. This is the value
-that is returned by \fBpcre2_config()\fP. However, when the 16-bit library is
-compiled, a value of 3 is rounded up to 4, and when the 32-bit library is
-compiled, internal linkages always use 4 bytes, so the configured value is not
-relevant.
+The output is a uint32_t integer that contains the number of bytes the library
+was instructed to use for internal linkage in compiled regular expressions.
+When PCRE2 is configured, the value can be set to 2, 3, or 4, with the default
+being 2 for most libraries.
+.P
+The actual number of bytes used depends on the size of the code units that the
+library supports and can be higher. See PCRE2_CONFIG_EFFECTIVE_LINKSIZE above
+for details.
 .P
 The default value of 2 for the 8-bit and 16-bit libraries is sufficient for all
 but the most massive patterns, since it allows the size of the compiled pattern

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -487,6 +487,7 @@ released, the numbers must not be changed. */
 #define PCRE2_CONFIG_NEVER_BACKSLASH_C      13
 #define PCRE2_CONFIG_COMPILED_WIDTHS        14
 #define PCRE2_CONFIG_TABLES_LENGTH          15
+#define PCRE2_CONFIG_EFFECTIVE_LINKSIZE     16
 
 /* Optimization directives for pcre2_set_optimize().
 For binary compatibility, only add to this list; do not renumber. */

--- a/src/pcre2_config.c
+++ b/src/pcre2_config.c
@@ -72,7 +72,7 @@ pcre2_config(uint32_t what, void *where)
 {
 if (where == NULL)  /* Requests a length */
   {
-  switch(what)
+  switch (what)
     {
     default:
     return PCRE2_ERROR_BADOPTION;
@@ -80,6 +80,7 @@ if (where == NULL)  /* Requests a length */
     case PCRE2_CONFIG_BSR:
     case PCRE2_CONFIG_COMPILED_WIDTHS:
     case PCRE2_CONFIG_DEPTHLIMIT:
+    case PCRE2_CONFIG_EFFECTIVE_LINKSIZE:
     case PCRE2_CONFIG_HEAPLIMIT:
     case PCRE2_CONFIG_JIT:
     case PCRE2_CONFIG_LINKSIZE:
@@ -117,19 +118,23 @@ switch (what)
   case PCRE2_CONFIG_COMPILED_WIDTHS:
   *((uint32_t *)where) = 0
 #ifdef SUPPORT_PCRE2_8
-  + 1
+  + (1 << 0)
 #endif
 #ifdef SUPPORT_PCRE2_16
-  + 2
+  + (1 << 1)
 #endif
 #ifdef SUPPORT_PCRE2_32
-  + 4
+  + (1 << 2)
 #endif
   ;
   break;
 
   case PCRE2_CONFIG_DEPTHLIMIT:
   *((uint32_t *)where) = MATCH_LIMIT_DEPTH;
+  break;
+
+  case PCRE2_CONFIG_EFFECTIVE_LINKSIZE:
+  *((uint32_t *)where) = LINK_SIZE * sizeof(PCRE2_UCHAR);
   break;
 
   case PCRE2_CONFIG_HEAPLIMIT:
@@ -199,8 +204,7 @@ switch (what)
 #endif
     return (int)(1 + ((where == NULL)?
       strlen(v) : PRIV(strcpy_c8)((PCRE2_UCHAR *)where, v)));
-   }
-  break;
+    }
 
   case PCRE2_CONFIG_UNICODE:
 #if defined SUPPORT_UNICODE
@@ -237,6 +241,7 @@ switch (what)
     return (int)(1 + ((where == NULL)?
       strlen(v) : PRIV(strcpy_c8)((PCRE2_UCHAR *)where, v)));
     }
+
   }
 
 return 0;

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -413,7 +413,6 @@ modes, so use the form of the first that is available. */
 #if defined SUPPORT_PCRE2_8
 #define DEFAULT_TEST_MODE PCRE8_MODE
 #define VERSION_TYPE PCRE2_UCHAR8
-#define PCRE2_CONFIG pcre2_config_8
 #define PCRE2_JIT_STACK pcre2_jit_stack_8
 #define PCRE2_REAL_GENERAL_CONTEXT pcre2_real_general_context_8
 #define PCRE2_REAL_COMPILE_CONTEXT pcre2_real_compile_context_8
@@ -423,7 +422,6 @@ modes, so use the form of the first that is available. */
 #elif defined SUPPORT_PCRE2_16
 #define DEFAULT_TEST_MODE PCRE16_MODE
 #define VERSION_TYPE PCRE2_UCHAR16
-#define PCRE2_CONFIG pcre2_config_16
 #define PCRE2_JIT_STACK pcre2_jit_stack_16
 #define PCRE2_REAL_GENERAL_CONTEXT pcre2_real_general_context_16
 #define PCRE2_REAL_COMPILE_CONTEXT pcre2_real_compile_context_16
@@ -433,7 +431,6 @@ modes, so use the form of the first that is available. */
 #elif defined SUPPORT_PCRE2_32
 #define DEFAULT_TEST_MODE PCRE32_MODE
 #define VERSION_TYPE PCRE2_UCHAR32
-#define PCRE2_CONFIG pcre2_config_32
 #define PCRE2_JIT_STACK pcre2_jit_stack_32
 #define PCRE2_REAL_GENERAL_CONTEXT pcre2_real_general_context_32
 #define PCRE2_REAL_COMPILE_CONTEXT pcre2_real_compile_context_32
@@ -996,7 +993,7 @@ static coptstruct coptlist[] = {
   { "ebcdic-nl25", CONF_FIX, SUPPORT_EBCDIC_NL25 },
   { "jit",         CONF_INT, PCRE2_CONFIG_JIT },
   { "jitusable",   CONF_JU,  0 },
-  { "linksize",    CONF_INT, PCRE2_CONFIG_LINKSIZE },
+  { "linksize",    CONF_INT, PCRE2_CONFIG_EFFECTIVE_LINKSIZE },
   { "newline",     CONF_NL,  PCRE2_CONFIG_NEWLINE },
   { "pcre2-16",    CONF_FIX, SUPPORT_16 },
   { "pcre2-32",    CONF_FIX, SUPPORT_32 },
@@ -1269,6 +1266,22 @@ are supported. */
     G(a,16) = pcre2_compile_16(b,c,d,e,f,g); \
   else \
     G(a,32) = pcre2_compile_32(b,c,d,e,f,g)
+
+#define PCRE2_CONFIG(lv,a,b) \
+  if (test_mode == PCRE8_MODE) \
+    lv = pcre2_config_8(a,b); \
+  else if (test_mode == PCRE16_MODE) \
+    lv = pcre2_config_16(a,b); \
+  else \
+    lv = pcre2_config_32(a,b)
+
+#define PCRE2_CONFIGV(a,b) \
+  if (test_mode == PCRE8_MODE) \
+    (void)pcre2_config_8(a,b); \
+  else if (test_mode == PCRE16_MODE) \
+    (void)pcre2_config_16(a,b); \
+  else \
+    (void)pcre2_config_32(a,b)
 
 #define PCRE2_CONVERTED_PATTERN_FREE(a) \
   if (test_mode == PCRE8_MODE) pcre2_converted_pattern_free_8((PCRE2_UCHAR8 *)a); \
@@ -1852,6 +1865,18 @@ the three different cases. */
   else \
     G(a,BITTWO) = G(pcre2_compile_,BITTWO)(b,c,d,e,f,g)
 
+#define PCRE2_CONFIG(lv,a,b) \
+  if (test_mode == G(G(PCRE,BITONE),_MODE)) \
+    lv = G(pcre2_config_,BITONE)(a,b); \
+  else \
+    lv = G(pcre2_config_,BITTWO)(a,b)
+
+#define PCRE2_CONFIGV(a,b) \
+  if (test_mode == G(G(PCRE,BITONE),_MODE)) \
+    (void)G(pcre2_config_,BITONE)(a,b); \
+  else \
+    (void)G(pcre2_config_,BITTWO)(a,b)
+
 #define PCRE2_CONVERTED_PATTERN_FREE(a) \
   if (test_mode == G(G(PCRE,BITONE),_MODE)) \
     G(pcre2_converted_pattern_free_,BITONE)((G(PCRE2_UCHAR,BITONE) *)a); \
@@ -2267,6 +2292,8 @@ the three different cases. */
 #define PCRE2_CODE_COPY_TO_VOID(a,b) a = (void *)pcre2_code_copy_8(G(b,8))
 #define PCRE2_CODE_COPY_WITH_TABLES_TO_VOID(a,b) a = (void *)pcre2_code_copy_with_tables_8(G(b,8))
 #define PCRE2_COMPILE(a,b,c,d,e,f,g) G(a,8) = pcre2_compile_8(b,c,d,e,f,g)
+#define PCRE2_CONFIG(lv,a,b) lv = pcre2_config_8(a,b)
+#define PCRE2_CONFIGV(a,b) (void)pcre2_config_8(a,b)
 #define PCRE2_CONVERTED_PATTERN_FREE(a) \
   pcre2_converted_pattern_free_8((PCRE2_UCHAR8 *)a)
 #define PCRE2_DFA_MATCH(a,b,c,d,e,f,g,h,i,j) \
@@ -2384,6 +2411,8 @@ the three different cases. */
 #define PCRE2_CODE_COPY_TO_VOID(a,b) a = (void *)pcre2_code_copy_16(G(b,16))
 #define PCRE2_CODE_COPY_WITH_TABLES_TO_VOID(a,b) a = (void *)pcre2_code_copy_with_tables_16(G(b,16))
 #define PCRE2_COMPILE(a,b,c,d,e,f,g) G(a,16) = pcre2_compile_16(b,c,d,e,f,g)
+#define PCRE2_CONFIG(lv,a,b) lv = pcre2_config_16(a,b)
+#define PCRE2_CONFIGV(a,b) (void)pcre2_config_16(a,b)
 #define PCRE2_CONVERTED_PATTERN_FREE(a) \
   pcre2_converted_pattern_free_16((PCRE2_UCHAR16 *)a)
 #define PCRE2_DFA_MATCH(a,b,c,d,e,f,g,h,i,j) \
@@ -2499,6 +2528,8 @@ the three different cases. */
 #define PCRE2_CODE_COPY_TO_VOID(a,b) a = (void *)pcre2_code_copy_32(G(b,32))
 #define PCRE2_CODE_COPY_WITH_TABLES_TO_VOID(a,b) a = (void *)pcre2_code_copy_with_tables_32(G(b,32))
 #define PCRE2_COMPILE(a,b,c,d,e,f,g) G(a,32) = pcre2_compile_32(b,c,d,e,f,g)
+#define PCRE2_CONFIG(lv,a,b) lv = pcre2_config_32(a,b)
+#define PCRE2_CONFIGV(a,b) (void)pcre2_config_32(a,b)
 #define PCRE2_CONVERTED_PATTERN_FREE(a) \
   pcre2_converted_pattern_free_32((PCRE2_UCHAR32 *)a)
 #define PCRE2_DFA_MATCH(a,b,c,d,e,f,g,h,i,j) \
@@ -5881,13 +5912,14 @@ switch(cmd)
 
   if (tables3 == NULL)
     {
-    (void)PCRE2_CONFIG(PCRE2_CONFIG_TABLES_LENGTH, &loadtables_length);
-    tables3 = malloc(loadtables_length);
+    int r;
+    PCRE2_CONFIG(r, PCRE2_CONFIG_TABLES_LENGTH, &loadtables_length);
+    if (r >= 0) tables3 = malloc(loadtables_length);
     }
 
   if (tables3 == NULL)
     {
-    fprintf(outfile, "** Failed: malloc failed for #loadtables\n");
+    fprintf(outfile, "** Failed: malloc/config for #loadtables\n");
     yield = PR_ABEND;
     }
   else if (fread(tables3, 1, loadtables_length, f) != loadtables_length)
@@ -9796,7 +9828,7 @@ if (arg != NULL && arg[0] != '-')
   switch (coptlist[i].type)
     {
     case CONF_BSR:
-    (void)PCRE2_CONFIG(coptlist[i].value, &optval);
+    PCRE2_CONFIGV(coptlist[i].value, &optval);
     printf("%s\n", (optval == PCRE2_BSR_ANYCRLF)? "ANYCRLF" : "ANY");
     break;
 
@@ -9806,12 +9838,12 @@ if (arg != NULL && arg[0] != '-')
     break;
 
     case CONF_INT:
-    (void)PCRE2_CONFIG(coptlist[i].value, &yield);
+    PCRE2_CONFIGV(coptlist[i].value, &yield);
     printf("%d\n", yield);
     break;
 
     case CONF_NL:
-    (void)PCRE2_CONFIG(coptlist[i].value, &optval);
+    PCRE2_CONFIGV(coptlist[i].value, &optval);
     print_newline_config(optval, TRUE);
     break;
 
@@ -9881,7 +9913,7 @@ printf("  Input/output for pcre2test is ASCII, not EBCDIC\n");
 #endif
 #endif
 
-(void)PCRE2_CONFIG(PCRE2_CONFIG_COMPILED_WIDTHS, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_COMPILED_WIDTHS, &optval);
 if (optval & 1) printf("  8-bit support\n");
 if (optval & 2) printf("  16-bit support\n");
 if (optval & 4) printf("  32-bit support\n");
@@ -9890,7 +9922,7 @@ if (optval & 4) printf("  32-bit support\n");
 printf("  Valgrind support\n");
 #endif
 
-(void)PCRE2_CONFIG(PCRE2_CONFIG_UNICODE, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_UNICODE, &optval);
 if (optval != 0)
   {
   printf("  UTF and UCP support (");
@@ -9899,7 +9931,7 @@ if (optval != 0)
   }
 else printf("  No Unicode support\n");
 
-(void)PCRE2_CONFIG(PCRE2_CONFIG_JIT, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_JIT, &optval);
 if (optval != 0)
   {
   printf("  Just-in-time compiler support\n");
@@ -9932,23 +9964,26 @@ else
   printf("  No just-in-time compiler support\n");
   }
 
-(void)PCRE2_CONFIG(PCRE2_CONFIG_NEWLINE, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_NEWLINE, &optval);
 print_newline_config(optval, FALSE);
-(void)PCRE2_CONFIG(PCRE2_CONFIG_BSR, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_BSR, &optval);
 printf("  \\R matches %s\n",
   (optval == PCRE2_BSR_ANYCRLF)? "CR, LF, or CRLF only" :
                                  "all Unicode newlines");
-(void)PCRE2_CONFIG(PCRE2_CONFIG_NEVER_BACKSLASH_C, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_NEVER_BACKSLASH_C, &optval);
 printf("  \\C is %ssupported\n", optval? "not ":"");
-(void)PCRE2_CONFIG(PCRE2_CONFIG_LINKSIZE, &optval);
-printf("  Internal link size = %d\n", optval);
-(void)PCRE2_CONFIG(PCRE2_CONFIG_PARENSLIMIT, &optval);
+printf("  Internal link size\n");
+PCRE2_CONFIGV(PCRE2_CONFIG_LINKSIZE, &optval);
+printf("    Requested = %d\n", optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_EFFECTIVE_LINKSIZE, &optval);
+printf("    Effective = %d\n", optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_PARENSLIMIT, &optval);
 printf("  Parentheses nest limit = %d\n", optval);
-(void)PCRE2_CONFIG(PCRE2_CONFIG_HEAPLIMIT, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_HEAPLIMIT, &optval);
 printf("  Default heap limit = %d kibibytes\n", optval);
-(void)PCRE2_CONFIG(PCRE2_CONFIG_MATCHLIMIT, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_MATCHLIMIT, &optval);
 printf("  Default match limit = %d\n", optval);
-(void)PCRE2_CONFIG(PCRE2_CONFIG_DEPTHLIMIT, &optval);
+PCRE2_CONFIGV(PCRE2_CONFIG_DEPTHLIMIT, &optval);
 printf("  Default depth limit = %d\n", optval);
 
 #if defined SUPPORT_LIBREADLINE
@@ -10247,6 +10282,7 @@ display_selected_modifiers(FALSE, "SUBJECT");
 int
 main(int argc, char **argv)
 {
+int r1, r2;
 uint32_t temp;
 uint32_t yield = 0;
 uint32_t op = 1;
@@ -10277,17 +10313,33 @@ if (PO(options) != DO(options) || PO(control) != DO(control) ||
 same time checking that a request for the length gives the same answer. Also
 check lengths for non-string items. */
 
-if (PCRE2_CONFIG(PCRE2_CONFIG_VERSION, NULL) !=
-    PCRE2_CONFIG(PCRE2_CONFIG_VERSION, version) ||
+PCRE2_CONFIG(r1, PCRE2_CONFIG_VERSION, NULL);
+PCRE2_CONFIG(r2, PCRE2_CONFIG_VERSION, version);
+if (r1 != r2)
+  {
+  fprintf(stderr, "** Error in pcre2_config(PCRE2_CONFIG_VERSION): bad length\n");
+  return 1;
+  }
 
-    PCRE2_CONFIG(PCRE2_CONFIG_UNICODE_VERSION, NULL) !=
-    PCRE2_CONFIG(PCRE2_CONFIG_UNICODE_VERSION, uversion) ||
+PCRE2_CONFIG(r1, PCRE2_CONFIG_UNICODE_VERSION, NULL);
+PCRE2_CONFIG(r2, PCRE2_CONFIG_UNICODE_VERSION, uversion);
+if (r1 != r2)
+  {
+  fprintf(stderr, "** Error in pcre2_config(PCRE2_CONFIG_UNICODE_VERSION): bad length\n");
+  return 1;
+  }
 
-    PCRE2_CONFIG(PCRE2_CONFIG_JITTARGET, NULL) !=
-    PCRE2_CONFIG(PCRE2_CONFIG_JITTARGET, jittarget) ||
+PCRE2_CONFIG(r1, PCRE2_CONFIG_JITTARGET, NULL);
+PCRE2_CONFIG(r2, PCRE2_CONFIG_JITTARGET, jittarget);
+if (r1 != r2)
+  {
+  fprintf(stderr, "** Error in pcre2_config(PCRE2_CONFIG_JITTARGET): bad length\n");
+  return 1;
+  }
 
-    PCRE2_CONFIG(PCRE2_CONFIG_UNICODE, NULL) != sizeof(uint32_t) ||
-    PCRE2_CONFIG(PCRE2_CONFIG_MATCHLIMIT, NULL) != sizeof(uint32_t))
+PCRE2_CONFIG(r1, PCRE2_CONFIG_UNICODE, NULL);
+PCRE2_CONFIG(r2, PCRE2_CONFIG_MATCHLIMIT, NULL);
+if (r1 != r2 || r1 != sizeof(uint32_t))
   {
   fprintf(stderr, "** Error in pcre2_config(): bad length\n");
   return 1;
@@ -10295,8 +10347,10 @@ if (PCRE2_CONFIG(PCRE2_CONFIG_VERSION, NULL) !=
 
 /* Check that bad options are diagnosed. */
 
-if (PCRE2_CONFIG(999, NULL) != PCRE2_ERROR_BADOPTION ||
-    PCRE2_CONFIG(999, &temp) != PCRE2_ERROR_BADOPTION)
+PCRE2_CONFIG(r1, 999, NULL);
+PCRE2_CONFIG(r2, 999, &temp);
+
+if (r1 != r2 || r2 != PCRE2_ERROR_BADOPTION)
   {
   fprintf(stderr, "** Error in pcre2_config(): bad option not diagnosed\n");
   return 1;
@@ -10305,7 +10359,8 @@ if (PCRE2_CONFIG(999, NULL) != PCRE2_ERROR_BADOPTION ||
 /* This configuration option is now obsolete, but running a quick check ensures
 that its code is covered. */
 
-(void)PCRE2_CONFIG(PCRE2_CONFIG_STACKRECURSE, &temp);
+PCRE2_CONFIGV(PCRE2_CONFIG_STACKRECURSE, &temp);
+PCRE2_CONFIGV(PCRE2_CONFIG_LINKSIZE, &temp);
 
 /* Get buffers from malloc() so that valgrind will check their misuse when
 debugging. They grow automatically when very long lines are read. The 16-


### PR DESCRIPTION
`pcre2test` reports the `linksize` that was set at build time by all libraries, but at least in the case of the 32-bit library, it is never correct by default, or even relevant as described in [pcre2build](https://www.pcre.org/current/doc/html/pcre2build.html#SEC10).

CAVEAT: before this change; eventhough there were three (one per library, if all enabled) identical versions of this function linked with pcre2test, only the first one found was being used and that was "by design", which this changes.