### PR TITLE
Add runtime checks for invalid uses of \K in lookaround

### DIFF
--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -440,6 +440,7 @@ released, the numbers must not be changed. */
 #define PCRE2_ERROR_DIFFSUBSSUBJECT   (-72)
 #define PCRE2_ERROR_DIFFSUBSOFFSET    (-73)
 #define PCRE2_ERROR_DIFFSUBSOPTIONS   (-74)
+#define PCRE2_ERROR_BAD_BACKSLASH_K   (-75)
 
 
 /* Request types for pcre2_pattern_info() */

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -440,6 +440,7 @@ released, the numbers must not be changed. */
 #define PCRE2_ERROR_DIFFSUBSSUBJECT   (-72)
 #define PCRE2_ERROR_DIFFSUBSOFFSET    (-73)
 #define PCRE2_ERROR_DIFFSUBSOPTIONS   (-74)
+#define PCRE2_ERROR_BAD_BACKSLASH_K   (-75)
 
 
 /* Request types for pcre2_pattern_info() */

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -8370,6 +8370,10 @@ for (;; pptr++)
       case ESC_A:
       if (cb->max_lookbehind == 0) cb->max_lookbehind = 1;
       break;
+
+      case ESC_K:
+      cb->external_flags |= PCRE2_HASBSK;  /* Record */
+      break;
       }
 
     *code++ = meta_arg;

--- a/src/pcre2_error.c
+++ b/src/pcre2_error.c
@@ -305,6 +305,7 @@ static const unsigned char match_error_texts[] =
   "substitute subject differs from prior match call\0"
   "substitute start offset differs from prior match call\0"
   "substitute options differ from prior match call\0"
+  "disallowed use of \\K in lookaround\0"
   ;
 
 

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -538,6 +538,7 @@ bytes in a code unit in that mode. */
 #define PCRE2_DUPCAPUSED    0x00200000u /* contains (?| */
 #define PCRE2_HASBKC        0x00400000u /* contains \C */
 #define PCRE2_HASACCEPT     0x00800000u /* contains (*ACCEPT) */
+#define PCRE2_HASBSK        0x01000000u /* contains \K */
 
 #define PCRE2_MODE_MASK     (PCRE2_MODE8 | PCRE2_MODE16 | PCRE2_MODE32)
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -969,7 +969,9 @@ typedef struct match_block {
   uint32_t match_call_count;      /* Number of times a new frame is created */
   BOOL hitend;                    /* Hit the end of the subject at some point */
   BOOL hasthen;                   /* Pattern contains (*THEN) */
+  BOOL hasbsk;                    /* Pattern contains \K */
   BOOL allowemptypartial;         /* Allow empty hard partial */
+  BOOL allowlookaroundbsk;        /* Allow \K within lookarounds */
   const uint8_t *lcc;             /* Points to lower casing table */
   const uint8_t *fcc;             /* Points to case-flipping table */
   const uint8_t *ctypes;          /* Points to table of type maps */

--- a/src/pcre2_jit_match_inc.h
+++ b/src/pcre2_jit_match_inc.h
@@ -107,6 +107,7 @@ return match_data->rc = PCRE2_ERROR_JIT_BADOPTION;
 pcre2_real_code *re = (pcre2_real_code *)code;
 executable_functions *functions = (executable_functions *)re->executable_jit;
 pcre2_jit_stack *jit_stack;
+PCRE2_SIZE *ovector = match_data->ovector;
 uint32_t oveccount = match_data->oveccount;
 uint32_t max_oveccount;
 union {
@@ -171,6 +172,17 @@ if (jit_stack != NULL)
   }
 else
   rc = jit_machine_stack_exec(&arguments, convert_executable_func.call_executable_func);
+
+/* XXXXXXXXXX HACK
+Surely there's a better place to put this? I've just stuffed it in here, badly
+I guess it should go into the epilogue of the JIT-generated code somehow,
+conditionally on PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK? */
+if (rc >= 0 &&
+    (ovector[0] < start_offset || ovector[0] > ovector[1]) &&
+    (re->extra_options & PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK) == 0)
+  {
+  rc = PCRE2_ERROR_BAD_BACKSLASH_K;
+  }
 
 if (rc > (int)oveccount)
   rc = 0;

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -6378,7 +6378,38 @@ a)"xI
 
 /^abc(?<!b\Kq)d/,allow_lookaround_bsk
     abcd
