### PR TITLE
Silence clang compiler warning: unannotated fall-through between switch labels

### DIFF
--- a/src/pcre2_auto_possess.c
+++ b/src/pcre2_auto_possess.c
@@ -804,21 +804,21 @@ for(;;)
 
       case OP_NOT_DIGIT:
       invert_bits = TRUE;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_DIGIT:
       set2 = (const uint8_t *)(cb->cbits + cbit_digit);
       break;
 
       case OP_NOT_WHITESPACE:
       invert_bits = TRUE;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_WHITESPACE:
       set2 = (const uint8_t *)(cb->cbits + cbit_space);
       break;
 
       case OP_NOT_WORDCHAR:
       invert_bits = TRUE;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_WORDCHAR:
       set2 = (const uint8_t *)(cb->cbits + cbit_word);
       break;
@@ -1101,7 +1101,7 @@ for(;;)
 
       case OP_NCLASS:
       if (chr > 255) return FALSE;
-      /* Fall through */
+      __attribute__((fallthrough));
 
       case OP_CLASS:
       if (chr > 255) break;

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -1936,7 +1936,7 @@ else
 
     if (c >= CHAR_8) break;
 
-    /* Fall through */
+    __attribute__((fallthrough));
 
     /* \0 always starts an octal number, but we may drop through to here with a
     larger first octal digit. The original code used just to take the least
@@ -2908,21 +2908,21 @@ switch(escape)
   {
   case ESC_D:
   prop = ESC_P;
-  /* Fall through */
+  __attribute__((fallthrough));
   case ESC_d:
   ascii_option = PCRE2_EXTRA_ASCII_BSD;
   break;
 
   case ESC_S:
   prop = ESC_P;
-  /* Fall through */
+  __attribute__((fallthrough));
   case ESC_s:
   ascii_option = PCRE2_EXTRA_ASCII_BSS;
   break;
 
   case ESC_W:
   prop = ESC_P;
-  /* Fall through */
+  __attribute__((fallthrough));
   case ESC_w:
   ascii_option = PCRE2_EXTRA_ASCII_BSW;
   break;
@@ -4560,7 +4560,7 @@ while (ptr < ptrend)
 
           default:
           PCRE2_DEBUG_UNREACHABLE();
-          /* Fall through */
+          __attribute__((fallthrough));
 
           case ESC_A:
           case ESC_Z:
@@ -5224,7 +5224,7 @@ while (ptr < ptrend)
         ++ptr;
         goto FAILED_FORWARD;
         }
-      /* Fall through */
+      __attribute__((fallthrough));
 
       case CHAR_0: case CHAR_1: case CHAR_2: case CHAR_3: case CHAR_4:
       case CHAR_5: case CHAR_6: case CHAR_7: case CHAR_8: case CHAR_9:
@@ -5974,7 +5974,7 @@ for (;;)
     case OP_UCP_WORD_BOUNDARY:
     case OP_NOT_UCP_WORD_BOUNDARY:
     if (!skipassert) return code;
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case OP_CALLOUT:
     case OP_CREF:
@@ -6493,7 +6493,7 @@ for (;; pptr++)
     case META_PRUNE:
     case META_SKIP:
     cb->had_pruneorskip = TRUE;
-    /* Fall through */
+    __attribute__((fallthrough));
     case META_COMMIT:
     case META_FAIL:
     *code++ = verbops[(meta - META_MARK) >> 16];
@@ -6518,7 +6518,7 @@ for (;; pptr++)
     case META_PRUNE_ARG:
     case META_SKIP_ARG:
     cb->had_pruneorskip = TRUE;
-    /* Fall through */
+    __attribute__((fallthrough));
     case META_MARK:
     case META_COMMIT_ARG:
     VERB_ARG:
@@ -7498,7 +7498,7 @@ for (;; pptr++)
       group_return = -1;  /* Set "may match empty string" */
 
       /* Now treat as a repeated OP_BRA. */
