### PR TITLE
Remove never-implemented UTF-21 mode placeholders

### DIFF
--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -1601,7 +1601,7 @@ for (;;)
           goto ANYNL01;
 
           case CHAR_CR:
-          if (ptr + 1 < end_subject && UCHAR21TEST(ptr + 1) == CHAR_LF) ncount = 1;
+          if (ptr + 1 < end_subject && ptr[1] == CHAR_LF) ncount = 1;
           /* Fall through */
 
           ANYNL01:
@@ -1879,7 +1879,7 @@ for (;;)
           goto ANYNL02;
 
           case CHAR_CR:
-          if (ptr + 1 < end_subject && UCHAR21TEST(ptr + 1) == CHAR_LF) ncount = 1;
+          if (ptr + 1 < end_subject && ptr[1] == CHAR_LF) ncount = 1;
           /* Fall through */
 
           ANYNL02:
@@ -2160,7 +2160,7 @@ for (;;)
           goto ANYNL03;
 
           case CHAR_CR:
-          if (ptr + 1 < end_subject && UCHAR21TEST(ptr + 1) == CHAR_LF) ncount = 1;
+          if (ptr + 1 < end_subject && ptr[1] == CHAR_LF) ncount = 1;
           /* Fall through */
 
           ANYNL03:
@@ -2341,7 +2341,7 @@ for (;;)
           if ((mb->moptions & PCRE2_PARTIAL_HARD) != 0)
             reset_could_continue = TRUE;
           }
-        else if (UCHAR21TEST(ptr + 1) == CHAR_LF)
+        else if (ptr[1] == CHAR_LF)
           {
           ADD_NEW_DATA(-(state_offset + 1), 0, 1);
           }
