### PR TITLE
Add some CMake fixes for z/OS (not previously tested with CMake)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -439,10 +439,13 @@ jobs:
             export _TAG_REDIR_ERR=txt;
             export _TAG_REDIR_IN=txt;
             export _TAG_REDIR_OUT=txt;
+            export PATH="/data/zopen/usr/local/bin:/data/zopen/usr/bin:/data/zopen/bin:/data/zopen/boot:/bin:/usr/lpp/IBM/cnw/v2r1/openxl/bin";
             . /data/zopen/etc/zopen-config;
             set -e;
             set -x;
             cd /data;
+
+            echo "== Autoconf, XLC compiler ==";
             rm -rf pcre2-build;
             mkdir pcre2-build;
             gtar xzf pcre2-build.tar.gz -C pcre2-build;
@@ -450,7 +453,20 @@ jobs:
             chtag -R -tc ISO8859-1 .;
             MAKE=gmake CC=xlc ./configure --enable-ebcdic --disable-unicode;
             gmake;
-            gmake check'
+            gmake check;
+
+            echo "== CMake, IBM-Clang -m64 compiler ==";
+            cd ..;
+            rm -rf pcre2-build;
+            mkdir pcre2-build;
+            gtar xzf pcre2-build.tar.gz -C pcre2-build;
+            cd pcre2-build;
+            chtag -R -tc ISO8859-1 .;
+            cmake $CMAKE_FLAGS -G Ninja -DPCRE2_EBCDIC=ON -DPCRE2_SUPPORT_UNICODE=OFF -DCMAKE_C_COMPILER=ibm-clang -DCMAKE_C_FLAGS="-m64 $CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
+            cd build;
+            ninja;
+            ctest -j3 --output-on-failure;
+            '
 
   distcheck:
     name: Build & verify distribution

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ include(CheckTypeSize)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs) # for CMAKE_INSTALL_LIBDIR
 include(PCRE2CheckLinkerFlag)
+include(PCRE2UseSystemExtensions)
 
 check_include_file(assert.h HAVE_ASSERT_H)
 check_include_file(dirent.h HAVE_DIRENT_H)
