### PR TITLE
Add pcre2_substitute checks to enforce subject hasn't changed

### DIFF
--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -436,6 +436,9 @@ released, the numbers must not be changed. */
 #define PCRE2_ERROR_JIT_UNSUPPORTED   (-68)
 #define PCRE2_ERROR_REPLACECASE       (-69)
 #define PCRE2_ERROR_TOOLARGEREPLACE   (-70)
+#define PCRE2_ERROR_DIFFERENT_SUBJECT (-71)
+#define PCRE2_ERROR_DIFFERENT_LENGTH  (-72)
+#define PCRE2_ERROR_DIFFERENT_OFFSET  (-73)
 
 
 /* Request types for pcre2_pattern_info() */

--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -436,9 +436,8 @@ released, the numbers must not be changed. */
 #define PCRE2_ERROR_JIT_UNSUPPORTED   (-68)
 #define PCRE2_ERROR_REPLACECASE       (-69)
 #define PCRE2_ERROR_TOOLARGEREPLACE   (-70)
-#define PCRE2_ERROR_DIFFERENT_SUBJECT (-71)
-#define PCRE2_ERROR_DIFFERENT_LENGTH  (-72)
-#define PCRE2_ERROR_DIFFERENT_OFFSET  (-73)
+#define PCRE2_ERROR_DIFFSUBSSUBJECT   (-71)
+#define PCRE2_ERROR_DIFFSUBSOFFSET    (-72)
 
 
 /* Request types for pcre2_pattern_info() */

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -436,6 +436,9 @@ released, the numbers must not be changed. */
 #define PCRE2_ERROR_JIT_UNSUPPORTED   (-68)
 #define PCRE2_ERROR_REPLACECASE       (-69)
 #define PCRE2_ERROR_TOOLARGEREPLACE   (-70)
+#define PCRE2_ERROR_DIFFERENT_SUBJECT (-71)
+#define PCRE2_ERROR_DIFFERENT_LENGTH  (-72)
+#define PCRE2_ERROR_DIFFERENT_OFFSET  (-73)
 
 
 /* Request types for pcre2_pattern_info() */

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -436,9 +436,8 @@ released, the numbers must not be changed. */
 #define PCRE2_ERROR_JIT_UNSUPPORTED   (-68)
 #define PCRE2_ERROR_REPLACECASE       (-69)
 #define PCRE2_ERROR_TOOLARGEREPLACE   (-70)
-#define PCRE2_ERROR_DIFFERENT_SUBJECT (-71)
-#define PCRE2_ERROR_DIFFERENT_LENGTH  (-72)
-#define PCRE2_ERROR_DIFFERENT_OFFSET  (-73)
+#define PCRE2_ERROR_DIFFSUBSSUBJECT   (-71)
+#define PCRE2_ERROR_DIFFSUBSOFFSET    (-72)
 
 
 /* Request types for pcre2_pattern_info() */

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -3387,6 +3387,19 @@ rws->next = NULL;
 rws->size = RWS_BASE_SIZE;
 rws->free = RWS_BASE_SIZE - RWS_ANCHOR_SIZE;
 
+if (match_data == NULL) return PCRE2_ERROR_NULL;
+
+/* store data needed by pcre2_substitute */
+match_data->original_subject = subject;
+if (length == PCRE2_ZERO_TERMINATED)
+  {
+  length = PRIV(strlen)(subject);
+  was_zero_terminated = 1;
+  }
+match_data->subject_length = length;
+match_data->start_offset = start_offset;
+
+
 /* Recognize NULL, length 0 as an empty string. */
 
 if (subject == NULL && length == 0) subject = null_str;
@@ -3399,14 +3412,8 @@ if (re == NULL || subject == NULL || workspace == NULL)
 if ((options & ~PUBLIC_DFA_MATCH_OPTIONS) != 0)
   { rc = PCRE2_ERROR_BADOPTION; goto EXIT; }
 
-if (length == PCRE2_ZERO_TERMINATED)
-  {
-  length = PRIV(strlen)(subject);
-  was_zero_terminated = 1;
-  }
-
-if (wscount < 20) { rc = PCRE2_ERROR_DFA_WSSIZE; goto EXIT; }
-if (start_offset > length) { rc = PCRE2_ERROR_BADOFFSET; goto EXIT; }
+if (wscount < 20) return match_data->rc = PCRE2_ERROR_DFA_WSSIZE;
+if (start_offset > length) return match_data->rc = PCRE2_ERROR_BADOFFSET;
 
 /* Partial matching and PCRE2_ENDANCHORED are currently not allowed at the same
 time. */
