### PR TITLE
Update build.zig to compile on the latest stable Zig 0.15.2

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,7 @@ pub fn build(b: *std.Build) !void {
     const rt = target.result;
 
     const linkage = b.option(std.builtin.LinkMode, "linkage", "whether to statically or dynamically link the library") orelse @as(std.builtin.LinkMode, if (rt.isGnuLibC()) .dynamic else .static);
+    const sanitize_c = b.option(std.zig.SanitizeC, "sanitize_c", "whether to build with undefined behaviour sanitizer enabled") orelse .off;
     const codeUnitWidth = b.option(CodeUnitWidth, "code-unit-width", "Sets the code unit width") orelse .@"8";
     const jit = b.option(bool, "support_jit", "Enable/disable JIT compiler support") orelse false;
 
@@ -39,18 +40,16 @@ pub fn build(b: *std.Build) !void {
             .HAVE_SYS_TYPES_H = true,
             .HAVE_UNISTD_H = is_unix or is_mingw,
             .HAVE_WINDOWS_H = rt.os.tag == .windows,
-            .HAVE_MKOSTEMP = is_unix,
+
             .HAVE_MEMFD_CREATE = is_musl or is_glibc or is_freebsd,
             .HAVE_SECURE_GETENV = is_musl or is_glibc or is_freebsd,
-            .HAVE_REALPATH = is_unix,
 
             // all compilation is using the Zig bundled c compiler
-            .HAVE_ATTRIBUTE_UNINITIALIZED = true,
-            .HAVE_VISIBILITY = true,
             .HAVE_BUILTIN_ASSUME = null,
             .HAVE_BUILTIN_MUL_OVERFLOW = true,
             .HAVE_BUILTIN_UNREACHABLE = true,
-            .INTEL_CET_ENABLED = null,
+            .HAVE_ATTRIBUTE_UNINITIALIZED = true,
+            .HAVE_VISIBILITY = true,
 
             .SUPPORT_PCRE2_8 = codeUnitWidth == .@"8",
             .SUPPORT_PCRE2_16 = codeUnitWidth == .@"16",
@@ -78,6 +77,7 @@ pub fn build(b: *std.Build) !void {
     const lib_mod = b.createModule(.{
         .target = target,
         .optimize = optimize,
+        .sanitize_c = sanitize_c,
         .link_libc = true,
     });
 
@@ -126,6 +126,9 @@ pub fn build(b: *std.Build) !void {
             "src/pcre2_ucd.c",
             "src/pcre2_valid_utf.c",
             "src/pcre2_xclass.c",
+        },
+        .flags = &.{
+            "-fvisibility=hidden",
         },
     });
 
@@ -203,6 +206,7 @@ pub fn build(b: *std.Build) !void {
 
         pcre2test_mod.linkLibrary(posixLib);
 
+        b.addNamedLazyPath("pcre2posix.h", b.path("src/pcre2posix.h"));
         posixLib.installHeader(b.path("src/pcre2posix.h"), "pcre2posix.h");
         b.installArtifact(posixLib);
     }

--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,10 @@ pub fn build(b: *std.Build) !void {
     const is_glibc = rt.isGnuLibC();
     const is_freebsd = rt.isFreeBSDLibC();
 
+    const cflags = &.{
+        "-fvisibility=hidden",
+    };
+
     const config_h = b.addConfigHeader(
         .{
             .style = .{
@@ -33,6 +37,10 @@ pub fn build(b: *std.Build) !void {
             },
             .include_path = "config.h",
         },
+        // These options should be kept in-sync with those in config-cmake.h.in, and
+        // should be the same set of options (no more needed). It is permitted to
+        // specify fewer options here than in config-cmake.h.in, if an option is
+        // disabled in all zig build configurations.
         .{
             .HAVE_ASSERT_H = true,
             .HAVE_DIRENT_H = is_unix or is_mingw,
@@ -49,7 +57,6 @@ pub fn build(b: *std.Build) !void {
             .HAVE_BUILTIN_MUL_OVERFLOW = true,
             .HAVE_BUILTIN_UNREACHABLE = true,
             .HAVE_ATTRIBUTE_UNINITIALIZED = true,
-            .HAVE_VISIBILITY = true,
 
             .SUPPORT_PCRE2_8 = codeUnitWidth == .@"8",
             .SUPPORT_PCRE2_16 = codeUnitWidth == .@"16",
@@ -57,10 +64,11 @@ pub fn build(b: *std.Build) !void {
             .SUPPORT_UNICODE = true,
             .SUPPORT_JIT = jit,
 
-            .PCRE2_EXPORT = switch (linkage) {
-                .dynamic => "__attribute__ ((visibility (\"default\")))",
-                else => null,
-            },
+            // As for CMake builds, use visibilty attributes for both shared and static
+            // builds. Internal symbols should be hidden even in static builds, because
+            // the user could be statically linking PCRE2 into their own shared library.
+            .PCRE2_EXPORT = "__attribute__ ((visibility (\"default\")))",
+
             .PCRE2_LINK_SIZE = 2,
             .PCRE2_PARENS_NEST_LIMIT = 250,
             .PCRE2_HEAP_LIMIT = 20000000,
@@ -93,6 +101,7 @@ pub fn build(b: *std.Build) !void {
 
     lib_mod.addCSourceFile(.{
         .file = b.addWriteFiles().addCopyFile(b.path("src/pcre2_chartables.c.dist"), "pcre2_chartables.c"),
+        .flags = cflags,
     });
     lib_mod.addCSourceFiles(.{
         .files = &.{
@@ -127,9 +136,7 @@ pub fn build(b: *std.Build) !void {
             "src/pcre2_valid_utf.c",
             "src/pcre2_xclass.c",
         },
-        .flags = &.{
-            "-fvisibility=hidden",
-        },
+        .flags = cflags,
     });
 
     const lib = b.addLibrary(.{
@@ -145,11 +152,18 @@ pub fn build(b: *std.Build) !void {
     const pcre2test_mod = b.createModule(.{
         .target = target,
         .optimize = optimize,
+        .sanitize_c = sanitize_c,
         .link_libc = true,
     });
 
     pcre2test_mod.addCMacro("HAVE_CONFIG_H", "");
 
+    // Note: On Windows, consumers linking against the static library should
+    // probably define PCRE2_STATIC themselves (e.g. via
+    // addCMacro("PCRE2_STATIC", "")).
+    // As far as I know, Zig's build system does not currently have a mechanism
+    // to propagate compile definitions to downstream consumers (like CMake's
+    // PUBLIC target_compile_definitions). On non-Windows targets this is a no-op.
     switch (linkage) {
         .static => pcre2test_mod.addCMacro("PCRE2_STATIC", ""),
         .dynamic => pcre2test_mod.addCMacro("PCRE2POSIX_SHARED", ""),
@@ -165,6 +179,7 @@ pub fn build(b: *std.Build) !void {
 
     pcre2test_mod.addCSourceFile(.{
         .file = b.path("src/pcre2test.c"),
+        .flags = cflags,
     });
 
     pcre2test_mod.linkLibrary(lib);
@@ -175,6 +190,7 @@ pub fn build(b: *std.Build) !void {
         const posixLib_mod = b.createModule(.{
             .target = target,
             .optimize = optimize,
+            .sanitize_c = sanitize_c,
             .link_libc = true,
         });
 
@@ -194,6 +210,7 @@ pub fn build(b: *std.Build) !void {
             .files = &.{
                 "src/pcre2posix.c",
             },
+            .flags = cflags,
         });
 
         posixLib_mod.linkLibrary(lib);

--- a/build.zig
+++ b/build.zig
@@ -7,50 +7,74 @@ pub const CodeUnitWidth = enum {
 };
 
 pub fn build(b: *std.Build) !void {
-    const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const linkage = b.option(std.builtin.LinkMode, "linkage", "whether to statically or dynamically link the library") orelse @as(std.builtin.LinkMode, if (target.result.isGnuLibC()) .dynamic else .static);
+    const target = b.standardTargetOptions(.{});
+    const rt = target.result;
+
+    const linkage = b.option(std.builtin.LinkMode, "linkage", "whether to statically or dynamically link the library") orelse @as(std.builtin.LinkMode, if (rt.isGnuLibC()) .dynamic else .static);
     const codeUnitWidth = b.option(CodeUnitWidth, "code-unit-width", "Sets the code unit width") orelse .@"8";
     const jit = b.option(bool, "support_jit", "Enable/disable JIT compiler support") orelse false;
 
-    const pcre2_header_dir = b.addWriteFiles();
-    const pcre2_header = pcre2_header_dir.addCopyFile(b.path("src/pcre2.h.generic"), "pcre2.h");
+    const pcre2_h_dir = b.addWriteFiles();
+    const pcre2_h = pcre2_h_dir.addCopyFile(b.path("src/pcre2.h.generic"), "pcre2.h");
+    b.addNamedLazyPath("pcre2.h", pcre2_h);
 
-    const config_header = b.addConfigHeader(
+    const is_unix = rt.os.tag != .windows;
+    const is_mingw = rt.isMinGW();
+    const is_musl = rt.isMuslLibC();
+    const is_glibc = rt.isGnuLibC();
+    const is_freebsd = rt.isFreeBSDLibC();
+
+    const config_h = b.addConfigHeader(
         .{
-            .style = .{ .cmake = b.path("src/config-cmake.h.in") },
+            .style = .{
+                .cmake = b.path("src/config-cmake.h.in"),
+            },
             .include_path = "config.h",
         },
         .{
             .HAVE_ASSERT_H = true,
-            .HAVE_UNISTD_H = (target.result.os.tag != .windows),
-            .HAVE_WINDOWS_H = (target.result.os.tag == .windows),
+            .HAVE_DIRENT_H = is_unix or is_mingw,
+            .HAVE_SYS_STAT_H = true,
+            .HAVE_SYS_TYPES_H = true,
+            .HAVE_UNISTD_H = is_unix or is_mingw,
+            .HAVE_WINDOWS_H = rt.os.tag == .windows,
+            .HAVE_MKOSTEMP = is_unix,
+            .HAVE_MEMFD_CREATE = is_musl or is_glibc or is_freebsd,
+            .HAVE_SECURE_GETENV = is_musl or is_glibc or is_freebsd,
+            .HAVE_REALPATH = is_unix,
 
+            // all compilation is using the Zig bundled c compiler
             .HAVE_ATTRIBUTE_UNINITIALIZED = true,
+            .HAVE_VISIBILITY = true,
+            .HAVE_BUILTIN_ASSUME = null,
             .HAVE_BUILTIN_MUL_OVERFLOW = true,
             .HAVE_BUILTIN_UNREACHABLE = true,
+            .INTEL_CET_ENABLED = null,
 
-            .SUPPORT_PCRE2_8 = codeUnitWidth == CodeUnitWidth.@"8",
-            .SUPPORT_PCRE2_16 = codeUnitWidth == CodeUnitWidth.@"16",
-            .SUPPORT_PCRE2_32 = codeUnitWidth == CodeUnitWidth.@"32",
+            .SUPPORT_PCRE2_8 = codeUnitWidth == .@"8",
+            .SUPPORT_PCRE2_16 = codeUnitWidth == .@"16",
+            .SUPPORT_PCRE2_32 = codeUnitWidth == .@"32",
             .SUPPORT_UNICODE = true,
             .SUPPORT_JIT = jit,
 
-            .PCRE2_EXPORT = null,
+            .PCRE2_EXPORT = switch (linkage) {
+                .dynamic => "__attribute__ ((visibility (\"default\")))",
+                else => null,
+            },
             .PCRE2_LINK_SIZE = 2,
+            .PCRE2_PARENS_NEST_LIMIT = 250,
             .PCRE2_HEAP_LIMIT = 20000000,
+            .PCRE2_MAX_VARLOOKBEHIND = 255,
             .PCRE2_MATCH_LIMIT = 10000000,
             .PCRE2_MATCH_LIMIT_DEPTH = "MATCH_LIMIT",
-            .PCRE2_MAX_VARLOOKBEHIND = 255,
-            .NEWLINE_DEFAULT = 2,
-            .PCRE2_PARENS_NEST_LIMIT = 250,
             .PCRE2GREP_BUFSIZE = 20480,
             .PCRE2GREP_MAX_BUFSIZE = 1048576,
+            .NEWLINE_DEFAULT = 2,
         },
     );
 
     // pcre2-8/16/32 library
-
     const lib_mod = b.createModule(.{
         .target = target,
         .optimize = optimize,
@@ -59,25 +83,18 @@ pub fn build(b: *std.Build) !void {
 
     lib_mod.addCMacro("HAVE_CONFIG_H", "");
     lib_mod.addCMacro("PCRE2_CODE_UNIT_WIDTH", @tagName(codeUnitWidth));
-    if (linkage == .static) {
-        lib_mod.addCMacro("PCRE2_STATIC", "");
+    switch (linkage) {
+        .static => lib_mod.addCMacro("PCRE2_STATIC", ""),
+        .dynamic => {},
     }
+    lib_mod.addConfigHeader(config_h);
+    lib_mod.addIncludePath(pcre2_h_dir.getDirectory());
+    lib_mod.addIncludePath(b.path("src"));
 
-    const lib = b.addLibrary(.{
-        .name = b.fmt("pcre2-{s}", .{@tagName(codeUnitWidth)}),
-        .root_module = lib_mod,
-        .linkage = linkage,
-    });
-
-    lib.addConfigHeader(config_header);
-    lib.addIncludePath(pcre2_header_dir.getDirectory());
-    lib.addIncludePath(b.path("src"));
-
-    lib.addCSourceFile(.{
+    lib_mod.addCSourceFile(.{
         .file = b.addWriteFiles().addCopyFile(b.path("src/pcre2_chartables.c.dist"), "pcre2_chartables.c"),
     });
-
-    lib.addCSourceFiles(.{
+    lib_mod.addCSourceFiles(.{
         .files = &.{
             "src/pcre2_auto_possess.c",
             "src/pcre2_chkdint.c",
@@ -112,11 +129,16 @@ pub fn build(b: *std.Build) !void {
         },
     });
 
-    lib.installHeader(pcre2_header, "pcre2.h");
+    const lib = b.addLibrary(.{
+        .name = b.fmt("pcre2-{t}", .{codeUnitWidth}),
+        .root_module = lib_mod,
+        .linkage = linkage,
+    });
+
+    lib.installHeader(pcre2_h, "pcre2.h");
     b.installArtifact(lib);
 
     // pcre2test
-
     const pcre2test_mod = b.createModule(.{
         .target = target,
         .optimize = optimize,
@@ -124,19 +146,28 @@ pub fn build(b: *std.Build) !void {
     });
 
     pcre2test_mod.addCMacro("HAVE_CONFIG_H", "");
-    if (linkage == .static) {
-        pcre2test_mod.addCMacro("PCRE2_STATIC", "");
-    } else {
-        pcre2test_mod.addCMacro("PCRE2POSIX_SHARED", "");
+
+    switch (linkage) {
+        .static => pcre2test_mod.addCMacro("PCRE2_STATIC", ""),
+        .dynamic => pcre2test_mod.addCMacro("PCRE2POSIX_SHARED", ""),
     }
 
     const pcre2test = b.addExecutable(.{
         .name = "pcre2test",
         .root_module = pcre2test_mod,
     });
+    pcre2test_mod.addConfigHeader(config_h);
+    pcre2test_mod.addIncludePath(pcre2_h_dir.getDirectory());
+    pcre2test_mod.addIncludePath(b.path("src"));
+
+    pcre2test_mod.addCSourceFile(.{
+        .file = b.path("src/pcre2test.c"),
+    });
+
+    pcre2test_mod.linkLibrary(lib);
+    b.installArtifact(pcre2test);
 
     // pcre2-posix library
-
     if (codeUnitWidth == CodeUnitWidth.@"8") {
         const posixLib_mod = b.createModule(.{
             .target = target,
@@ -146,11 +177,23 @@ pub fn build(b: *std.Build) !void {
 
         posixLib_mod.addCMacro("HAVE_CONFIG_H", "");
         posixLib_mod.addCMacro("PCRE2_CODE_UNIT_WIDTH", @tagName(codeUnitWidth));
-        if (linkage == .static) {
-            posixLib_mod.addCMacro("PCRE2_STATIC", "");
-        } else {
-            posixLib_mod.addCMacro("PCRE2POSIX_SHARED", "");
+
+        switch (linkage) {
+            .static => posixLib_mod.addCMacro("PCRE2_STATIC", ""),
+            .dynamic => posixLib_mod.addCMacro("PCRE2POSIX_SHARED", ""),
         }
+
+        posixLib_mod.addConfigHeader(config_h);
+        posixLib_mod.addIncludePath(pcre2_h_dir.getDirectory());
+        posixLib_mod.addIncludePath(b.path("src"));
+
+        posixLib_mod.addCSourceFiles(.{
+            .files = &.{
+                "src/pcre2posix.c",
+            },
+        });
+
+        posixLib_mod.linkLibrary(lib);
 
         const posixLib = b.addLibrary(.{
             .name = "pcre2-posix",
@@ -158,35 +201,9 @@ pub fn build(b: *std.Build) !void {
             .linkage = linkage,
         });
 
-        posixLib.addConfigHeader(config_header);
-        posixLib.addIncludePath(pcre2_header_dir.getDirectory());
-        posixLib.addIncludePath(b.path("src"));
-
-        posixLib.addCSourceFiles(.{
-            .files = &.{
-                "src/pcre2posix.c",
-            },
-        });
-
-        posixLib.linkLibrary(lib);
+        pcre2test_mod.linkLibrary(posixLib);
 
         posixLib.installHeader(b.path("src/pcre2posix.h"), "pcre2posix.h");
         b.installArtifact(posixLib);
-
-        pcre2test.linkLibrary(posixLib);
     }
-
-    // pcre2test (again)
-
-    pcre2test.addConfigHeader(config_header);
-    pcre2test.addIncludePath(pcre2_header_dir.getDirectory());
-    pcre2test.addIncludePath(b.path("src"));
-
-    pcre2test.addCSourceFile(.{
-        .file = b.path("src/pcre2test.c"),
-    });
-
-    pcre2test.linkLibrary(lib);
-
-    b.installArtifact(pcre2test);
 }


### PR DESCRIPTION
Add a named LazyPath called `pcre2.h`, which library users can import and add to their projects' include directory, like https://github.com/bernardassan/Glib/blob/49ef9727f43d41011baa1f3961076a29ebebb515/build/glib/root.zig#L93

Add some more config_h options

Correctly set PCRE2_EXPORT