### PR TITLE
Add bounds checks for truncated/malformed UTF-8 in 8-bit mode

### DIFF
--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -732,7 +732,16 @@ for (;;)
     {
     clen = 1;        /* Number of data items in the character */
 #ifdef SUPPORT_UNICODE
-    GETCHARLENTEST(c, ptr, clen);
+    if (utf && UTF8CLENTOOLONG(ptr, end_subject))
+      {
+      clen = 0;
+      c = NOTACHAR;
+      }
+    else
+      {
+      GETCHARLENTEST(c, ptr, clen);
+      if (c > 0x10ffffu) { clen = 0; c = NOTACHAR; }
+      }
 #else
     c = *ptr;
 #endif  /* SUPPORT_UNICODE */
@@ -1104,21 +1113,34 @@ for (;;)
           PCRE2_SPTR temp = ptr - 1;
           if (temp < mb->start_used_ptr) mb->start_used_ptr = temp;
 #if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
-          if (utf) { BACKCHAR(temp); }
-#endif
-          GETCHARTEST(d, temp);
-#ifdef SUPPORT_UNICODE
-          if (codevalue == OP_UCP_WORD_BOUNDARY ||
-              codevalue == OP_NOT_UCP_WORD_BOUNDARY)
+          if (utf)
             {
-            int chartype = UCD_CHARTYPE(d);
-            int category = PRIV(ucp_gentype)[chartype];
-            left_word = (category == ucp_L || category == ucp_N ||
-              chartype == ucp_Mn || chartype == ucp_Pc);
+            while (temp > start_subject && (*temp & 0xc0u) == 0x80u) temp--;
             }
-          else
 #endif
-          left_word = d < 256 && (ctypes[d] & ctype_word) != 0;
+          if (utf && UTF8CLENTOOLONG(temp, end_subject))
+            left_word = FALSE;
+          else
+            {
+            GETCHARTEST(d, temp);
+            if (d > 0x10ffffu)
+              left_word = FALSE;
+            else
+              {
+#ifdef SUPPORT_UNICODE
+              if (codevalue == OP_UCP_WORD_BOUNDARY ||
+                  codevalue == OP_NOT_UCP_WORD_BOUNDARY)
+                {
+                int chartype = UCD_CHARTYPE(d);
+                int category = PRIV(ucp_gentype)[chartype];
+                left_word = (category == ucp_L || category == ucp_N ||
+                  chartype == ucp_Mn || chartype == ucp_Pc);
+                }
+              else
+#endif
+              left_word = d < 256 && (ctypes[d] & ctype_word) != 0;
+              }
+            }
           }
         else left_word = FALSE;
 