@@ -3745,7 +3745,7 @@ for (;;)
         BOOL ok = start_match < end_subject;
         if (ok)
           {
-          PCRE2_UCHAR c = UCHAR21TEST(start_match);
+          PCRE2_UCHAR c = *start_match;
           ok = has_first_cu && (c == first_cu || c == first_cu2);
           if (!ok && start_bits != NULL)
             {
@@ -3773,7 +3773,7 @@ for (;;)
 #if PCRE2_CODE_UNIT_WIDTH != 8
           PCRE2_UCHAR smc;
           while (start_match < end_subject &&
-                (smc = UCHAR21TEST(start_match)) != first_cu &&
+                (smc = *start_match) != first_cu &&
                  smc != first_cu2)
             start_match++;
 #else
@@ -3833,7 +3833,7 @@ for (;;)
         else
           {
 #if PCRE2_CODE_UNIT_WIDTH != 8
-          while (start_match < end_subject && UCHAR21TEST(start_match) !=
+          while (start_match < end_subject && *start_match !=
                  first_cu)
             start_match++;
 #else  /* 8-bit code units */
@@ -3885,7 +3885,7 @@ for (;;)
           if (start_match[-1] == CHAR_CR &&
                (mb->nltype == NLTYPE_ANY || mb->nltype == NLTYPE_ANYCRLF) &&
                start_match < end_subject &&
-               UCHAR21TEST(start_match) == CHAR_NL)
+               *start_match == CHAR_NL)
             start_match++;
           }
         }
@@ -3899,7 +3899,7 @@ for (;;)
         {
         while (start_match < end_subject)
           {
-          uint32_t c = UCHAR21TEST(start_match);
+          uint32_t c = *start_match;
 #if PCRE2_CODE_UNIT_WIDTH != 8
           if (c > 255) c = 255;
 #endif
@@ -3967,7 +3967,7 @@ for (;;)
 #if PCRE2_CODE_UNIT_WIDTH != 8
             while (p < end_subject)
               {
-              uint32_t pp = UCHAR21INCTEST(p);
+              uint32_t pp = *p++;
               if (pp == req_cu || pp == req_cu2) { p--; break; }
               }
 #else  /* 8-bit code units */
@@ -3988,7 +3988,7 @@ for (;;)
 #if PCRE2_CODE_UNIT_WIDTH != 8
             while (p < end_subject)
               {
-              if (UCHAR21INCTEST(p) == req_cu) { p--; break; }
+              if (*p++ == req_cu) { p--; break; }
               }
 
 #else  /* 8-bit code units */
@@ -4096,9 +4096,9 @@ for (;;)
   not contain any explicit matches for \r or \n, and the newline option is CRLF
   or ANY or ANYCRLF, advance the match position by one more character. */
 
-  if (UCHAR21TEST(start_match - 1) == CHAR_CR &&
+  if (start_match[-1] == CHAR_CR &&
       start_match < end_subject &&
-      UCHAR21TEST(start_match) == CHAR_NL &&
+      *start_match == CHAR_NL &&
       (re->flags & PCRE2_HASCRORLF) == 0 &&
         (mb->nltype == NLTYPE_ANY ||
          mb->nltype == NLTYPE_ANYCRLF ||

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -477,8 +477,8 @@ start/end of string field names are. */
        &(NLBLOCK->nllen), utf)) \
     : \
     ((p) <= NLBLOCK->PSEND - NLBLOCK->nllen && \
-     UCHAR21TEST(p) == NLBLOCK->nl[0] && \
-     (NLBLOCK->nllen == 1 || UCHAR21TEST(p+1) == NLBLOCK->nl[1])       \
+     *p == NLBLOCK->nl[0] && \
+     (NLBLOCK->nllen == 1 || p[1] == NLBLOCK->nl[1])       \
     ) \
   )
 
@@ -491,8 +491,8 @@ start/end of string field names are. */
        &(NLBLOCK->nllen), utf)) \
     : \
     ((p) >= NLBLOCK->PSSTART + NLBLOCK->nllen && \
-     UCHAR21TEST(p - NLBLOCK->nllen) == NLBLOCK->nl[0] &&              \
-     (NLBLOCK->nllen == 1 || UCHAR21TEST(p - NLBLOCK->nllen + 1) == NLBLOCK->nl[1]) \
+     *(p - NLBLOCK->nllen) == NLBLOCK->nl[0] &&              \
+     (NLBLOCK->nllen == 1 || *(p - NLBLOCK->nllen + 1) == NLBLOCK->nl[1]) \
     ) \
   )
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -250,21 +250,6 @@ check is needed before accessing these tables. */
 
 /* ----------------- Character-handling macros ----------------- */
 
-/* There is a proposed future special "UTF-21" mode, in which only the lowest
-21 bits of a 32-bit character are interpreted as UTF, with the remaining 11
-high-order bits available to the application for other uses. In preparation for
-the future implementation of this mode, there are macros that load a data item
-and, if in this special mode, mask it to 21 bits. These macros all have names
-starting with UCHAR21. In all other modes, including the normal 32-bit
-library, the macros all have the same simple definitions. When the new mode is
-implemented, it is expected that these definitions will be varied appropriately
-using #ifdef when compiling the library that supports the special mode. */
-
-#define UCHAR21(eptr)        (*(eptr))
-#define UCHAR21TEST(eptr)    (*(eptr))
-#define UCHAR21INC(eptr)     (*(eptr)++)
-#define UCHAR21INCTEST(eptr) (*(eptr)++)
-
 /* When UTF encoding is being used, a character is no longer just a single
 byte in 8-bit mode or a single short in 16-bit mode. The macros for character
 handling generate simple sequences when used in the basic mode, and more

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -455,8 +455,8 @@ if (caseless)
       {
       uint32_t cc, cp;
       if (eptr >= mb->end_subject) return 1;   /* Partial match */
-      cc = UCHAR21TEST(eptr);
-      cp = UCHAR21TEST(p);
+      cc = *eptr;
+      cp = *p;
       if (TABLE_GET(cp, mb->lcc, cp) != TABLE_GET(cc, mb->lcc, cc))
         return -1;  /* No match */
       p++;