@@ -4046,8 +4053,6 @@ for (;;)
       match_data->ovector[0] = (PCRE2_SIZE)(start_match - subject);
       match_data->ovector[1] = (PCRE2_SIZE)(end_subject - subject);
       }
-    match_data->subject_length = length;
-    match_data->start_offset = start_offset;
     match_data->leftchar = (PCRE2_SIZE)(mb->start_used_ptr - subject);
     match_data->rightchar = (PCRE2_SIZE)(mb->last_used_ptr - subject);
     match_data->startchar = (PCRE2_SIZE)(start_match - subject);

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -3389,8 +3389,17 @@ rws->free = RWS_BASE_SIZE - RWS_ANCHOR_SIZE;
 
 if (match_data == NULL) return PCRE2_ERROR_NULL;
 
+/* If the match data block was previously used with PCRE2_COPY_MATCHED_SUBJECT,
+free the memory that was obtained. */
+if ((match_data->flags & PCRE2_MD_COPIED_SUBJECT) != 0)
+  {
+  match_data->memctl.free((void *)match_data->subject,
+    match_data->memctl.memory_data);
+  match_data->flags &= ~PCRE2_MD_COPIED_SUBJECT;
+  }
+
 /* store data needed by pcre2_substitute */
-match_data->original_subject = subject;
+match_data->subject = match_data->original_subject = subject;
 if (length == PCRE2_ZERO_TERMINATED)
   {
   length = PRIV(strlen)(subject);
@@ -3681,20 +3690,9 @@ if ((re->flags & PCRE2_LASTSET) != 0)
     }
   }
 
-/* If the match data block was previously used with PCRE2_COPY_MATCHED_SUBJECT,
-free the memory that was obtained. */
-
-if ((match_data->flags & PCRE2_MD_COPIED_SUBJECT) != 0)
-  {
-  match_data->memctl.free((void *)match_data->subject,
-    match_data->memctl.memory_data);
-  match_data->flags &= ~PCRE2_MD_COPIED_SUBJECT;
-  }
-
 /* Fill in fields that are always returned in the match data. */
 
 match_data->code = re;
-match_data->subject = NULL;  /* Default for no match */
 match_data->mark = NULL;
 match_data->matchedby = PCRE2_MATCHEDBY_DFA_INTERPRETER;
 

--- a/src/pcre2_error.c
+++ b/src/pcre2_error.c
@@ -301,6 +301,9 @@ static const unsigned char match_error_texts[] =
   "error performing replacement case transformation\0"
   /* 70 */
   "replacement too large (longer than PCRE2_SIZE)\0"
+  "substitute subject differs from prior pcre2_match call\0"
+  "substitute subject length differs from prior pcre2_match call\0"
+  "substitute start offset differs from prior pcre2_match call\0"
   ;
 
 

--- a/src/pcre2_error.c
+++ b/src/pcre2_error.c
@@ -302,7 +302,6 @@ static const unsigned char match_error_texts[] =
   /* 70 */
   "replacement too large (longer than PCRE2_SIZE)\0"
   "substitute subject differs from prior pcre2_match call\0"
