### PR TITLE
Remove memmove, bcopy, and VPCOMPAT macros

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,7 +22,6 @@ copy_file(
 
 LOCAL_DEFINES = [
     "HAVE_CONFIG_H",
-    "HAVE_MEMMOVE",
     "HAVE_STRERROR",
     "PCRE2_STATIC",
     "SUPPORT_PCRE2_8",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,9 +172,7 @@ check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(unistd.h HAVE_UNISTD_H)
 check_include_file(windows.h HAVE_WINDOWS_H)
 
-check_symbol_exists(bcopy "strings.h" HAVE_BCOPY)
 check_symbol_exists(memfd_create "sys/mman.h" HAVE_MEMFD_CREATE)
-check_symbol_exists(memmove "string.h" HAVE_MEMMOVE)
 check_symbol_exists(secure_getenv "stdlib.h" HAVE_SECURE_GETENV)
 check_symbol_exists(strerror "string.h" HAVE_STRERROR)
 

--- a/configure.ac
+++ b/configure.ac
@@ -578,11 +578,7 @@ Boolean macros such as HAVE_STDLIB_H and SUPPORT_PCRE2_8 should either be
 defined (conventionally to 1) for TRUE, and not defined at all for FALSE. All
 such macros are listed as a commented #undef in config.h.generic. Macros such
 as MATCH_LIMIT, whose actual value is relevant, have defaults defined, but are
-surrounded by #ifndef/#endif lines so that the value can be overridden by -D.
-
-PCRE2 uses memmove() if HAVE_MEMMOVE is defined; otherwise it uses bcopy() if
-HAVE_BCOPY is defined. If your system has neither bcopy() nor memmove(), make
-sure both macros are undefined; an emulation function will then be used. */])
+surrounded by #ifndef/#endif lines so that the value can be overridden by -D. */])
 
 # Checks for header files.
 AC_CHECK_HEADERS(assert.h limits.h sys/types.h sys/stat.h dirent.h)
@@ -627,7 +623,7 @@ AC_TYPE_SIZE_T
 
 # Checks for library functions.
 
-AC_CHECK_FUNCS(bcopy memfd_create memmove mkostemp secure_getenv strerror)
+AC_CHECK_FUNCS(memfd_create mkostemp secure_getenv strerror)
 AC_MSG_CHECKING([for realpath])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdlib.h>

--- a/maint/README
+++ b/maint/README
@@ -226,9 +226,6 @@ new release.
     maint/RunPerlTest shell script can be used to do this testing in Unix-like
     environment.
 
-  - It is possible to test with the emulated memmove() function by undefining
-    HAVE_MEMMOVE and HAVE_BCOPY in config.h, though I do not do this often.
-
   - Check the external testing tools. CodeQL & Clang Static Analyzer report
     their results to the GitHub "Security" dashboard. Coverity has its own
     external dashboard, as does OSS-Fuzz. Since we have these tools, we should

--- a/src/config-cmake.h.in
+++ b/src/config-cmake.h.in
@@ -11,9 +11,7 @@
 #cmakedefine HAVE_UNISTD_H 1
 #cmakedefine HAVE_WINDOWS_H 1
 
-#cmakedefine HAVE_BCOPY 1
 #cmakedefine HAVE_MEMFD_CREATE 1
-#cmakedefine HAVE_MEMMOVE 1
 #cmakedefine HAVE_SECURE_GETENV 1
 #cmakedefine HAVE_STRERROR 1
 

--- a/src/config.h.generic
+++ b/src/config.h.generic
@@ -22,11 +22,7 @@ Boolean macros such as HAVE_STDLIB_H and SUPPORT_PCRE2_8 should either be
 defined (conventionally to 1) for TRUE, and not defined at all for FALSE. All
 such macros are listed as a commented #undef in config.h.generic. Macros such
 as MATCH_LIMIT, whose actual value is relevant, have defaults defined, but are
-surrounded by #ifndef/#endif lines so that the value can be overridden by -D.
-
-PCRE2 uses memmove() if HAVE_MEMMOVE is defined; otherwise it uses bcopy() if
-HAVE_BCOPY is defined. If your system has neither bcopy() nor memmove(), make
-sure both macros are undefined; an emulation function will then be used. */
+surrounded by #ifndef/#endif lines so that the value can be overridden by -D. */
 
 /* By default, the \R escape sequence matches any Unicode line ending
    character or sequence of characters. If BSR_ANYCRLF is defined (to any
@@ -63,9 +59,6 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define this if your compiler supports __attribute__((uninitialized)) */
 /* #undef HAVE_ATTRIBUTE_UNINITIALIZED */
 
