### PR TITLE
pcre2grep: retain const qualifier from pointer

### DIFF
--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -593,7 +593,7 @@ static char *
 parse_grep_colors(const char *gc)
 {
 static char seq[16];
-char *col;
+const char *col;
 uint32_t len;
 if (gc == NULL) return NULL;
 col = strstr(gc, "ms=");
@@ -1309,7 +1309,7 @@ if (*endptr != 0)   /* Error */
   {
   if (longop)
     {
-    char *equals = strchr(op->long_name, '=');
+    const char *equals = strchr(op->long_name, '=');
     int nlen = (equals == NULL)? (int)strlen(op->long_name) :
       (int)(equals - op->long_name);
     fprintf(stderr, "pcre2grep: Malformed number \"%s\" after --%.*s\n",
@@ -4007,8 +4007,8 @@ for (i = 1; i < argc; i++)
 
     for (op = optionlist; op->one_char != 0; op++)
       {
-      char *opbra = strchr(op->long_name, '(');
-      char *equals = strchr(op->long_name, '=');
+      const char *opbra = strchr(op->long_name, '(');
+      const char *equals = strchr(op->long_name, '=');
 
       /* Handle options with only one spelling of the name */
 


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

Resolves the following warnings:
```c
../src/pcre2grep.c: In function 'parse_grep_colors': ../src/pcre2grep.c:599:5: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  599 | col = strstr(gc, "ms=");
      |     ^
../src/pcre2grep.c:600:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  600 | if (col == NULL) col = strstr(gc, "mt=");
      |                      ^
../src/pcre2grep.c: In function 'decode_number':
../src/pcre2grep.c:1312:20: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 1312 |     char *equals = strchr(op->long_name, '=');
      |                    ^~~~~~
../src/pcre2grep.c: In function 'main':
../src/pcre2grep.c:4010:21: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 4010 |       char *opbra = strchr(op->long_name, '(');
      |                     ^~~~~~
../src/pcre2grep.c:4011:22: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 4011 |       char *equals = strchr(op->long_name, '=');
      |                      ^~~~~~
```