### PR TITLE
Avoid zero-length allocations, which return NULL on z/OS

### DIFF
--- a/src/pcre2test_inc.h
+++ b/src/pcre2test_inc.h
@@ -2533,6 +2533,7 @@ if (pat_patctl.convert_type != CONVERT_UNSET)
 
   // TODO No valgrind guards for out-of-bounds read in pcre2_pattern_convert(),
   // nor do we appear to have a facility for testing zero-terminated patterns here.
+  // Can we use something other than zero as a sentinel to allow testing empty inputs?
 
   if (pat_patctl.convert_length != 0)
     {


### PR DESCRIPTION
It's totally legal to return NULL for malloc(0), but every other platform that we target returns a non-NULL pointer. We don't need to do an allocation anyway (nor do we need to copy the terminating NUL byte).

This PR fixes a CI build failure on the z/OS runner.