-/* Define to 1 if you have the `bcopy' function. */
-/* #undef HAVE_BCOPY */
-
 /* Define this if your compiler provides __assume() */
 /* #undef HAVE_BUILTIN_ASSUME */
 
@@ -98,9 +91,6 @@ sure both macros are undefined; an emulation function will then be used. */
 
 /* Define to 1 if you have the `memfd_create' function. */
 /* #undef HAVE_MEMFD_CREATE */
-
-/* Define to 1 if you have the `memmove' function. */
-/* #undef HAVE_MEMMOVE */
 
 /* Define to 1 if you have the <minix/config.h> header file. */
 /* #undef HAVE_MINIX_CONFIG_H */

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -209,28 +209,6 @@ code that a non-static object is being referenced. */
 #define PRIV(name) _pcre2_##name
 #endif
 
-/* When compiling for use with the Virtual Pascal compiler, these functions
-need to have their names changed. PCRE2 must be compiled with the -DVPCOMPAT
-option on the command line. */
-
-#ifdef VPCOMPAT
-#define strlen(s)        _strlen(s)
-#define strncmp(s1,s2,m) _strncmp(s1,s2,m)
-#define memcmp(s,c,n)    _memcmp(s,c,n)
-#define memcpy(d,s,n)    _memcpy(d,s,n)
-#define memmove(d,s,n)   _memmove(d,s,n)
-#define memset(s,c,n)    _memset(s,c,n)
-#else  /* VPCOMPAT */
-
-/* Otherwise, to cope with SunOS4 and other systems that lack memmove(), define
-a macro that calls an emulating function. */
-
-#ifndef HAVE_MEMMOVE
-#undef  memmove          /* Some systems may have a macro */
-#define memmove(a, b, c) PRIV(memmove)(a, b, c)
-#endif   /* not HAVE_MEMMOVE */
-#endif   /* not VPCOMPAT */
-
 /* This is an unsigned int value that no UTF character can ever have, as
 Unicode doesn't go beyond 0x0010ffff. */
 
