### PR TITLE
build.zig: update to zig 0.15

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -473,14 +473,11 @@ jobs:
           submodules: true
 
       - name: Build
-        run: zig build
+        run: zig build -Dsupport_jit
 
       - name: Test
         run: |
-          # Zig does something weird with the stack - it uses more space than the
-          # equivalent plain C program.
-          ulimit -S -s 65536
-          srcdir=`pwd` pcre2test=`pwd`/zig-out/bin/pcre2test ./RunTest
+          srcdir=`pwd` pcre2test=`pwd`/zig-out/bin/pcre2test ./RunTest -bigstack
 
   bazel:
     # Tests with: Bazel build system


### PR DESCRIPTION
Syntax is compatible with 0.14 and now can generate cross compiled dynamic builds that run on Windows