### PR TITLE
Output CI test logs always

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
         run: cd build && make -j3
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure
+        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |
@@ -222,7 +222,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Test
-        run: cd build && ctest -C Release -j3 --output-on-failure
+        run: cd build && ctest -C Release -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |
@@ -326,7 +326,7 @@ jobs:
 
             ./configure CFLAGS="$CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-Werror
             make -j3
-            make check || (cat ./test-suite.log; false)
+            (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
             make install "DESTDIR=`pwd`/install-dir"
             maint/RunManifestTest install-dir maint/manifest-makeinstall-freebsd
@@ -338,7 +338,7 @@ jobs:
             cmake $CMAKE_FLAGS -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
             cd build
             make -j3
-            ctest -j3 --output-on-failure
+            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
             cmake --install . --prefix install-dir
             ../maint/RunManifestTest install-dir ../maint/manifest-cmakeinstall-freebsd
             ../maint/RunSymbolTest install-dir/lib/ ../maint/
@@ -400,7 +400,7 @@ jobs:
 
             ./configure CC="cc -m32" CFLAGS="$CFLAGS_SOLARIS_CC" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-errwarn
             make
-            make check || (cat ./test-suite.log; false)
+            (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
             make install "DESTDIR=`pwd`/install-dir"
             maint/RunManifestTest install-dir maint/manifest-makeinstall-solaris
@@ -411,7 +411,7 @@ jobs:
 
             ./configure CC="cc -m64" CFLAGS="$CFLAGS_SOLARIS_CC" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-errwarn
             make
-            make check || (cat ./test-suite.log; false)
+            (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
             make install "DESTDIR=`pwd`/install-dir"
             maint/RunManifestTest install-dir maint/manifest-makeinstall-solaris
@@ -423,7 +423,7 @@ jobs:
             CC="cc -m64" cmake $CMAKE_FLAGS -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_SOLARIS_CC" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
             cd build
             make
-            ctest -j3 --output-on-failure
+            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
             cmake --install . --prefix install-dir
             ../maint/RunManifestTest install-dir ../maint/manifest-cmakeinstall-solaris
             ../maint/RunSymbolTest install-dir/lib/ ../maint/
@@ -480,7 +480,7 @@ jobs:
             chtag -R -tc ISO8859-1 .;
             MAKE=gmake CC=xlc ./configure --enable-ebcdic --disable-unicode;
             gmake;
-            gmake check;
+            (gmake check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc);
 
             echo "== CMake, IBM-Clang -m64 compiler ==";
             cd ..;
@@ -492,7 +492,7 @@ jobs:
             cmake $CMAKE_FLAGS -G Ninja -DPCRE2_EBCDIC=ON -DPCRE2_SUPPORT_UNICODE=OFF -DCMAKE_C_COMPILER=ibm-clang -DCMAKE_C_FLAGS="-m64 $CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
             cd build;
             ninja;
-            ctest -j3 --output-on-failure;
+            ctest -j3 --output-on-failure; && (cat ./Testing/Temporary/LastTest.log || true)
             '
 
   distcheck:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,17 +64,8 @@ jobs:
       - name: Build
         run: make -j3
 
-      - name: Test (main test script)
-        run: ./RunTest
-
-      - name: Test (JIT test program)
-        run: ./pcre2_jit_test
-
-      - name: Test (pcre2grep test script)
-        run: ./RunGrepTest
-
-      - name: Test (pcre2posix program)
-        run: ./pcre2posix_test -v
+      - name: Test
+        run: (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
   dragon:
     # Tests with: clang AB/UB; link-size=3. Clang's logo is a dragon.
@@ -100,19 +91,10 @@ jobs:
       - name: Build
         run: make -j3
 
-      - name: Test (main test script)
+      - name: Test
         run: |
           ulimit -S -s 49152 # Raise stack limit; ASAN with -O0 is very stack-hungry
-          ./RunTest
-
-      - name: Test (JIT test program)
-        run: ./pcre2_jit_test
-
-      - name: Test (pcre2grep test script)
-        run: ./RunGrepTest
-
-      - name: Test (pcre2posix program)
-        run: ./pcre2posix_test -v
+          (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
   greatawk:
     # Tests with: GCC, -O3, oldest supported Ubuntu (in non-extended support)
@@ -140,7 +122,7 @@ jobs:
         run: cd build && make -j3
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure
+        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |
@@ -222,7 +204,7 @@ jobs:
         run: make -j3
 
       - name: Test
-        run: make check || (cat ./test-suite.log; false)
+        run: (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
       - name: Install
         run: |
@@ -271,7 +253,7 @@ jobs:
         run: ninja -C build
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure
+        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |
@@ -298,7 +280,7 @@ jobs:
         run: cmake --build build --config RelWithDebInfo
 
       - name: Test
-        run: cd build && ctest -C RelWithDebInfo -j3 --output-on-failure
+        run: cd build && ctest -C RelWithDebInfo -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   pterodactyl:
     # Tests with: MSVC 64-bit, Debug, shared libraries
@@ -318,7 +300,7 @@ jobs:
         run: cmake --build build --config Debug
 
       - name: Test
-        run: cd build && ctest -C Debug -j3 --output-on-failure
+        run: cd build && ctest -C Debug -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   bigbird:
     # Job to execute ManyConfigTests
@@ -383,7 +365,7 @@ jobs:
         run: cd build && make -j3
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure
+        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   fruitbat:
     # Tests with: MSYS2 unix-on-Windows environment
@@ -428,7 +410,7 @@ jobs:
 
       - name: Test
         shell: msys2 {0}
-        run: cd build && ctest -j3 --output-on-failure
+        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   ptarmigan:
     # Tests with various unusual processor architectures
@@ -496,8 +478,9 @@ jobs:
             set -e
             # TODO: Set -DCMAKE_COMPILE_WARNING_AS_ERROR=ON (there's currently a build failure on S390x)
             cmake $CMAKE_FLAGS -G Ninja -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build
-            ninja -C build
-            (cd build && ctest -j3 --output-on-failure)
+            cd build
+            ninja
+            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   zebrilus:
     # Tests with: Zig compiler. A "zebrilus" is known as a "zigzag heron".


### PR DESCRIPTION
In a recent PR, Zoltan wanted to see the output from pcre2_jit_test in the CI logs, but it's not being stored currently.

It seems reasonable. I'll output it on all the test jobs.