-      /* Fall through */
+      __attribute__((fallthrough));
 
       /* If previous was a bracket group, we may have to replicate it in
       certain cases. Note that at this point we can encounter only the "basic"
@@ -8348,7 +8348,7 @@ for (;; pptr++)
       if ((options & PCRE2_UCP) != 0 && (xoptions & PCRE2_EXTRA_ASCII_BSW) == 0)
         meta_arg = (meta_arg == ESC_B)? OP_NOT_UCP_WORD_BOUNDARY :
           OP_UCP_WORD_BOUNDARY;
-      /* Fall through */
+      __attribute__((fallthrough));
 
       case ESC_A:
       if (cb->max_lookbehind == 0) cb->max_lookbehind = 1;
@@ -9282,7 +9282,7 @@ do {
 
      case OP_EXACT:
      scode += IMM2_SIZE;
-     /* Fall through */
+     __attribute__((fallthrough));
 
      case OP_CHAR:
      case OP_PLUS:
@@ -9295,7 +9295,7 @@ do {
 
      case OP_EXACTI:
      scode += IMM2_SIZE;
-     /* Fall through */
+     __attribute__((fallthrough));
 
      case OP_CHARI:
      case OP_PLUSI:
@@ -9727,7 +9727,7 @@ for (;; pptr++)
     case META_BACKREF_BYNAME:
     if ((cb->external_options & PCRE2_MATCH_UNSET_BACKREF) != 0)
       goto ISNOTFIXED;
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case META_RECURSE_BYNAME:
       {
@@ -9776,7 +9776,7 @@ for (;; pptr++)
       goto RECURSE_OR_BACKREF_LENGTH;
       }
 
-    /* Fall through */
+    __attribute__((fallthrough));
     /* For groups >= 10 - picking up group twice does no harm. */
 
     /* A true recursion implies not fixed length, but a subroutine call may
@@ -9856,7 +9856,7 @@ for (;; pptr++)
 
     case META_CAPTURE:
     group = META_DATA(*pptr);
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case META_ATOMIC:
     case META_NOCAPTURE:
@@ -9903,7 +9903,7 @@ for (;; pptr++)
         else itemlength = (max - 1) * lastitemlength;
       break;
       }
-    /* Fall through */
+    __attribute__((fallthrough));
 
     /* Any other item means this branch does not have a fixed length. */
 

--- a/src/pcre2_compile_class.c
+++ b/src/pcre2_compile_class.c
@@ -65,7 +65,7 @@ b) none of the cases here:
 #define CLASS_END_CASES(meta) \
   default: \
   PCRE2_ASSERT((meta) <= META_END); \
-  /* Fall through */ \
+  __attribute__((fallthrough)); \
   case META_CLASS: \
   case META_CLASS_NOT: \
   case META_CLASS_EMPTY: \
@@ -2169,7 +2169,7 @@ switch (meta)
     }
 
   ptr++;
-  /* Fall through */
+  __attribute__((fallthrough));
 
   default:
   /* Scan forward characters, ranges, and properties.

--- a/src/pcre2_convert.c
+++ b/src/pcre2_convert.c
@@ -226,7 +226,7 @@ while (plength > 0)
           posix++;
           continue;    /* With next character after :] */
           }
-        /* Fall through */
+        __attribute__((fallthrough));
 
         case POSIX_CLASS_NOT_STARTED:
         if (c == CHAR_LEFT_SQUARE_BRACKET)
@@ -321,7 +321,7 @@ while (plength > 0)
 
     case CHAR_LEFT_PARENTHESIS:
     bracount++;
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case CHAR_QUESTION_MARK:
     case CHAR_PLUS:
@@ -329,7 +329,7 @@ while (plength > 0)
     case CHAR_RIGHT_CURLY_BRACKET:
     case CHAR_VERTICAL_LINE:
     if (!extended) goto ESCAPE_LITERAL;
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case CHAR_DOT:
     case CHAR_DOLLAR_SIGN:
@@ -358,7 +358,7 @@ while (plength > 0)
       posix_state = POSIX_ANCHORED;
       goto COPY_SPECIAL;
       }
-    /* Fall through */
+    __attribute__((fallthrough));
 
     default:
     if (c < 255 && strchr(pcre2_escaped_literals, c) != NULL)

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -2328,7 +2328,7 @@ for (;;)
         case 0x2029:
 #endif  /* Not EBCDIC */
         if (mb->bsr_convention == PCRE2_BSR_ANYCRLF) break;