--- a/src/pcre2_extuni.c
+++ b/src/pcre2_extuni.c
@@ -94,13 +94,20 @@ PRIV(extuni)(uint32_t c, PCRE2_SPTR eptr, PCRE2_SPTR start_subject,
   PCRE2_SPTR end_subject, BOOL utf, int *xcount)
 {
 BOOL was_ep_ZWJ = FALSE;
-int lgb = UCD_GRAPHBREAK(c);
+int lgb;
+if (c > 0x10ffffu) return eptr;
+lgb = UCD_GRAPHBREAK(c);
 
 while (eptr < end_subject)
   {
   int rgb;
   int len = 1;
-  if (!utf) c = *eptr; else { GETCHARLEN(c, eptr, len); }
+  if (!utf) c = *eptr; else
+    {
+    if (UTF8CLENTOOLONG(eptr, end_subject)) break;
+    GETCHARLEN(c, eptr, len);
+    if (c > 0x10ffffu) break;
+    }
   rgb = UCD_GRAPHBREAK(c);
   if ((PRIV(ucp_gbtable)[lgb] & (1u << rgb)) == 0) break;
 
@@ -126,8 +133,10 @@ while (eptr < end_subject)
       bptr--;
       if (utf)
         {
-        BACKCHAR(bptr);
+        while (bptr > start_subject && (*bptr & 0xc0u) == 0x80u) bptr--;
+        if (UTF8CLENTOOLONG(bptr, end_subject)) break;
         GETCHAR(c, bptr);
+        if (c > 0x10ffffu) break;
         }
       else
       c = *bptr;

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -248,6 +248,14 @@ is not supported. */
 
 #define HASUTF8EXTRALEN(c) ((c) >= 0xc0)
 
+/* Check that a multi-byte UTF-8 character starting at eptr fits within the
+buffer ending at end. Returns TRUE if the sequence is truncated (would read past
+end). The lead byte at *eptr must be >= 0xc0. */
+
+#define UTF8CLENTOOLONG(eptr, end) \
+  (*(eptr) >= 0xc0u && \
+   (eptr) + 1 + PRIV(utf8_table4)[*(eptr) & 0x3fu] > (end))
+
 /* The following macros were originally written in the form of loops that used
 data from the tables whose names start with PRIV(utf8_table). They were
 rewritten by a user so as not to use loops, because in some environments this

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -1180,6 +1180,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       else
         {
         uint32_t dc;
+        if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+          { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
         GETCHARINC(dc, Feptr);
         Fecode += length;
         if (dc != fc && dc != UCD_OTHERCASE(fc)) RRETURN(MATCH_NOMATCH);
@@ -1235,6 +1237,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       uint32_t ch;
       Fecode++;
       GETCHARINC(ch, Fecode);
+      if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+        { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
       GETCHARINC(fc, Feptr);
       if (ch == fc)
         {
@@ -1762,6 +1766,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(d, Feptr);
           if (Lc == d || Loc == d) RRETURN(MATCH_NOMATCH);
           }
@@ -1801,6 +1807,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINC(d, Feptr);
             if (Lc == d || Loc == d) RRETURN(MATCH_NOMATCH);
             }
@@ -1845,6 +1853,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(d, Feptr, len);
             if (Lc == d || Loc == d) break;
             Feptr += len;
@@ -1904,6 +1914,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(d, Feptr);
           if (Lc == d) RRETURN(MATCH_NOMATCH);
           }
@@ -1941,6 +1953,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINC(d, Feptr);
             if (Lc == d) RRETURN(MATCH_NOMATCH);
             }
@@ -1983,6 +1997,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(d, Feptr, len);
             if (Lc == d) break;
             Feptr += len;
@@ -2101,6 +2117,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           if (fc > 255)
             {
@@ -2155,6 +2173,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINC(fc, Feptr);
             if (fc > 255)
               {
@@ -2209,6 +2229,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc > 255)
               {
@@ -2337,6 +2359,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
           SCHECK_PARTIAL();
           RRETURN(MATCH_NOMATCH);
           }
+        if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+          { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
         GETCHARINCTEST(fc, Feptr);
         if (!PRIV(xclass)(fc, Lxclass_data,
             (const uint8_t*)mb->start_code, utf))
@@ -2362,6 +2386,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINCTEST(fc, Feptr);
           if (!PRIV(xclass)(fc, Lxclass_data,
               (const uint8_t*)mb->start_code, utf))
@@ -2384,6 +2410,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             break;
             }
 #ifdef SUPPORT_UNICODE
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); break; }
           GETCHARLENTEST(fc, Feptr, len);
 #else
           fc = *Feptr;
@@ -2480,6 +2508,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
           SCHECK_PARTIAL();
           RRETURN(MATCH_NOMATCH);
           }
+        if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+          { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
         GETCHARINCTEST(fc, Feptr);
         if (!PRIV(eclass)(fc, Leclass_data, Leclass_data + Leclass_len,
                           (const uint8_t*)mb->start_code, utf))
@@ -2505,6 +2535,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINCTEST(fc, Feptr);
           if (!PRIV(eclass)(fc, Leclass_data, Leclass_data + Leclass_len,
                             (const uint8_t*)mb->start_code, utf))
@@ -2527,6 +2559,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             break;
             }
 #ifdef SUPPORT_UNICODE
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); break; }
           GETCHARLENTEST(fc, Feptr, len);
 #else
           fc = *Feptr;
@@ -2577,6 +2611,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     if (CHMAX_255(fc) && (mb->ctypes[fc] & ctype_digit) != 0)
       RRETURN(MATCH_NOMATCH);
@@ -2589,6 +2625,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     if (!CHMAX_255(fc) || (mb->ctypes[fc] & ctype_digit) == 0)
       RRETURN(MATCH_NOMATCH);
@@ -2601,6 +2639,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     if (CHMAX_255(fc) && (mb->ctypes[fc] & ctype_space) != 0)
       RRETURN(MATCH_NOMATCH);
@@ -2613,6 +2653,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     if (!CHMAX_255(fc) || (mb->ctypes[fc] & ctype_space) == 0)
       RRETURN(MATCH_NOMATCH);
@@ -2625,6 +2667,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     if (CHMAX_255(fc) && (mb->ctypes[fc] & ctype_word) != 0)
       RRETURN(MATCH_NOMATCH);
@@ -2637,6 +2681,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     if (!CHMAX_255(fc) || (mb->ctypes[fc] & ctype_word) == 0)
       RRETURN(MATCH_NOMATCH);
@@ -2649,6 +2695,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     switch(fc)
       {
@@ -2684,6 +2732,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     switch(fc)
       {
@@ -2699,6 +2749,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     switch(fc)
       {
@@ -2714,6 +2766,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     switch(fc)
       {
@@ -2729,6 +2783,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
     switch(fc)
       {
@@ -2752,7 +2808,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       SCHECK_PARTIAL();
       RRETURN(MATCH_NOMATCH);
       }
+    if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+      { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
     GETCHARINCTEST(fc, Feptr);
+    if (fc > 0x10ffffu) { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
       {
       const uint32_t *cp;
       uint32_t chartype;
@@ -2894,6 +2953,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       }
     else
       {
+      if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+        { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
       GETCHARINCTEST(fc, Feptr);
       Feptr = PRIV(extuni)(fc, Feptr, mb->start_subject, mb->end_subject, utf,
         NULL);
@@ -3005,7 +3066,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             chartype = UCD_CHARTYPE(fc);
             if ((chartype == ucp_Lu ||
                  chartype == ucp_Ll ||
@@ -3022,7 +3086,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_CATEGORY(fc) == Lpropvalue) == notmatch)
               RRETURN(MATCH_NOMATCH);
             }
@@ -3036,7 +3103,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_CHARTYPE(fc) == Lpropvalue) == notmatch)
               RRETURN(MATCH_NOMATCH);
             }
@@ -3050,7 +3120,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_SCRIPT(fc) == Lpropvalue) == notmatch)
               RRETURN(MATCH_NOMATCH);
             }
@@ -3066,7 +3139,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu) { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             prop = GET_UCD(fc);
             ok = (prop->script == Lpropvalue ||
                   MAPBIT(PRIV(ucd_script_sets) + UCD_SCRIPTX_PROP(prop), Lpropvalue) != 0);
@@ -3084,7 +3160,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             category = UCD_CATEGORY(fc);
             if ((category == ucp_L || category == ucp_N) == notmatch)
               RRETURN(MATCH_NOMATCH);
@@ -3104,7 +3183,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             switch(fc)
               {
               HSPACE_CASES:
@@ -3129,7 +3211,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             chartype = UCD_CHARTYPE(fc);
             category = PRIV(ucp_gentype)[chartype];
             if ((category == ucp_L || category == ucp_N ||
@@ -3147,6 +3232,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
 #if PCRE2_CODE_UNIT_WIDTH == 32
             if (fc > MAX_UTF_CODE_POINT)
@@ -3180,6 +3267,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
             if ((fc == CHAR_DOLLAR_SIGN || fc == CHAR_COMMERCIAL_AT ||
                  fc == CHAR_GRAVE_ACCENT || (fc >= 0xa0 && fc <= 0xd7ff) ||
@@ -3196,7 +3285,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_BIDICLASS(fc) == Lpropvalue) == notmatch)
               RRETURN(MATCH_NOMATCH);
             }
@@ -3212,7 +3304,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu) { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             prop = GET_UCD(fc);
             ok = MAPBIT(PRIV(ucd_boolprop_sets) +
               UCD_BPROPS_PROP(prop), Lpropvalue) != 0;
@@ -3245,6 +3340,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             }
           else
             {
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
             Feptr = PRIV(extuni)(fc, Feptr, mb->start_subject,
               mb->end_subject, utf, NULL);
@@ -3309,6 +3406,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           switch(fc)
             {
@@ -3342,6 +3441,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           switch(fc)
             {
@@ -3359,6 +3460,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           switch(fc)
             {
@@ -3376,6 +3479,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           switch(fc)
             {
@@ -3393,6 +3498,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           switch(fc)
             {
@@ -3410,6 +3517,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           if (fc < 128 && (mb->ctypes[fc] & ctype_digit) != 0)
             RRETURN(MATCH_NOMATCH);
@@ -3792,7 +3901,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             chartype = UCD_CHARTYPE(fc);
             if ((chartype == ucp_Lu ||
                  chartype == ucp_Ll ||
@@ -3812,7 +3924,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_CATEGORY(fc) == Lpropvalue) == (Lctype == OP_NOTPROP))
               RRETURN(MATCH_NOMATCH);
             }
@@ -3829,7 +3944,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_CHARTYPE(fc) == Lpropvalue) == (Lctype == OP_NOTPROP))
               RRETURN(MATCH_NOMATCH);
             }
@@ -3846,7 +3964,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_SCRIPT(fc) == Lpropvalue) == (Lctype == OP_NOTPROP))
               RRETURN(MATCH_NOMATCH);
             }
@@ -3865,7 +3986,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu) { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             prop = GET_UCD(fc);
             ok = (prop->script == Lpropvalue
                   || MAPBIT(PRIV(ucd_script_sets) + UCD_SCRIPTX_PROP(prop), Lpropvalue) != 0);
@@ -3886,7 +4010,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             category = UCD_CATEGORY(fc);
             if ((category == ucp_L || category == ucp_N) == (Lctype == OP_NOTPROP))
               RRETURN(MATCH_NOMATCH);
@@ -3909,7 +4036,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             switch(fc)
               {
               HSPACE_CASES:
@@ -3937,7 +4067,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             chartype = UCD_CHARTYPE(fc);
             category = PRIV(ucp_gentype)[chartype];
             if ((category == ucp_L ||
@@ -3960,6 +4093,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
 #if PCRE2_CODE_UNIT_WIDTH == 32
             if (fc > MAX_UTF_CODE_POINT)
@@ -3996,6 +4131,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
             if ((fc == CHAR_DOLLAR_SIGN || fc == CHAR_COMMERCIAL_AT ||
                  fc == CHAR_GRAVE_ACCENT || (fc >= 0xa0 && fc <= 0xd7ff) ||
@@ -4015,7 +4152,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             if ((UCD_BIDICLASS(fc) == Lpropvalue) == (Lctype == OP_NOTPROP))
               RRETURN(MATCH_NOMATCH);
             }
@@ -4034,7 +4174,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               RRETURN(MATCH_NOMATCH);
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
+            if (fc > 0x10ffffu) { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             prop = GET_UCD(fc);
             ok = MAPBIT(PRIV(ucd_boolprop_sets) +
               UCD_BPROPS_PROP(prop), Lpropvalue) != 0;
@@ -4070,6 +4213,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             }
           else
             {
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHARINCTEST(fc, Feptr);
             Feptr = PRIV(extuni)(fc, Feptr, mb->start_subject, mb->end_subject,
               utf, NULL);
@@ -4096,6 +4241,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             RRETURN(MATCH_NOMATCH);
             }
           if (Lctype == OP_ANY && IS_NEWLINE(Feptr)) RRETURN(MATCH_NOMATCH);
+          if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+            { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
           GETCHARINC(fc, Feptr);
           switch(Lctype)
             {
@@ -4386,7 +4533,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             chartype = UCD_CHARTYPE(fc);
             if ((chartype == ucp_Lu ||
                  chartype == ucp_Ll ||
@@ -4405,7 +4555,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             if ((UCD_CATEGORY(fc) == Lpropvalue) == notmatch) break;
             Feptr+= len;
             }
@@ -4420,7 +4573,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             if ((UCD_CHARTYPE(fc) == Lpropvalue) == notmatch) break;
             Feptr+= len;
             }
@@ -4435,7 +4591,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             if ((UCD_SCRIPT(fc) == Lpropvalue) == notmatch) break;
             Feptr+= len;
             }
@@ -4452,7 +4611,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             prop = GET_UCD(fc);
             ok = (prop->script == Lpropvalue ||
                   MAPBIT(PRIV(ucd_script_sets) + UCD_SCRIPTX_PROP(prop), Lpropvalue) != 0);
@@ -4471,7 +4633,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             category = UCD_CATEGORY(fc);
             if ((category == ucp_L || category == ucp_N) == notmatch)
               break;
@@ -4493,7 +4658,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             switch(fc)
               {
               HSPACE_CASES:
@@ -4521,7 +4689,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             chartype = UCD_CHARTYPE(fc);
             category = PRIV(ucp_gentype)[chartype];
             if ((category == ucp_L ||
@@ -4543,6 +4714,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
 #if PCRE2_CODE_UNIT_WIDTH == 32
             if (fc > MAX_UTF_CODE_POINT)
@@ -4576,6 +4749,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
             if ((fc == CHAR_DOLLAR_SIGN || fc == CHAR_COMMERCIAL_AT ||
                  fc == CHAR_GRAVE_ACCENT || (fc >= 0xa0 && fc <= 0xd7ff) ||
@@ -4594,7 +4769,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             if ((UCD_BIDICLASS(fc) == Lpropvalue) == notmatch) break;
             Feptr+= len;
             }
@@ -4611,7 +4789,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLENTEST(fc, Feptr, len);
+            if (fc > 0x10ffffu) break;
             prop = GET_UCD(fc);
             ok = MAPBIT(PRIV(ucd_boolprop_sets) +
               UCD_BPROPS_PROP(prop), Lpropvalue) != 0;
@@ -4659,6 +4840,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             }
           else
             {
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARINCTEST(fc, Feptr);
             Feptr = PRIV(extuni)(fc, Feptr, mb->start_subject, mb->end_subject,
               utf, NULL);
@@ -4692,7 +4875,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
           if (!utf) fc = *Feptr; else
             {
             BACKCHAR(Feptr);
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             GETCHAR(fc, Feptr);
+            if (fc > 0x10ffffu)              { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
             }
           rgb = UCD_GRAPHBREAK(fc);
 
@@ -4703,7 +4889,9 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
             if (!utf) fc = *fptr; else
               {
               BACKCHAR(fptr);
+              if (UTF8CLENTOOLONG(fptr, mb->end_subject)) break;
               GETCHAR(fc, fptr);
+              if (fc > 0x10ffffu) break;
               }
             lgb = UCD_GRAPHBREAK(fc);
             if ((PRIV(ucp_gbtable)[lgb] & (1u << rgb)) == 0) break;
@@ -4786,6 +4974,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc == CHAR_CR)
               {
@@ -4818,6 +5008,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             switch(fc)
               {
@@ -4840,6 +5032,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             switch(fc)
               {
@@ -4860,6 +5054,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc < 256 && (mb->ctypes[fc] & ctype_digit) != 0) break;
             Feptr+= len;
@@ -4875,6 +5071,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc >= 256 ||(mb->ctypes[fc] & ctype_digit) == 0) break;
             Feptr+= len;
@@ -4890,6 +5088,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc < 256 && (mb->ctypes[fc] & ctype_space) != 0) break;
             Feptr+= len;
@@ -4905,6 +5105,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc >= 256 ||(mb->ctypes[fc] & ctype_space) == 0) break;
             Feptr+= len;
@@ -4920,6 +5122,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc < 256 && (mb->ctypes[fc] & ctype_word) != 0) break;
             Feptr+= len;
@@ -4935,6 +5139,8 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               SCHECK_PARTIAL();
               break;
               }
+            if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+              { SCHECK_PARTIAL(); break; }
             GETCHARLEN(fc, Feptr, len);
             if (fc >= 256 || (mb->ctypes[fc] & ctype_word) == 0) break;
             Feptr+= len;
@@ -6709,8 +6915,14 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
 #ifdef SUPPORT_UNICODE
       if (utf)
         {
-        BACKCHAR(lastptr);
+        while (lastptr > mb->start_subject && (*lastptr & 0xc0u) == 0x80u)
+          lastptr--;
+        if (lastptr < mb->start_subject ||
+            UTF8CLENTOOLONG(lastptr, mb->end_subject))
+          { prev_is_word = FALSE; goto GOT_PREV_WORD; }
         GETCHAR(fc, lastptr);
+        if (fc > 0x10ffffu)
+          { prev_is_word = FALSE; goto GOT_PREV_WORD; }
         }
       else
 #endif  /* SUPPORT_UNICODE */
@@ -6729,6 +6941,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       prev_is_word = CHMAX_255(fc) && (mb->ctypes[fc] & ctype_word) != 0;
       }
 
+    GOT_PREV_WORD:
     /* Get status of next character */
 
     if (Feptr >= mb->end_subject)
@@ -6743,7 +6956,10 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
       if (utf)
         {
         FORWARDCHARTEST(nextptr, mb->end_subject);
+        if (utf && UTF8CLENTOOLONG(Feptr, mb->end_subject))
+          { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
         GETCHAR(fc, Feptr);
+        if (fc > 0x10ffffu)          { SCHECK_PARTIAL(); RRETURN(MATCH_NOMATCH); }
         }
       else
 #endif  /* SUPPORT_UNICODE */

--- a/src/pcre2_script_run.c
+++ b/src/pcre2_script_run.c
@@ -97,7 +97,9 @@ uint32_t c;
 /* Any string containing fewer than 2 characters is a valid script run. */
 
 if (ptr >= endptr) return TRUE;
+if (utf && UTF8CLENTOOLONG(ptr, endptr)) return FALSE;
 GETCHARINCTEST(c, ptr);
+if (c > 0x10ffffu) return FALSE;
 if (ptr >= endptr) return TRUE;
 
 /* Initialize the require map. This is a full-size bitmap that has a bit for
@@ -329,7 +331,9 @@ for (;;)
   /* If we haven't yet got to the end, pick up the next character. */
 
   if (ptr >= endptr) return TRUE;
+  if (utf && UTF8CLENTOOLONG(ptr, endptr)) return FALSE;
   GETCHARINCTEST(c, ptr);
+  if (c > 0x10ffffu) return FALSE;
   }  /* End checking loop */
 
 #else   /* NOT SUPPORT_UNICODE */

--- a/src/pcre2_substitute.c
+++ b/src/pcre2_substitute.c
@@ -510,6 +510,7 @@ switch (state->to_case)
   PCRE2_SPTR ch_end = input;
   uint32_t ch;
 
+  if (utf && UTF8CLENTOOLONG(ch_end, input + input_len)) return 0;
   GETCHARINCTEST(ch, ch_end);
   (void) ch;
   PCRE2_ASSERT(ch_end <= input + input_len && ch_end - input <= 6);
@@ -1620,6 +1621,7 @@ for (;;)
 
       LOADLITERAL:
       ch_start = ptr;
+      if (utf && UTF8CLENTOOLONG(ptr, repend)) goto BAD;
       GETCHARINCTEST(ch, ptr);    /* Get character value, increment pointer */
       (void) ch;
 

--- a/src/pcre2_xclass.c
+++ b/src/pcre2_xclass.c
@@ -93,7 +93,9 @@ encounter XCL_PROP or XCL_NOTPROP when UTF support is not compiled. */
 if (*data == XCL_PROP || *data == XCL_NOTPROP)
   {
   /* The UCD record is the same for all properties. */
-  const ucd_record *prop = GET_UCD(c);
+  const ucd_record *prop;
+  if (c > 0x10ffffu) return !not_negated;
+  prop = GET_UCD(c);
 
   do
     {


### PR DESCRIPTION
When PCRE2_NO_UTF_CHECK is used with pcre2_match, pcre2_dfa_match,
or pcre2_substitute, truncated UTF-8 sequences at the end of the
subject can cause GETCHAR macros to read past the subject buffer.
Malformed sequences within the buffer can also produce codepoint
values above 0x10FFFF, which then index out of bounds in the
Unicode property tables.

This patch adds:

1. A `UTF8CLENTOOLONG` helper macro in pcre2_internal.h that checks
   whether a lead byte's implied sequence length would exceed the
   remaining buffer.

2. Pre-GETCHAR truncation checks using this macro before all subject
   reads in the match engine, DFA engine, script run checker,
   extended grapheme handler, substitute function, and xclass handler.

3. Post-GETCHAR codepoint range checks (c > 0x10FFFF) before
   UCD property table lookups, to guard against malformed sequences
   that assemble garbage codepoints within buffer bounds.

4. Bounded BACKCHAR scans to prevent underflow past the subject
   start when the subject begins with continuation bytes (0x80-0xBF).

Affected files: pcre2_match.c, pcre2_dfa_match.c, pcre2_xclass.c,
pcre2_extuni.c, pcre2_script_run.c, pcre2_substitute.c.