@@ -476,7 +476,7 @@ else
     for (; length > 0; length--)
       {
       if (eptr >= mb->end_subject) return 1;   /* Partial match */
-      if (UCHAR21INCTEST(p) != UCHAR21INCTEST(eptr)) return -1;  /* No match */
+      if (*p++ != *eptr++) return -1;  /* No match */
       }
     }
 
@@ -1064,7 +1064,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
         Feptr == mb->end_subject - 1 &&
         NLBLOCK->nltype == NLTYPE_FIXED &&
         NLBLOCK->nllen == 2 &&
-        UCHAR21TEST(Feptr) == NLBLOCK->nl[0])
+        *Feptr == NLBLOCK->nl[0])
       {
       mb->hitend = TRUE;
       if (mb->partial > 1) return PCRE2_ERROR_PARTIAL;
@@ -1120,7 +1120,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
         }
       for (; length > 0; length--)
         {
-        if (*Fecode++ != UCHAR21INC(Feptr)) RRETURN(MATCH_NOMATCH);
+        if (*Fecode++ != *Feptr++) RRETURN(MATCH_NOMATCH);
         }
       }
     else
@@ -1166,7 +1166,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
 
       if (fc < 128)
         {
-        uint32_t cc = UCHAR21(Feptr);
+        uint32_t cc = *Feptr;
         if (mb->lcc[fc] != TABLE_GET(cc, mb->lcc, cc)) RRETURN(MATCH_NOMATCH);
         Fecode++;
         Feptr++;
@@ -1191,7 +1191,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
 
     else if (ucp)
       {
-      uint32_t cc = UCHAR21(Feptr);
+      uint32_t cc = *Feptr;
       fc = Fecode[1];
       if (fc < 128)
         {
@@ -1255,7 +1255,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
     else if (ucp)
       {
       uint32_t ch;
-      fc = UCHAR21INC(Feptr);
+      fc = *Feptr++;
       ch = Fecode[1];
       Fecode += 2;
 
@@ -1280,7 +1280,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
 
       {
       uint32_t ch = Fecode[1];
-      fc = UCHAR21INC(Feptr);
+      fc = *Feptr++;
       if (ch == fc || (Fop == OP_NOTI && TABLE_GET(ch, mb->fcc, ch) == fc))
         RRETURN(MATCH_NOMATCH);
       Fecode += 2;
@@ -1523,7 +1523,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
           SCHECK_PARTIAL();
           RRETURN(MATCH_NOMATCH);
           }
-        cc = UCHAR21TEST(Feptr);
+        cc = *Feptr;
         if (Lc != cc && Loc != cc) RRETURN(MATCH_NOMATCH);
         Feptr++;
         }
@@ -1542,7 +1542,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
-          cc = UCHAR21TEST(Feptr);
+          cc = *Feptr;
           if (Lc != cc && Loc != cc) RRETURN(MATCH_NOMATCH);
           Feptr++;
           }
@@ -1560,7 +1560,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             break;
             }
-          cc = UCHAR21TEST(Feptr);
+          cc = *Feptr;
           if (Lc != cc && Loc != cc) break;
           Feptr++;
           }
@@ -1585,7 +1585,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
           SCHECK_PARTIAL();
           RRETURN(MATCH_NOMATCH);
           }
-        if (Lc != UCHAR21INCTEST(Feptr)) RRETURN(MATCH_NOMATCH);
+        if (Lc != *Feptr++) RRETURN(MATCH_NOMATCH);
         }
 
       if (Lmin == Lmax) continue;
@@ -1602,7 +1602,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
-          if (Lc != UCHAR21INCTEST(Feptr)) RRETURN(MATCH_NOMATCH);
+          if (Lc != *Feptr++) RRETURN(MATCH_NOMATCH);
           }
         PCRE2_UNREACHABLE(); /* Control never reaches here */
         }
@@ -1617,7 +1617,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             break;
             }
 
-          if (Lc != UCHAR21TEST(Feptr)) break;
+          if (Lc != *Feptr) break;
           Feptr++;
           }
 