-        /* Fall through */
+        __attribute__((fallthrough));
 
         case CHAR_LF:
         ADD_NEW(state_offset + 1, 0);
@@ -2440,7 +2440,7 @@ for (;;)
       caseless = TRUE;
       codevalue -= OP_STARI - OP_STAR;
 
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_PLUS:
       case OP_MINPLUS:
       case OP_POSPLUS:
@@ -2484,7 +2484,7 @@ for (;;)
       case OP_NOTPOSQUERYI:
       caseless = TRUE;
       codevalue -= OP_STARI - OP_STAR;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_QUERY:
       case OP_MINQUERY:
       case OP_POSQUERY:
@@ -2525,7 +2525,7 @@ for (;;)
       case OP_NOTPOSSTARI:
       caseless = TRUE;
       codevalue -= OP_STARI - OP_STAR;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_STAR:
       case OP_MINSTAR:
       case OP_POSSTAR:
@@ -2562,7 +2562,7 @@ for (;;)
       case OP_NOTEXACTI:
       caseless = TRUE;
       codevalue -= OP_STARI - OP_STAR;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_EXACT:
       case OP_NOTEXACT:
       count = current_state->count;  /* Number already matched */
@@ -2597,7 +2597,7 @@ for (;;)
       case OP_NOTPOSUPTOI:
       caseless = TRUE;
       codevalue -= OP_STARI - OP_STAR;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_UPTO:
       case OP_MINUPTO:
       case OP_POSUPTO:

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -970,7 +970,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       Fecode += 1 + LINK_SIZE;
       continue;
       }
-    /* Fall through */
+    __attribute__((fallthrough));
 
     /* OP_END itself can never be reached within a recursion because that is
     picked up when the OP_KET that always precedes OP_END is reached. */
@@ -1054,7 +1054,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       mb->hitend = TRUE;
       if (mb->partial > 1) return PCRE2_ERROR_PARTIAL;
       }
-    /* Fall through */
+    __attribute__((fallthrough));
 
     /* Match any single character whatsoever. */
 
@@ -6062,7 +6062,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
                 assert_accept_frame->offset_top * sizeof(PCRE2_SIZE));
           Foffset_top = assert_accept_frame->offset_top;
 
-          /* Fall through */
+          __attribute__((fallthrough));
           /* In the case of a match, the captures have already been put into
           the current frame. */
 
@@ -6360,7 +6360,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       case OP_ASSERTBACK_NA:
       if (branch_start[1 + LINK_SIZE] == OP_VREVERSE && Feptr != P->eptr)
         RRETURN(MATCH_NOMATCH);
-      /* Fall through */
+      __attribute__((fallthrough));
 
       case OP_ASSERT_NA:
       if (Feptr > mb->last_used_ptr) mb->last_used_ptr = Feptr;
@@ -6374,12 +6374,12 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       case OP_ASSERTBACK:
       if (branch_start[1 + LINK_SIZE] == OP_VREVERSE && Feptr != P->eptr)
         RRETURN(MATCH_NOMATCH);
-      /* Fall through */
+      __attribute__((fallthrough));
 
       case OP_ASSERT:
       if (Feptr > mb->last_used_ptr) mb->last_used_ptr = Feptr;
       Feptr = P->eptr;
-      /* Fall through */
+      __attribute__((fallthrough));
 
       /* For an atomic group, discard internal backtracking points. We must
       also ensure that any remaining branches within the top-level of the group
@@ -6403,7 +6403,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       case OP_ASSERTBACK_NOT:
       if (branch_start[1 + LINK_SIZE] == OP_VREVERSE && Feptr != P->eptr)
         RRETURN(MATCH_NOMATCH);
-      /* Fall through */
+      __attribute__((fallthrough));
 
       case OP_ASSERT_NOT:
       RRETURN(MATCH_MATCH);
@@ -6537,7 +6537,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
     if ((mb->moptions & PCRE2_NOTEOL) != 0) RRETURN(MATCH_NOMATCH);
     if ((mb->poptions & PCRE2_DOLLAR_ENDONLY) == 0) goto ASSERT_NL_OR_EOS;
 
