### PR TITLE
pcre2test: detect setrlimit instead of hardcoding platform list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ endif()
 check_symbol_exists(mkostemp stdlib.h HAVE_MKOSTEMP) # glibc 2.7
 check_symbol_exists(memfd_create "sys/mman.h" HAVE_MEMFD_CREATE) # glibc 2.27
 check_symbol_exists(secure_getenv "stdlib.h" HAVE_SECURE_GETENV) # glibc 2.17
+check_symbol_exists(setrlimit "sys/resource.h" HAVE_SETRLIMIT)
 cmake_pop_check_state()
 
 check_c_source_compiles(

--- a/configure.ac
+++ b/configure.ac
@@ -627,7 +627,7 @@ AC_TYPE_SIZE_T
 
 # Checks for library functions.
 
-AC_CHECK_FUNCS(memfd_create mkostemp secure_getenv)
+AC_CHECK_FUNCS(memfd_create mkostemp secure_getenv setrlimit)
 AC_MSG_CHECKING([for realpath])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdlib.h>

--- a/src/config-cmake.h.in
+++ b/src/config-cmake.h.in
@@ -13,6 +13,7 @@
 
 #cmakedefine HAVE_MEMFD_CREATE 1
 #cmakedefine HAVE_SECURE_GETENV 1
+#cmakedefine HAVE_SETRLIMIT 1
 
 #cmakedefine SUPPORT_PCRE2_8 1
 #cmakedefine SUPPORT_PCRE2_16 1

--- a/src/config.h.generic
+++ b/src/config.h.generic
@@ -119,6 +119,9 @@ surrounded by #ifndef/#endif lines so that the value can be overridden by -D. */
 /* Define to 1 if you have the `secure_getenv' function. */
 /* #undef HAVE_SECURE_GETENV */
 
+/* Define to 1 if you have the `setrlimit' function. */
+/* #undef HAVE_SETRLIMIT */
+
 /* Define to 1 if you have the <stdint.h> header file. */
 /* #undef HAVE_STDINT_H */
 

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -3774,7 +3774,12 @@ while (argc > 1 && argv[op][0] == '-' && argv[op][1] != 0)
   else if (strcmp(arg, "-S") == 0 && argc > 2 &&
       ((uli = strtoul(argv[op+1], &endptr, 10)), *endptr == 0))
     {
-#if !defined(HAVE_SETRLIMIT) || defined(__HAIKU__) || defined(NATIVE_ZOS)
+    /* On Win32, we exclude setrlimit() regardless of whether it may have been detected
+    due to some Unix emulation environment. On Haiku and z/OS, setrlimit() is reported
+    to be detected (with the function linking successfully and RLIMIT_STACK defined in
+    the headers), but it does not actually work, so we exclude it as well. */
+#if defined(_WIN32) || defined(WIN32) || !defined(HAVE_SETRLIMIT) || \
+  defined(__HAIKU__) || defined(NATIVE_ZOS)
     cfprintf(clr_test_error, stderr, "pcre2test: -S is not supported on this OS\n");
     exit(1);
 #else

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -150,8 +150,10 @@ patterns. */
 /* Not Windows */
 
 #else
+#ifdef HAVE_SETRLIMIT
 #include <sys/time.h>          /* These two includes are needed */
 #include <sys/resource.h>      /* for setrlimit(). */
+#endif
 #if defined NATIVE_ZOS         /* z/OS uses non-binary I/O */
 #define INPUT_MODE   "r"
 #define OUTPUT_MODE  "w"
@@ -3772,7 +3774,7 @@ while (argc > 1 && argv[op][0] == '-' && argv[op][1] != 0)
   else if (strcmp(arg, "-S") == 0 && argc > 2 &&
       ((uli = strtoul(argv[op+1], &endptr, 10)), *endptr == 0))
     {
-#if defined(_WIN32) || defined(WIN32) || defined(__HAIKU__) || defined(NATIVE_ZOS) || defined(__VMS)
+#if !defined(HAVE_SETRLIMIT) || defined(__HAIKU__) || defined(NATIVE_ZOS)
     cfprintf(clr_test_error, stderr, "pcre2test: -S is not supported on this OS\n");
     exit(1);
 #else


### PR DESCRIPTION
Replace the growing platform preprocessor check for -S flag support with AC_CHECK_FUNCS/check_symbol_exists detection of setrlimit. This automatically handles any platform lacking setrlimit (WASI, VMS, etc.) without maintaining a manual list.

Haiku and z/OS are kept as explicit exclusions because they provide setrlimit but don't support RLIMIT_STACK.