@@ -2659,7 +2659,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
         {
         SCHECK_PARTIAL();
         }
-      else if (UCHAR21TEST(Feptr) == CHAR_LF) Feptr++;
+      else if (*Feptr == CHAR_LF) Feptr++;
       break;
 
       case CHAR_LF:
@@ -3273,7 +3273,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               Feptr + 1 >= mb->end_subject &&
               NLBLOCK->nltype == NLTYPE_FIXED &&
               NLBLOCK->nllen == 2 &&
-              UCHAR21(Feptr) == NLBLOCK->nl[0])
+              *Feptr == NLBLOCK->nl[0])
             {
             mb->hitend = TRUE;
             if (mb->partial > 1) return PCRE2_ERROR_PARTIAL;
@@ -3315,7 +3315,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             default: RRETURN(MATCH_NOMATCH);
 
             case CHAR_CR:
-            if (Feptr < mb->end_subject && UCHAR21(Feptr) == CHAR_LF) Feptr++;
+            if (Feptr < mb->end_subject && *Feptr == CHAR_LF) Feptr++;
             break;
 
             case CHAR_LF:
@@ -3425,7 +3425,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
-          cc = UCHAR21(Feptr);
+          cc = *Feptr;
           if (cc >= 128 || (mb->ctypes[cc] & ctype_digit) == 0)
             RRETURN(MATCH_NOMATCH);
           Feptr++;
@@ -3442,7 +3442,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
-          cc = UCHAR21(Feptr);
+          cc = *Feptr;
           if (cc < 128 && (mb->ctypes[cc] & ctype_space) != 0)
             RRETURN(MATCH_NOMATCH);
           Feptr++;
@@ -3459,7 +3459,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
-          cc = UCHAR21(Feptr);
+          cc = *Feptr;
           if (cc >= 128 || (mb->ctypes[cc] & ctype_space) == 0)
             RRETURN(MATCH_NOMATCH);
           Feptr++;
@@ -3476,7 +3476,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
-          cc = UCHAR21(Feptr);
+          cc = *Feptr;
           if (cc < 128 && (mb->ctypes[cc] & ctype_word) != 0)
             RRETURN(MATCH_NOMATCH);
           Feptr++;
@@ -3493,7 +3493,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
-          cc = UCHAR21(Feptr);
+          cc = *Feptr;
           if (cc >= 128 || (mb->ctypes[cc] & ctype_word) == 0)
             RRETURN(MATCH_NOMATCH);
           Feptr++;
@@ -4121,7 +4121,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               default: RRETURN(MATCH_NOMATCH);
 
               case CHAR_CR:
-              if (Feptr < mb->end_subject && UCHAR21(Feptr) == CHAR_LF) Feptr++;
+              if (Feptr < mb->end_subject && *Feptr == CHAR_LF) Feptr++;
               break;
 
               case CHAR_LF:
@@ -4734,7 +4734,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
                 Feptr + 1 >= mb->end_subject &&
                 NLBLOCK->nltype == NLTYPE_FIXED &&
                 NLBLOCK->nllen == 2 &&
-                UCHAR21(Feptr) == NLBLOCK->nl[0])
+                *Feptr == NLBLOCK->nl[0])
               {
               mb->hitend = TRUE;
               if (mb->partial > 1) return PCRE2_ERROR_PARTIAL;
@@ -4790,7 +4790,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             if (fc == CHAR_CR)
               {
               if (++Feptr >= mb->end_subject) break;
-              if (UCHAR21(Feptr) == CHAR_LF) Feptr++;
+              if (*Feptr == CHAR_LF) Feptr++;
               }
             else
               {
@@ -4962,7 +4962,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
           Feptr--;
           BACKCHAR(Feptr);
           if (Lctype == OP_ANYNL && Feptr > Lstart_eptr &&
-              UCHAR21(Feptr) == CHAR_NL && UCHAR21(Feptr - 1) == CHAR_CR)
+              *Feptr == CHAR_NL && Feptr[-1] == CHAR_CR)
             Feptr--;
           }
         }