@@ -272,6 +273,11 @@ check_c_source_compiles(
 if(INTEL_CET_ENABLED)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mshstk")
 endif()
+
+# Check whether any system-wide extensions need to be enabled, in order for
+# OS functionality to be exposed.
+
+pcre2_use_system_extensions()
 
 # User-configurable options
 #
@@ -1311,6 +1317,14 @@ if test \"$?\" != \"0\"; then exit 1; fi
 
     if(UNIX)
       add_test(pcre2_grep_test sh ${PROJECT_BINARY_DIR}/pcre2_grep_test.sh)
+
+      if(PCRE2_EBCDIC)
+        # The grep tests currently fail in EBCDIC mode because the test data
+        # files are in ASCII. This could be fixed properly, but for now, we
+        # have very few EBCDIC users and the pcre2grep utility is hardly even
+        # part of the official project artifacts.
+        set_property(TEST pcre2_grep_test PROPERTY WILL_FAIL TRUE)
+      endif()
     endif()
   endif()
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1014,6 +1014,7 @@ EXTRA_DIST += \
   cmake/FindReadline.cmake \
   cmake/pcre2-config.cmake.in \
   cmake/PCRE2CheckLinkerFlag.cmake \
+  cmake/PCRE2UseSystemExtensions.cmake \
   src/config-cmake.h.in \
   CMakeLists.txt
 

--- a/README
+++ b/README
@@ -972,6 +972,7 @@ The distribution should contain the files listed below.
   cmake/FindReadline.cmake
   cmake/pcre2-config.cmake.in
   cmake/PCRE2CheckLinkerFlag.cmake
+  cmake/PCRE2UseSystemExtensions.cmake
   src/config-cmake.h.in
   CMakeLists.txt
 

--- a/cmake/PCRE2UseSystemExtensions.cmake
+++ b/cmake/PCRE2UseSystemExtensions.cmake
@@ -1,0 +1,47 @@
+# This CMake module is supposed to give similar results to the
+# AC_USE_SYSTEM_EXTENSIONS Autoconf macro, which turns on a load of
+# system feature-check macros, including _ALL_SOURCE, _GNU_SOURCE,
+# _NETBSD_SOURCE, and many more.
+#
+# Because PCRE2 uses so few OS features, we don't seem to actually need to
+# enable many of these. Modern platforms with CMake users generally enable
+# all the basic POSIX features by default.
+#
+# So far, we know that we require:
+#   - _ALL_SOURCE on IBM systems (z/OS, probably AIX) in order to call
+#     getrlimit() in pcre2test.
+#
+# Autoconf enables this unconditionally. However, our CMake script potentially
+# supports *more* platforms than Autoconf, so we use a feature check.
+
+function(pcre2_use_system_extensions)
+  if (WIN32)
+    return()
+  endif()
+
+  include(CheckCSourceCompiles)
+
+  set(_pcre2_test_src "
+#include <sys/time.h>
+#include <sys/resource.h>
+
+int main(void) {
+    struct rlimit rlim;
+    getrlimit(RLIMIT_STACK, &rlim);
+    return 0;
+}
+")
+
+  check_c_source_compiles("${_pcre2_test_src}" HAVE_GETRLIMIT)
+
+  if (NOT HAVE_GETRLIMIT)
+    # Try again with _ALL_SOURCE
+    set(CMAKE_REQUIRED_DEFINITIONS "-D_ALL_SOURCE")
+    check_c_source_compiles("${_pcre2_test_src}" HAVE_GETRLIMIT_ALLSOURCE)
+    unset(CMAKE_REQUIRED_DEFINITIONS)
+
+    if (HAVE_GETRLIMIT_ALLSOURCE)
+      add_compile_definitions(_ALL_SOURCE)
+    endif()
+  endif()
+endfunction()

--- a/doc/html/README.txt
+++ b/doc/html/README.txt
@@ -972,6 +972,7 @@ The distribution should contain the files listed below.
   cmake/FindReadline.cmake
   cmake/pcre2-config.cmake.in
   cmake/PCRE2CheckLinkerFlag.cmake
+  cmake/PCRE2UseSystemExtensions.cmake
   src/config-cmake.h.in
   CMakeLists.txt
 

--- a/maint/manifest-tarball
+++ b/maint/manifest-tarball
@@ -27,6 +27,7 @@ drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/cmake
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/cmake/FindEditline.cmake
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/cmake/FindReadline.cmake
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/cmake/PCRE2CheckLinkerFlag.cmake
+-rw-r--r-- tarball-dir/pcre2-SNAPSHOT/cmake/PCRE2UseSystemExtensions.cmake
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/cmake/pcre2-config.cmake.in
 -rwxr-xr-x tarball-dir/pcre2-SNAPSHOT/compile
 -rwxr-xr-x tarball-dir/pcre2-SNAPSHOT/config.guess

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -632,7 +632,7 @@ have 16-bit arguments in 8-bit and 16-bit modes, so we need no more than a
 #define CODE_BLOCKSIZE_TYPE PCRE2_SIZE
 
 #undef  LOOKBEHIND_MAX
-#define LOOKBEHIND_MAX UINT16_MAX
+#define LOOKBEHIND_MAX ((int)UINT16_MAX)
 
 typedef struct pcre2_real_code {
   pcre2_memctl memctl;            /* Memory control fields */

--- a/src/pcre2_study.c
+++ b/src/pcre2_study.c
@@ -138,7 +138,7 @@ for (;;)
   PCRE2_UCHAR op;
   PCRE2_SPTR cs, ce;
 
-  if (branchlength >= UINT16_MAX)
+  if (branchlength >= (int)UINT16_MAX)
     {
     branchlength = UINT16_MAX;
     cc = nextbranch;
@@ -627,11 +627,11 @@ for (;;)
       break;
       }
 
-     /* Take care not to overflow: (1) min and d are ints, so check that their
-     product is not greater than INT_MAX. (2) branchlength is limited to
-     UINT16_MAX (checked at the top of the loop). */
+    /* Take care not to overflow: (1) min and d are ints, so check that their
+    product is not greater than INT_MAX. (2) branchlength is limited to
+    UINT16_MAX (checked at the top of the loop). */
 
-    if ((d > 0 && (INT_MAX/d) < min) || UINT16_MAX - branchlength < min*d)
+    if ((d > 0 && (INT_MAX/d) < min) || (int)UINT16_MAX - branchlength < min*d)
       branchlength = UINT16_MAX;
     else branchlength += min * d;
     break;
@@ -2063,7 +2063,7 @@ if ((re->flags & (PCRE2_MATCH_EMPTY|PCRE2_HASACCEPT)) == 0 &&
     return 3; /* unrecognized opcode */
 
     default:
-    re->minlength = (min > UINT16_MAX)? UINT16_MAX : min;
+    re->minlength = (min > (int)UINT16_MAX)? (int)UINT16_MAX : min;
     break;
     }
   }


### PR DESCRIPTION
- Added CMake on z/OS to CI builds
- Added CMake module to enable _ALL_SOURCE if required for getrlimit(). This was already being done by Autoconf.
- Excluded pcre2_grep_test on EBCDIC platforms.  This was already being done for Autoconf builds.
- Suppressed compiler warnings for UINT16_MAX. On most platforms it's the integer constant `65535` (a signed constant), but on z/OS and possibly AIX it's defined to `65535u` (an unsigned constant), which causes warnings about unexpected signedness in comparisons and arithmetic.

Fixes #764, hopefully