-    
+
+# PCRE2 now also rejects sneaky cases where the \K is inside a lookaround... but
+# it's not always easy to detect this syntactically at compile-time (indeed,
+# a conditional expression could dynamically invoke \K via a subroutine, based
+# on the subject contents).
+
+/(?(DEFINE)(?<sneaky>b\K))a(?=(?&sneaky))/g,allow_lookaround_bsk
+    ab
+
+/(?(DEFINE)(?<sneaky>b\K))a(?=(?&sneaky))/g
+    ab
+    zz
+
+/a|(?(DEFINE)(?<sneaky>\Ka))(?<=(?&sneaky))b/g,allow_lookaround_bsk
+    ab
+
+/a|(?(DEFINE)(?<sneaky>\Ka))(?<=(?&sneaky))b/g
+    ab
+    zz
+
+/(?=.{10}(?1))x(\K){0}/
+    x1234567890
+
+/(?=.{10}(.))(*scs:(1)(?2))x(\K){0}/
+    x1234567890
+
+/(?=.{5}(?1))\d*(\K){0}/
+\= Totally fine - pattern does nothing bad even though \K is reachable
+    1234567890
+\= Not fine - the subject now causes the \K to misbehave
+    abcdefgh
+
 # --------- 
 
 # Tests for zero-length NULL to be treated as an empty string.

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -19062,7 +19062,51 @@ Failed: error 199 at offset 14: \K is not allowed in lookarounds (but see PCRE2_
 /^abc(?<!b\Kq)d/,allow_lookaround_bsk
     abcd
  0: abcd
-    
+
+# PCRE2 now also rejects sneaky cases where the \K is inside a lookaround... but
+# it's not always easy to detect this syntactically at compile-time (indeed,
+# a conditional expression could dynamically invoke \K via a subroutine, based
+# on the subject contents).
+
+/(?(DEFINE)(?<sneaky>b\K))a(?=(?&sneaky))/g,allow_lookaround_bsk
+    ab
+Start of matched string is beyond its end - displaying from end to start.
+ 0: b
+
+/(?(DEFINE)(?<sneaky>b\K))a(?=(?&sneaky))/g
+    ab
+Failed: error -75: disallowed use of \K in lookaround
+    zz
+No match
+
+/a|(?(DEFINE)(?<sneaky>\Ka))(?<=(?&sneaky))b/g,allow_lookaround_bsk
+    ab
+ 0: a
+ 0: ab
+
+/a|(?(DEFINE)(?<sneaky>\Ka))(?<=(?&sneaky))b/g
+    ab
+ 0: a
+Failed: error -75: disallowed use of \K in lookaround
+    zz
+No match
+
+/(?=.{10}(?1))x(\K){0}/
+    x1234567890
+Failed: error -75: disallowed use of \K in lookaround
+
+/(?=.{10}(.))(*scs:(1)(?2))x(\K){0}/
+    x1234567890
+Failed: error -75: disallowed use of \K in lookaround
+
+/(?=.{5}(?1))\d*(\K){0}/
+\= Totally fine - pattern does nothing bad even though \K is reachable
+    1234567890
+ 0: 67890
+\= Not fine - the subject now causes the \K to misbehave
+    abcdefgh
+Failed: error -75: disallowed use of \K in lookaround
+
 # --------- 
 
 # Tests for zero-length NULL to be treated as an empty string.


### PR DESCRIPTION
Fixes #736