@@ -6609,7 +6609,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
           Feptr + 1 >= mb->end_subject &&
           NLBLOCK->nltype == NLTYPE_FIXED &&
           NLBLOCK->nllen == 2 &&
-          UCHAR21TEST(Feptr) == NLBLOCK->nl[0])
+          *Feptr == NLBLOCK->nl[0])
         {
         mb->hitend = TRUE;
         if (mb->partial > 1) return PCRE2_ERROR_PARTIAL;
@@ -6657,7 +6657,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             Feptr + 1 >= mb->end_subject &&
             NLBLOCK->nltype == NLTYPE_FIXED &&
             NLBLOCK->nllen == 2 &&
-            UCHAR21TEST(Feptr) == NLBLOCK->nl[0])
+            *Feptr == NLBLOCK->nl[0])
           {
           mb->hitend = TRUE;
           if (mb->partial > 1) return PCRE2_ERROR_PARTIAL;
@@ -7659,7 +7659,7 @@ for(;;)
         BOOL ok = start_match < end_subject;
         if (ok)
           {
-          PCRE2_UCHAR c = UCHAR21TEST(start_match);
+          PCRE2_UCHAR c = *start_match;
           ok = has_first_cu && (c == first_cu || c == first_cu2);
           if (!ok && start_bits != NULL)
             {
@@ -7691,7 +7691,7 @@ for(;;)
 #if PCRE2_CODE_UNIT_WIDTH != 8
           PCRE2_UCHAR smc;
           while (start_match < end_subject &&
-                (smc = UCHAR21TEST(start_match)) != first_cu &&
+                (smc = *start_match) != first_cu &&
                  smc != first_cu2)
             start_match++;
 #else
@@ -7751,7 +7751,7 @@ for(;;)
         else
           {
 #if PCRE2_CODE_UNIT_WIDTH != 8
-          while (start_match < end_subject && UCHAR21TEST(start_match) !=
+          while (start_match < end_subject && *start_match !=
                  first_cu)
             start_match++;
 #else
@@ -7806,7 +7806,7 @@ for(;;)
           if (start_match[-1] == CHAR_CR &&
                (mb->nltype == NLTYPE_ANY || mb->nltype == NLTYPE_ANYCRLF) &&
                start_match < end_subject &&
-               UCHAR21TEST(start_match) == CHAR_NL)
+               *start_match == CHAR_NL)
             start_match++;
           }
         }
@@ -7820,7 +7820,7 @@ for(;;)
         {
         while (start_match < end_subject)
           {
-          uint32_t c = UCHAR21TEST(start_match);
+          uint32_t c = *start_match;
 #if PCRE2_CODE_UNIT_WIDTH != 8
           if (c > 255) c = 255;
 #endif
@@ -7894,7 +7894,7 @@ for(;;)
 #if PCRE2_CODE_UNIT_WIDTH != 8
             while (p < end_subject)
               {
-              uint32_t pp = UCHAR21INCTEST(p);
+              uint32_t pp = *p++;
               if (pp == req_cu || pp == req_cu2) { p--; break; }
               }
 #else  /* 8-bit code units */
@@ -7915,7 +7915,7 @@ for(;;)
 #if PCRE2_CODE_UNIT_WIDTH != 8
             while (p < end_subject)
               {
-              if (UCHAR21INCTEST(p) == req_cu) { p--; break; }
+              if (*p++ == req_cu) { p--; break; }
               }
 
 #else  /* 8-bit code units */


### PR DESCRIPTION
Philip agreed in #804 that these could be removed. It's quite possible that the placeholders are not used everywhere they should be, since it's not been tested, nor does the JIT have the required support.

Because the UTF-21 mode was never completed, and the original feature request has been presumably met in some other way, I am removing it. We can always revert or re-think if another user appears wanting this feature.

I have simply inlined the macros.