### PR TITLE
fuzz: fix stack-use-after-scope in LLVMFuzzerTestOneInput

### DIFF
--- a/src/pcre2_fuzzsupport.c
+++ b/src/pcre2_fuzzsupport.c
@@ -331,6 +331,7 @@ pcre2_compile_context *compile_context = NULL;
 pcre2_match_context *match_context = NULL;
 size_t match_size;
 int dfa_workspace[DFA_WORKSPACE_COUNT];
+uint32_t callout_count;
 
 if (size < sizeof(random_options)) return -1;
 
@@ -492,7 +493,6 @@ likewise do the match with and without the options. */
 
 for (int i = 0; i < 2; i++)
   {
-  uint32_t callout_count;
   int errorcode;
 #ifdef SUPPORT_JIT
   int errorcode_jit;


### PR DESCRIPTION
A variable `callout_count` is declared within the scope of a `for` loop in the function `LLVMFuzzerTestOneInput`. The address of this variable is passed to the function `pcre2_set_callout()` and stored within the variable `match_context`.

The variable `match_context` is defined outside the loop, initialized during the first loop iteration, and persists for the second iteration. The address of `callout_count` is a stale stack location in the second iteration. When `pcre2_match()` is called in the second iteration, a callback attempts to access this address, resulting in a stack-use-after-scope error.

This patch moves the declaration of `callout_count` to the function scope, ensuring its lifetime covers the entire duration that `match_context` is active.


Fixes: https://issues.oss-fuzz.com/issues/478301105