### PR TITLE
Exclude multilib directories in pcre2-config

### DIFF
--- a/pcre2-config.in
+++ b/pcre2-config.in
@@ -23,8 +23,8 @@ fi
 usage="Usage: pcre2-config [--prefix] [--exec-prefix] [--version] $libs $cflags"
 
 if test $# -eq 0; then
-      echo "${usage}" 1>&2
-      exit 1
+  echo "${usage}" 1>&2
+  exit 1
 fi
 
 libR=
@@ -38,9 +38,14 @@ case `uname -s` in
 esac
 
 libS=
-if test @libdir@ != /usr/lib ; then
-  libS=-L@libdir@
-fi
+case "@libdir@" in
+  /usr/lib|/usr/lib32|/usr/lib64|/usr/lib/*-gnu*|/lib|/lib32|/lib64|/lib/*-gnu*)
+  # system locations, no -L needed
+  ;;
+  *)
+  libS="-L@libdir@"
+  ;;
+esac
 
 while test $# -gt 0; do
   case "$1" in


### PR DESCRIPTION
I've noticed that many Linux distributions carry a patch to disable this block of code in pcre2-config.

I believe that few people actually use this script. However, if any downstream distributors are going to the trouble of including a patch, it's probably better to just accept that patch.