### PR TITLE
Fix bounds checks for truncated UTF-8 in pattern conversion

### DIFF
--- a/src/pcre2_convert.c
+++ b/src/pcre2_convert.c
@@ -192,6 +192,11 @@ while (plength > 0)
   c = *posix;
 #else
   GETCHARLENTEST(c, posix, clength);
+  if ((PCRE2_SIZE)clength > plength)
+    {
+    *bufflenptr = plength;
+    return PCRE2_ERROR_UTF8_ERR1;
+    }
 #endif
   posix += clength;
   plength -= clength;
@@ -704,6 +709,12 @@ while (pattern < pattern_end)
   char_start = pattern;
   GETCHARINCTEST(c, pattern);
 
+  if (pattern > pattern_end)
+    {
+    *from = pattern_end;
+    return PCRE2_ERROR_UTF8_ERR1;
+    }
+
   if (c == CHAR_RIGHT_SQUARE_BRACKET)
     {
     convert_glob_write(out, c);
@@ -752,12 +763,24 @@ while (pattern < pattern_end)
     char_start = pattern;
     GETCHARINCTEST(c, pattern);
 
+    if (pattern > pattern_end)
+      {
+      *from = pattern_end;
+      return PCRE2_ERROR_UTF8_ERR1;
+      }
+
     if (pattern >= pattern_end) break;
 
     if (escape != 0 && c == escape)
       {
       char_start = pattern;
       GETCHARINCTEST(c, pattern);
+
+      if (pattern > pattern_end)
+        {
+        *from = pattern_end;
+        return PCRE2_ERROR_UTF8_ERR1;
+        }
       }
     else if (c == CHAR_LEFT_SQUARE_BRACKET && *pattern == CHAR_COLON)
       {
@@ -782,6 +805,12 @@ while (pattern < pattern_end)
       {
       char_start = pattern;
       GETCHARINCTEST(c, pattern);
+
+      if (pattern > pattern_end)
+        {
+        *from = pattern_end;
+        return PCRE2_ERROR_UTF8_ERR1;
+        }
 
       if (pattern >= pattern_end) break;
       }


### PR DESCRIPTION
Add bounds validation after GETCHARLENTEST/GETCHARINCTEST in convert_posix() and convert_glob_parse_range() to detect when a multi-byte UTF-8 sequence extends past the end of the pattern buffer. Return PCRE2_ERROR_UTF8_ERR1 when remaining bytes are insufficient for the declared sequence length.

Five call sites are affected: one in convert_posix() (GETCHARLENTEST) and four in convert_glob_parse_range() (GETCHARINCTEST). Without these checks, a truncated UTF-8 lead byte at the end of a pattern causes reads past the buffer boundary when using pcre2_pattern_convert() with PCRE2_CONVERT_UTF.

Found while writing a fuzz harness for pcre2_pattern_convert().