-    /* Fall through */
+    __attribute__((fallthrough));
     /* Unconditional end of subject assertion (\z). */
 
     case OP_EOD:
@@ -7938,7 +7938,7 @@ for(;;)
       new_start_match = mb->verb_skip_ptr;
       break;
       }
-    /* Fall through */
+    __attribute__((fallthrough));
 
     /* NOMATCH and PRUNE advance by one character. THEN at this level acts
     exactly like PRUNE. Unset ignore SKIP-with-argument. */

--- a/src/pcre2_printint_inc.h
+++ b/src/pcre2_printint_inc.h
@@ -583,7 +583,7 @@ if (type == OP_XCLASS)
       {
       case XCL_NOTPROP:
       notch = "^";
-      /* Fall through */
+      __attribute__((fallthrough));
       case XCL_PROP:
         {
         unsigned int ptype = *ccode++;
@@ -799,7 +799,7 @@ for(;;)
     case OP_MINQUERYI:
     case OP_POSQUERYI:
     flag = "/i";
-    /* Fall through */
+    __attribute__((fallthrough));
     case OP_STAR:
     case OP_MINSTAR:
     case OP_POSSTAR:
@@ -838,7 +838,7 @@ for(;;)
     case OP_MINUPTOI:
     case OP_POSUPTOI:
     flag = "/i";
-    /* Fall through */
+    __attribute__((fallthrough));
     case OP_EXACT:
     case OP_UPTO:
     case OP_MINUPTO:
@@ -871,7 +871,7 @@ for(;;)
 
     case OP_NOTI:
     flag = "/i";
-    /* Fall through */
+    __attribute__((fallthrough));
     case OP_NOT:
     fprintf(f, " %s [^", flag);
     extra = print_char(f, code + 1, utf);
@@ -888,7 +888,7 @@ for(;;)
     case OP_NOTMINQUERYI:
     case OP_NOTPOSQUERYI:
     flag = "/i";
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case OP_NOTSTAR:
     case OP_NOTMINSTAR:
@@ -909,7 +909,7 @@ for(;;)
     case OP_NOTMINUPTOI:
     case OP_NOTPOSUPTOI:
     flag = "/i";
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case OP_NOTEXACT:
     case OP_NOTUPTO:
@@ -934,7 +934,7 @@ for(;;)
 
     case OP_REFI:
     flag = "/i";
-    /* Fall through */
+    __attribute__((fallthrough));
     case OP_REF:
     fprintf(f, " %s \\%d", flag, GET2(code,1));
     i = (*code == OP_REFI)? code[1 + IMM2_SIZE] : 0;
@@ -944,7 +944,7 @@ for(;;)
 
     case OP_DNREFI:
     flag = "/i";
-    /* Fall through */
+    __attribute__((fallthrough));
     case OP_DNREF:
       {
       PCRE2_SPTR entry = nametable + (GET2(code, 1) * nesize) + IMM2_SIZE;
@@ -1111,7 +1111,7 @@ for(;;)
     case OP_CIRCM:
     case OP_DOLLM:
     flag = "/m";
-    /* Fall through */
+    __attribute__((fallthrough));
 
     /* Anything else is just an item with no data, but possibly a flag. */
 

--- a/src/pcre2_study.c
+++ b/src/pcre2_study.c
@@ -175,7 +175,7 @@ for (;;)
       cc += 1 + LINK_SIZE;
       break;
       }
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case OP_ONCE:
     case OP_SCRIPT_RUN:
@@ -252,7 +252,7 @@ for (;;)
     case OP_ASSERT_SCS:
     case OP_ASSERTBACK_NA:
     do cc += GET(cc, 1); while (*cc == OP_ALT);
-    /* Fall through */
+    __attribute__((fallthrough));
 
     /* Skip over things that don't match chars */
 
@@ -352,7 +352,7 @@ for (;;)
     case OP_PROP:
     case OP_NOTPROP:
     cc += 2;
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case OP_NOT_DIGIT:
     case OP_DIGIT:
@@ -433,7 +433,7 @@ for (;;)
       case OP_CRMINPLUS:
       case OP_CRPOSPLUS:
       branchlength++;
-      /* Fall through */
+      __attribute__((fallthrough));
 
       case OP_CRSTAR:
       case OP_CRMINSTAR:
@@ -1303,7 +1303,7 @@ do
 
         case OP_PROP:
         if (ncode[1] != PT_CLIST) break;
-        /* Fall through */
+        __attribute__((fallthrough));
         case OP_ANYNL:
         case OP_CHAR:
         case OP_CHARI:
@@ -1327,7 +1327,7 @@ do
         tcode = ncode;
         continue;   /* With the following significant opcode */
         }
-      /* Fall through */
+      __attribute__((fallthrough));
 
       /* For a group bracket or a positive assertion without an immediately
       following mandatory setting, recurse to set bits from within the
@@ -1455,7 +1455,7 @@ do
 
       case OP_EXACT:
       tcode += IMM2_SIZE;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_CHAR:
       case OP_PLUS:
       case OP_MINPLUS:
@@ -1466,7 +1466,7 @@ do
 
       case OP_EXACTI:
       tcode += IMM2_SIZE;
-      /* Fall through */
+      __attribute__((fallthrough));
       case OP_CHARI:
       case OP_PLUSI:
       case OP_MINPLUSI:
@@ -1602,7 +1602,7 @@ do
       case OP_TYPEUPTO:
       case OP_TYPEMINUPTO:
       case OP_TYPEPOSUPTO:
-      tcode += IMM2_SIZE;  /* Fall through */
+      tcode += IMM2_SIZE;  __attribute__((fallthrough));
 
       case OP_TYPESTAR:
       case OP_TYPEMINSTAR:
@@ -1783,7 +1783,7 @@ do
       /* It seems that the fall through comment must be outside the #ifdef if
       it is to avoid the gcc compiler warning. */
 
-      /* Fall through */
+      __attribute__((fallthrough));
 
       /* Enter here for a negative non-XCLASS. In the 8-bit library, if we are
       in UTF mode, any byte with a value >= 0xc4 is a potentially valid starter
@@ -1801,7 +1801,7 @@ do
 #elif PCRE2_CODE_UNIT_WIDTH != 8
       SET_BIT(0xFF);                             /* For characters >= 255 */
 #endif
-      /* Fall through */
+      __attribute__((fallthrough));
 
       /* Enter here for a positive non-XCLASS. If we have fallen through from
       an XCLASS, classmap will already be set; just advance the code pointer.

--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -2053,7 +2053,7 @@ switch (*(++string))
     break;
     }
 
-  /* Fall through */
+  __attribute__((fallthrough));
 
   /* The maximum capture number is 65535, so any number greater than that will
   always be an unknown capture number. We just stop incrementing, in order to

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -4445,7 +4445,7 @@ for (;;)
       *((uint32_t *)field) = (uint32_t)(m->value);
       break;
       }
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case MOD_INT:    /* Unsigned integer */
     if (!isdigit(*pp)) goto INVALID_VALUE;
@@ -7542,7 +7542,7 @@ if ((dat_datctl.control2 & CTL2_CALLOUT_EXTRA) != 0)
 
     case PCRE2_CALLOUT_STARTMATCH|PCRE2_CALLOUT_BACKTRACK:
     fprintf(f, "Backtrack\nNo other matching paths\n");
-    /* Fall through */
+    __attribute__((fallthrough));
 
     case PCRE2_CALLOUT_STARTMATCH:
     fprintf(f, "New match attempt\n");
@@ -10216,7 +10216,7 @@ for (i = 0; i < MODLISTCOUNT; i++)
     break;
 
     default: printf("** Unknown type for modifier \"%s\"\n", m->name);
-    /* Fall through */
+    __attribute__((fallthrough));
     case MOD_PD:        /* Pattern or subject */
     case MOD_PDP:       /* As PD, OK for Perl-compatible test */
     is_pattern = for_pattern;


### PR DESCRIPTION
Hi there,

we are using clang with -Wimplicit-fallthrough and -Werror enabled which helped us identify a few odd places in our code base. In the PCRE2 code base those places have already been commented and I propose to use the corresponding compiler attribute to make the compiler aware the fact that fallthrough is allowed at these places.