@@ -2379,13 +2357,6 @@ extern BOOL         _pcre2_was_newline(PCRE2_SPTR, uint32_t, PCRE2_SPTR,
 extern BOOL         _pcre2_xclass(uint32_t, PCRE2_SPTR, const uint8_t *, BOOL);
 extern BOOL         _pcre2_eclass(uint32_t, PCRE2_SPTR, PCRE2_SPTR,
                       const uint8_t *, BOOL);
-
-/* This function is needed only when memmove() is not available. */
-
-#if !defined(VPCOMPAT) && !defined(HAVE_MEMMOVE)
-#define _pcre2_memmove               PCRE2_SUFFIX(_pcre2_memmove)
-extern void *       _pcre2_memmove(void *, const void *, size_t);
-#endif
 
 #endif  /* PCRE2_CODE_UNIT_WIDTH */
 

--- a/src/pcre2_string_utils.c
+++ b/src/pcre2_string_utils.c
@@ -49,42 +49,6 @@ functions work only on 8-bit data. */
 
 
 /*************************************************
-*    Emulated memmove() for systems without it   *
-*************************************************/
-
-/* This function can make use of bcopy() if it is available. Otherwise do it by
-steam, as there some non-Unix environments that lack both memmove() and
-bcopy(). */
-
-#if !defined(VPCOMPAT) && !defined(HAVE_MEMMOVE)
-void *
-PRIV(memmove)(void *d, const void *s, size_t n)
-{
-#ifdef HAVE_BCOPY
-bcopy(s, d, n);
-return d;
-#else
-size_t i;
-unsigned char *dest = (unsigned char *)d;
-const unsigned char *src = (const unsigned char *)s;
-if (dest > src)
-  {
-  dest += n;
-  src += n;
-  for (i = 0; i < n; ++i) *(--dest) = *(--src);
-  return (void *)dest;
-  }
-else
-  {
-  for (i = 0; i < n; ++i) *dest++ = *src++;
-  return (void *)(dest - n);
-  }
-#endif   /* not HAVE_BCOPY */
-}
-#endif   /* not VPCOMPAT && not HAVE_MEMMOVE */
-
-
-/*************************************************
 *    Compare two zero-terminated PCRE2 strings   *
 *************************************************/
 

--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -535,44 +535,6 @@ const char utf8_table4[] = {
   3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5 };
 
 
-#if !defined(VPCOMPAT) && !defined(HAVE_MEMMOVE)
-/*************************************************
-*    Emulated memmove() for systems without it   *
-*************************************************/
-
-/* This function can make use of bcopy() if it is available. Otherwise do it by
-steam, as there are some non-Unix environments that lack both memmove() and
-bcopy(). */
-
-static void *
-emulated_memmove(void *d, const void *s, size_t n)
-{
-#ifdef HAVE_BCOPY
-bcopy(s, d, n);
-return d;
-#else
-size_t i;
-unsigned char *dest = (unsigned char *)d;
-const unsigned char *src = (const unsigned char *)s;
-if (dest > src)
-  {
-  dest += n;
-  src += n;
-  for (i = 0; i < n; ++i) *(--dest) = *(--src);
-  return (void *)dest;
-  }
-else
-  {
-  for (i = 0; i < n; ++i) *dest++ = *src++;
-  return (void *)(dest - n);
-  }
-#endif   /* not HAVE_BCOPY */
-}
-#undef memmove
-#define memmove(d,s,n) emulated_memmove(d,s,n)
-#endif   /* not VPCOMPAT && not HAVE_MEMMOVE */
-
-
 
 /*************************************************
 *           Convert code point to UTF-8          *

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -1421,45 +1421,6 @@ static const uint8_t tables2[] = {
 
 
 
-#if !defined(VPCOMPAT) && !defined(HAVE_MEMMOVE)
-/*************************************************
-*    Emulated memmove() for systems without it   *
-*************************************************/
-
-/* This function can make use of bcopy() if it is available. Otherwise do it by
-steam, as there are some non-Unix environments that lack both memmove() and
-bcopy(). */
-
-static void *
-emulated_memmove(void *d, const void *s, size_t n)
-{
-#ifdef HAVE_BCOPY
-bcopy(s, d, n);
-return d;
-#else
-size_t i;
-unsigned char *dest = (unsigned char *)d;
-const unsigned char *src = (const unsigned char *)s;
-if (dest > src)
-  {
-  dest += n;
-  src += n;
-  for (i = 0; i < n; ++i) *(--dest) = *(--src);
-  return (void *)dest;
-  }
-else
-  {
-  for (i = 0; i < n; ++i) *dest++ = *src++;
-  return (void *)(dest - n);
-  }
-#endif   /* not HAVE_BCOPY */
-}
-#undef memmove
-#define memmove(d,s,n) emulated_memmove(d,s,n)
-#endif   /* not VPCOMPAT && not HAVE_MEMMOVE */
-
-
-
 #ifndef HAVE_STRERROR
 /*************************************************
 *     Provide strerror() for non-ANSI libraries  *

--- a/vms/configure.com
+++ b/vms/configure.com
@@ -463,11 +463,7 @@ Boolean macros such as HAVE_STDLIB_H and SUPPORT_PCRE2_8 should either be
 defined (conventionally to 1) for TRUE, and not defined at all for FALSE. All
 such macros are listed as a commented #undef in config.h.generic. Macros such
 as MATCH_LIMIT, whose actual value is relevant, have defaults defined, but are
-surrounded by #ifndef/#endif lines so that the value can be overridden by -D.
-
-PCRE2 uses memmove() if HAVE_MEMMOVE is defined; otherwise it uses bcopy() if
-HAVE_BCOPY is defined. If your system has neither bcopy() nor memmove(), make
-sure both macros are undefined; an emulation function will then be used. */
+surrounded by #ifndef/#endif lines so that the value can be overridden by -D. */
 
 /* By default, the \R escape sequence matches any Unicode line ending
    character or sequence of characters. If BSR_ANYCRLF is defined (to any
@@ -499,9 +495,6 @@ sure both macros are undefined; an emulation function will then be used. */
 /* Define to 1 if you have the <assert.h> header file. */
 #define HAVE_ASSERT_H 1
 
-/* Define to 1 if you have the 'bcopy' function. */
-#define HAVE_BCOPY 1
-
 /* Define this if your compiler provides __builtin_mul_overflow() */
 #undef HAVE_BUILTIN_MUL_OVERFLOW
 
@@ -528,9 +521,6 @@ sure both macros are undefined; an emulation function will then be used. */
 
 /* Define to 1 if you have the 'memfd_create' function. */
 #undef HAVE_MEMFD_CREATE
-
-/* Define to 1 if you have the 'memmove' function. */
-#define HAVE_MEMMOVE 1
 
 /* Define to 1 if you have the <minix/config.h> header file. */
 #undef HAVE_MINIX_CONFIG_H


### PR DESCRIPTION
The `memmove` function dates back to C89, and has been available in all systems since 1993 (when SunOS 5 and BSD 4.4 were released).

The Visual Pascal compiler had its last release in 2003 and its original author posted in 2005 that "Virtual Pascal has died". Those macros can also be removed now.

The only reason I want to be proactive about this is because many users incorporate the source files from PCRE2 into their own build system. Some of these users are undoubtedly getting the memmove fallback code, if they are not providing the HAVE_MEMMOVE macro. Our minimum supported C version is now C99, so there is no need for pre-C89 fallbacks.