### PR TITLE
Fix incorrect version in docs

### DIFF
--- a/doc/html/pcre2api.html
+++ b/doc/html/pcre2api.html
@@ -3526,7 +3526,7 @@ A common task for applications is to implement "global" matching behaviour,
 for example, replacing all matches in the subject; splitting the subject on all
 matches; or simply counting the number of matches. The <b>pcre2_next_match()</b>
 function helps with this task by providing the appropriate parameters for the
-next match attempt (available since PCRE2 10.46).
+next match attempt (available since PCRE2 10.47).
 </p>
 <p>
 First, a match attempt should be made using one of the matching functions

--- a/doc/html/pcre2pattern.html
+++ b/doc/html/pcre2pattern.html
@@ -3451,7 +3451,7 @@ below.
 Recursion and subroutines with returned capture groups
 </h3>
 <p>
-Since PCRE2 10.46, recursion and subroutine calls may also specify a list of
+Since PCRE2 10.47, recursion and subroutine calls may also specify a list of
 capture groups to return. This is a PCRE2 syntax extension not supported by
 Perl. The pattern matching recurses into the referenced expression as described
 above, however, when the recursion returns to the calling expression the

--- a/doc/pcre2.txt
+++ b/doc/pcre2.txt
@@ -3414,7 +3414,7 @@ ITERATING OVER ALL MATCHES
        subject on all matches; or simply counting the number of  matches.  The
        pcre2_next_match()  function  helps with this task by providing the ap-
        propriate parameters for the next match attempt (available since  PCRE2
-       10.46).
+       10.47).
 
        First,  a  match attempt should be made using one of the matching func-
        tions (pcre2_match(), pcre2_dfa_match(), or pcre2_jit_match()).   Then,
@@ -10105,7 +10105,7 @@ RECURSIVE PATTERNS
 
    Recursion and subroutines with returned capture groups
 
-       Since  PCRE2  10.46,  recursion and subroutine calls may also specify a
+       Since  PCRE2  10.47,  recursion and subroutine calls may also specify a
        list of capture groups to return. This is a PCRE2 syntax extension  not
        supported  by  Perl.  The pattern matching recurses into the referenced
        expression as described above, however, when the recursion  returns  to

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -3543,7 +3543,7 @@ A common task for applications is to implement "global" matching behaviour,
 for example, replacing all matches in the subject; splitting the subject on all
 matches; or simply counting the number of matches. The \fBpcre2_next_match()\fP
 function helps with this task by providing the appropriate parameters for the
-next match attempt (available since PCRE2 10.46).
+next match attempt (available since PCRE2 10.47).
 .P
 First, a match attempt should be made using one of the matching functions
 (\fBpcre2_match()\fP, \fBpcre2_dfa_match()\fP, or \fBpcre2_jit_match()\fP).

--- a/doc/pcre2pattern.3
+++ b/doc/pcre2pattern.3
@@ -3499,7 +3499,7 @@ below.
 .SS "Recursion and subroutines with returned capture groups"
 .rs
 .sp
-Since PCRE2 10.46, recursion and subroutine calls may also specify a list of
+Since PCRE2 10.47, recursion and subroutine calls may also specify a list of
 capture groups to return. This is a PCRE2 syntax extension not supported by
 Perl. The pattern matching recurses into the referenced expression as described
 above, however, when the recursion returns to the calling expression the


### PR DESCRIPTION
I noticed the version is incorrect since these features were released in 10.47.

(I know I don't need to fix all the file types, but I'd hate to submit an inconsistent PR 😇)
