### PR TITLE
Add _lib_version to sym files for benefit of Solaris

### DIFF
--- a/src/libpcre2-16.sym
+++ b/src/libpcre2-16.sym
@@ -83,6 +83,7 @@ PCRE2_10.47 {
   local:
     _fini;
     _init;
+    _lib_version;
 };
 
 # PCRE2_10.48 {} PCRE2_10.47;

--- a/src/libpcre2-32.sym
+++ b/src/libpcre2-32.sym
@@ -83,6 +83,7 @@ PCRE2_10.47 {
   local:
     _fini;
     _init;
+    _lib_version;
 };
 
 # PCRE2_10.48 {} PCRE2_10.47;

--- a/src/libpcre2-8.sym
+++ b/src/libpcre2-8.sym
@@ -83,6 +83,7 @@ PCRE2_10.47 {
   local:
     _fini;
     _init;
+    _lib_version;
 };
 
 # PCRE2_10.48 {} PCRE2_10.47;

--- a/src/libpcre2-posix.sym
+++ b/src/libpcre2-posix.sym
@@ -8,6 +8,7 @@ PCRE2_10.47 {
   local:
     _fini;
     _init;
+    _lib_version;
 };
 
 # PCRE2_10.48 {} PCRE2_10.47;


### PR DESCRIPTION
This fixes the following build error:

  Undefined first referenced
  symbol in file
  _lib_version /usr/lib/sparcv9/values-Xa.o (symbol has no version assigned)
  ld: fatal: symbol referencing errors

Fixes #878 