-  "substitute subject length differs from prior pcre2_match call\0"
   "substitute start offset differs from prior pcre2_match call\0"
   ;
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -714,7 +714,6 @@ typedef struct pcre2_real_match_data {
   pcre2_memctl     memctl;           /* Memory control fields */
   const pcre2_real_code *code;       /* The pattern used for the match */
   PCRE2_SPTR       subject;          /* The subject that was matched */
-  PCRE2_SPTR       original_subject; /* the pointer that was actually passed to pcre2_match */
   PCRE2_SPTR       mark;             /* Pointer to last mark */
   struct heapframe *heapframes;      /* Backtracking frames heap memory */
   PCRE2_SIZE       heapframes_size;  /* Malloc-ed size */

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -714,6 +714,7 @@ typedef struct pcre2_real_match_data {
   pcre2_memctl     memctl;           /* Memory control fields */
   const pcre2_real_code *code;       /* The pattern used for the match */
   PCRE2_SPTR       subject;          /* The subject that was matched */
+  PCRE2_SPTR       original_subject; /* the pointer that was actually passed to pcre2_match */
   PCRE2_SPTR       mark;             /* Pointer to last mark */
   struct heapframe *heapframes;      /* Backtracking frames heap memory */
   PCRE2_SIZE       heapframes_size;  /* Malloc-ed size */

--- a/src/pcre2_jit_match_inc.h
+++ b/src/pcre2_jit_match_inc.h
@@ -118,7 +118,7 @@ int rc;
 int index = 0;
 
 /* store data needed by pcre2_substitute */
-match_data->original_subject = subject;
+match_data->subject = match_data->original_subject = subject;
 match_data->subject_length = length;
 match_data->start_offset = start_offset;
 
@@ -180,7 +180,6 @@ else
 if (rc > (int)oveccount)
   rc = 0;
 match_data->code = re;
-match_data->subject = (rc >= 0 || rc == PCRE2_ERROR_PARTIAL)? subject : NULL;
 match_data->rc = rc;
 match_data->startchar = arguments.startchar_ptr - subject;
 match_data->leftchar = 0;

--- a/src/pcre2_jit_match_inc.h
+++ b/src/pcre2_jit_match_inc.h
@@ -117,11 +117,6 @@ jit_arguments arguments;
 int rc;
 int index = 0;
 
-/* store data needed by pcre2_substitute */
-match_data->subject = match_data->original_subject = subject;
-match_data->subject_length = length;
-match_data->start_offset = start_offset;
-
 if ((options & PCRE2_PARTIAL_HARD) != 0)
   index = 2;
 else if ((options & PCRE2_PARTIAL_SOFT) != 0)
@@ -180,6 +175,10 @@ else
 if (rc > (int)oveccount)
   rc = 0;
 match_data->code = re;
+match_data->subject =
+  (rc >= 0 || rc == PCRE2_ERROR_NOMATCH || rc == PCRE2_ERROR_PARTIAL)? subject : NULL;
+match_data->subject_length = length;
+match_data->start_offset = start_offset;
 match_data->rc = rc;
 match_data->startchar = arguments.startchar_ptr - subject;
 match_data->leftchar = 0;

--- a/src/pcre2_jit_match_inc.h
+++ b/src/pcre2_jit_match_inc.h
@@ -117,6 +117,11 @@ jit_arguments arguments;
 int rc;
 int index = 0;
 
+/* store data needed by pcre2_substitute */
+match_data->original_subject = subject;
+match_data->subject_length = length;
+match_data->start_offset = start_offset;
+
 if ((options & PCRE2_PARTIAL_HARD) != 0)
   index = 2;
 else if ((options & PCRE2_PARTIAL_SOFT) != 0)
@@ -176,8 +181,6 @@ if (rc > (int)oveccount)
   rc = 0;
 match_data->code = re;
 match_data->subject = (rc >= 0 || rc == PCRE2_ERROR_PARTIAL)? subject : NULL;
-match_data->subject_length = length;
-match_data->start_offset = start_offset;
 match_data->rc = rc;
 match_data->startchar = arguments.startchar_ptr - subject;
 match_data->leftchar = 0;

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -795,6 +795,21 @@ if (replacement == NULL)
 if (rlength == PCRE2_ZERO_TERMINATED) rlength = PRIV(strlen)(replacement);
 repend = replacement + rlength;
 
+/* Check for using a match that has already happened. Note that the subject
+pointer in the match data may be NULL after a no-match. */
+
+use_existing_match = ((options & PCRE2_SUBSTITUTE_MATCHED) != 0);
+if (use_existing_match && match_data == NULL) return PCRE2_ERROR_NULL;
+
+replacement_only = ((options & PCRE2_SUBSTITUTE_REPLACEMENT_ONLY) != 0);
+
+if (use_existing_match && match_data->rc < PCRE2_ERROR_NOMATCH)
+  /* Return early, as the rest of the match_data may not have been initialised */
+  return match_data->rc;
+
+if (use_existing_match && match_data->original_subject != subject)
+  return PCRE2_ERROR_DIFFERENT_SUBJECT;
+
 /* A NULL subject of zero length is treated as an empty string. */
 
 if (subject == NULL)
@@ -810,6 +825,12 @@ pointer in the match data may be NULL after a no-match. */
 
 use_existing_match = ((options & PCRE2_SUBSTITUTE_MATCHED) != 0);
 replacement_only = ((options & PCRE2_SUBSTITUTE_REPLACEMENT_ONLY) != 0);
+
+if (use_existing_match && match_data->subject_length != length)
+  return PCRE2_ERROR_DIFFERENT_LENGTH;
+
+if (use_existing_match && match_data->start_offset != start_offset)
+  return PCRE2_ERROR_DIFFERENT_OFFSET;
 
 /* If starting from an existing match, there must be an externally provided
 match data block. We create an internal match_data block in two cases: (a) an
@@ -827,7 +848,6 @@ have to be changes below. */
 if (match_data == NULL)
   {
   pcre2_general_context gcontext;
-  if (use_existing_match) return PCRE2_ERROR_NULL;
   gcontext.memctl = (mcontext == NULL)?
     ((pcre2_real_code *)code)->memctl :
     ((pcre2_real_match_context *)mcontext)->memctl;

--- a/testdata/testinputNEW
+++ b/testdata/testinputNEW
@@ -72,7 +72,27 @@
 
 # Keeping the length the same, the offset the same, and the pointer the same
 # Is ok, even if the contents DIFFER
+# (also has some fun with copy_matched_subject)
 /\w+|^$/replace=<$&>,global,substitute_matched
     foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,zero_terminate
+
+# Using null tells substitute to use the copied match_subject
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo|bar\=offset=1,null_substitute_subject,copy_matched_subject
+    :::\=offset=1,null_substitute_subject,copy_matched_subject
+
+# Still need the length to be correct when using null
+# Failed: error -72: substitute subject length differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo\=substitute_subject=x,null_substitute_subject,copy_matched_subject
+    :::\=substitute_subject=x,null_substitute_subject,copy_matched_subject
+
+# Can use substitute_zero_terminate with copy_matched_subject
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo|bar\=offset=1,substitute_subject=x,substitute_overwrite,copy_matched_subject,substitute_zero_terminate
+    :::\=offset=1,substitute_subject=x,substitute_overwrite,copy_matched_subject,substitute_zero_terminate
+
+# Can modify text with copy_matched_subject, original text is used
+/\w+|^$/replace=<$&>,global,substitute_matched
     foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,copy_matched_subject
     :::\=offset=1,substitute_subject=foo,substitute_overwrite,copy_matched_subject

--- a/testdata/testinputNEW
+++ b/testdata/testinputNEW
@@ -1,0 +1,78 @@
+# The test regex and subjects we will use for the following
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=substitute_subject=,substitute_overwrite
+    \=null_subject
+    :::
+    foo\=zero_terminate
+    foo|bar\=offset=1,substitute_offset=1
+    F|OOBAR\=offset=1
+
+# ####################
+# ERRORS
+# ####################
+
+# substitute_subject has the same contents, but a different pointer
+# Failed: error -71: substitute subject differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=null_subject,substitute_subject=
+    \=null_substitute_subject
+    \=substitute_subject=
+    foo\=substitute_subject=foo
+
+
+# Failed: error -72: substitute subject length differs from prior pcre2_match call
+# Changing the length is always an error
+# (using PCRE2_ZERO_TERMINATED but with different length strings also counts)
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=substitute_subject=x,substitute_overwrite
+    \=substitute_subject=x,substitute_overwrite,copy_matched_subject,zero_terminate,substitute_zero_terminate
+    foo\=substitute_subject=foooo,substitute_overwrite,copy_matched_subject,substitute_zero_terminate
+    :::\=substitute_subject=::,substitute_overwrite,copy_matched_subject,zero_terminate
+    foo\=substitute_subject=x,substitute_overwrite
+
+# Changing the start offset is not allowed
+# Failed: error -73: substitute start offset differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo\=substitute_offset=1
+    :::\=offset=1,substitute_offset=0
+    foo\=offset=1,substitute_offset=2
+    :::\=offset=1,substitute_offset=10
+
+# From a strict reading of the documentation,
+# using a different pointer is NOT allowed with PCRE2_COPY_MATCHED_SUBJECT
+# Failed: error -71: substitute subject differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=substitute_subject=,copy_matched_subject
+    \=null_substitute_subject,copy_matched_subject
+    \=null_subject,substitute_subject=,copy_matched_subject
+    foo\=substitute_subject=foo,copy_matched_subject
+    :::\=substitute_subject=:::,copy_matched_subject
+
+# Tests demonstrating the precedence of errors is: prior_match error, pointer, length, then start offset
+/\w+|^$/replace=<$&>,global,substitute_matched
+    x\=null_subject,substitute_subject=x
+    foo\=substitute_subject=x
+    :::\=substitute_subject=:::,offset=1,substitute_offset=0
+    foo\=substitute_subject=x,offset=1,substitute_offset=0
+    :::\=substitute_subject=x,substitute_overwrite,offset=1,substitute_offset=0
+
+# ####################
+# ALLOWED AND GOOD
+# ####################
+
+# For simplicity, PCRE2_ZERO_TERMINATED vs a concrete length doesn't count as changing the length
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo\=substitute_subject=foo,substitute_overwrite,substitute_zero_terminate
+    :::\=substitute_subject=:::,substitute_overwrite,zero_terminate
+    foo\=zero_terminate,substitute_subject=foo,substitute_overwrite
+
+# ####################
+# ALLOWED AND BAD
+# ####################
+
+# Keeping the length the same, the offset the same, and the pointer the same
+# Is ok, even if the contents DIFFER
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,zero_terminate
+    foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,copy_matched_subject
+    :::\=offset=1,substitute_subject=foo,substitute_overwrite,copy_matched_subject

--- a/testdata/testoutputNEW
+++ b/testdata/testoutputNEW
@@ -64,7 +64,7 @@ Failed: error -73: substitute start offset differs from prior pcre2_match call
     \=substitute_subject=,copy_matched_subject
 Failed: error -71: substitute subject differs from prior pcre2_match call
     \=null_substitute_subject,copy_matched_subject
-Failed: error -71: substitute subject differs from prior pcre2_match call
+ 1: <>
     \=null_subject,substitute_subject=,copy_matched_subject
 Failed: error -71: substitute subject differs from prior pcre2_match call
     foo\=substitute_subject=foo,copy_matched_subject
@@ -104,10 +104,36 @@ Failed: error -72: substitute subject length differs from prior pcre2_match call
 
 # Keeping the length the same, the offset the same, and the pointer the same
 # Is ok, even if the contents DIFFER
+# (also has some fun with copy_matched_subject)
 /\w+|^$/replace=<$&>,global,substitute_matched
     foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,zero_terminate
  2: F<|O><OBAR>
+
+# Using null tells substitute to use the copied match_subject
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo|bar\=offset=1,null_substitute_subject,copy_matched_subject
+ 2: f<oo>|<bar>
+    :::\=offset=1,null_substitute_subject,copy_matched_subject
+ 0: :::
+
+# Still need the length to be correct when using null
+# Failed: error -72: substitute subject length differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo\=substitute_subject=x,null_substitute_subject,copy_matched_subject
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+    :::\=substitute_subject=x,null_substitute_subject,copy_matched_subject
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+
+# Can use substitute_zero_terminate with copy_matched_subject
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo|bar\=offset=1,substitute_subject=x,substitute_overwrite,copy_matched_subject,substitute_zero_terminate
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+    :::\=offset=1,substitute_subject=x,substitute_overwrite,copy_matched_subject,substitute_zero_terminate
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+
+# Can modify text with copy_matched_subject, original text is used
+/\w+|^$/replace=<$&>,global,substitute_matched
     foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,copy_matched_subject
- 2: F<|O><OBAR>
+ 2: f<oo>|<bar>
     :::\=offset=1,substitute_subject=foo,substitute_overwrite,copy_matched_subject
- 0: foo
+ 0: :::

--- a/testdata/testoutputNEW
+++ b/testdata/testoutputNEW
@@ -1,0 +1,113 @@
+# The test regex and subjects we will use for the following
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=substitute_subject=,substitute_overwrite
+ 1: <>
+    \=null_subject
+ 1: <>
+    :::
+ 0: :::
+    foo\=zero_terminate
+ 1: <foo>
+    foo|bar\=offset=1,substitute_offset=1
+ 2: f<oo>|<bar>
+    F|OOBAR\=offset=1
+ 1: F|<OOBAR>
+
+# ####################
+# ERRORS
+# ####################
+
+# substitute_subject has the same contents, but a different pointer
+# Failed: error -71: substitute subject differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=null_subject,substitute_subject=
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    \=null_substitute_subject
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    \=substitute_subject=
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    foo\=substitute_subject=foo
+Failed: error -71: substitute subject differs from prior pcre2_match call
+
+
+# Failed: error -72: substitute subject length differs from prior pcre2_match call
+# Changing the length is always an error
+# (using PCRE2_ZERO_TERMINATED but with different length strings also counts)
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=substitute_subject=x,substitute_overwrite
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+    \=substitute_subject=x,substitute_overwrite,copy_matched_subject,zero_terminate,substitute_zero_terminate
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+    foo\=substitute_subject=foooo,substitute_overwrite,copy_matched_subject,substitute_zero_terminate
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+    :::\=substitute_subject=::,substitute_overwrite,copy_matched_subject,zero_terminate
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+    foo\=substitute_subject=x,substitute_overwrite
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+
+# Changing the start offset is not allowed
+# Failed: error -73: substitute start offset differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo\=substitute_offset=1
+Failed: error -73: substitute start offset differs from prior pcre2_match call
+    :::\=offset=1,substitute_offset=0
+Failed: error -73: substitute start offset differs from prior pcre2_match call
+    foo\=offset=1,substitute_offset=2
+Failed: error -73: substitute start offset differs from prior pcre2_match call
+    :::\=offset=1,substitute_offset=10
+Failed: error -73: substitute start offset differs from prior pcre2_match call
+
+# From a strict reading of the documentation,
+# using a different pointer is NOT allowed with PCRE2_COPY_MATCHED_SUBJECT
+# Failed: error -71: substitute subject differs from prior pcre2_match call
+/\w+|^$/replace=<$&>,global,substitute_matched
+    \=substitute_subject=,copy_matched_subject
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    \=null_substitute_subject,copy_matched_subject
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    \=null_subject,substitute_subject=,copy_matched_subject
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    foo\=substitute_subject=foo,copy_matched_subject
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    :::\=substitute_subject=:::,copy_matched_subject
+Failed: error -71: substitute subject differs from prior pcre2_match call
+
+# Tests demonstrating the precedence of errors is: prior_match error, pointer, length, then start offset
+/\w+|^$/replace=<$&>,global,substitute_matched
+    x\=null_subject,substitute_subject=x
+Failed: error -51: NULL argument passed with non-zero length
+    foo\=substitute_subject=x
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    :::\=substitute_subject=:::,offset=1,substitute_offset=0
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    foo\=substitute_subject=x,offset=1,substitute_offset=0
+Failed: error -71: substitute subject differs from prior pcre2_match call
+    :::\=substitute_subject=x,substitute_overwrite,offset=1,substitute_offset=0
+Failed: error -72: substitute subject length differs from prior pcre2_match call
+
+# ####################
+# ALLOWED AND GOOD
+# ####################
+
+# For simplicity, PCRE2_ZERO_TERMINATED vs a concrete length doesn't count as changing the length
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo\=substitute_subject=foo,substitute_overwrite,substitute_zero_terminate
+ 1: <foo>
+    :::\=substitute_subject=:::,substitute_overwrite,zero_terminate
+ 0: :::
+    foo\=zero_terminate,substitute_subject=foo,substitute_overwrite
+ 1: <foo>
+
+# ####################
+# ALLOWED AND BAD
+# ####################
+
+# Keeping the length the same, the offset the same, and the pointer the same
+# Is ok, even if the contents DIFFER
+/\w+|^$/replace=<$&>,global,substitute_matched
+    foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,zero_terminate
+ 2: F<|O><OBAR>
+    foo|bar\=offset=1,substitute_subject=F|OOBAR,substitute_overwrite,copy_matched_subject
+ 2: F<|O><OBAR>
+    :::\=offset=1,substitute_subject=foo,substitute_overwrite,copy_matched_subject
+ 0: foo


### PR DESCRIPTION
With thanks to @IsaacOscar.

I have:
* Tried to reduce the number of lines of change in the `_match.c` files, by preserving a little more of the original behaviour. The main change is now simply that we set the `subject` field when returning NOMATCH.
* Merged the "different subject" and "different subject length" errors.
* Simplified the logic around PCRE2_COPY_MATCHED_SUBJECT. Isaac had a system where you could opt to pass in a NULL subject to pcre2_substitute if the match data had a copied subject. However, I don't see a strong need to allow that (in fact, the entire option PCRE2_COPY_MATCHED_SUBJECT has a fairly weak motivation), so from my point of view it's a simpler narrative to just say, "PCRE2_COPY_MATCHED_SUBJECT doesn't affect the documented restrictions of passing in the same subject to pcre2_match and pcre2_substitute". Simpler than adding yet more conditional logic to the documentation of what is and isn't allowed.

- [ ] TODO I shall also cherry-pick over the pcre2test changes
- [ ] TODO I think I want to add a check also to ensure that the match options haven't changed