### PR TITLE
Support for direct installation via `zig fetch`

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -634,9 +634,9 @@ jobs:
       (github.event_name == 'workflow_dispatch' && (inputs.job_id == 'all' || inputs.job_id == 'zebrilus')) ||
       github.event_name == 'push'
     steps:
-      - name: Setup
-        run: |
-          sudo snap install zig --classic --beta
+      # The zig version from minimum_zig_version in build.zig.zon will be installed.
+      - name: Install zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ src/stamp-h1
 /bazel-*
 *.bazel.lock
 
+zig-pkg/
 zig-out/
 zig-cache/
 .zig-cache/

--- a/Makefile.am
+++ b/Makefile.am
@@ -294,7 +294,8 @@ EXTRA_DIST += \
 EXTRA_DIST += \
   BUILD.bazel \
   MODULE.bazel \
-  build.zig
+  build.zig \
+  build.zig.zon
 
 # These are support files for building under VMS
 

--- a/README
+++ b/README
@@ -991,6 +991,7 @@ The distribution should contain the files listed below.
   BUILD.bazel             ) files used by the Bazel
   MODULE.bazel            )   build system
   build.zig               file used by zig's build system
+  build.zig.zon           file used by zig's package manager
 
 (G) Auxiliary files for building PCRE2 under OpenVMS
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,11 @@
 .{
     .name = .pcre2,
     .version = "10.48.0-DEV",
-    .fingerprint = 0x914b3d63ebab9e21, // Changing this has security and trust implications.
+
+    // Do NOT change this for new releases.
+    // DO change this if making a fork of PCRE2 which is used by any Zig clients.
+    .fingerprint = 0x914b3d63ebab9e21,
+
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = .pcre2,
+    .version = "10.48.0-DEV",
+    .fingerprint = 0x914b3d63ebab9e21, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.15.2",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",  "build.zig.zon",
+        "src/",       "doc/",
+        "HACKING",    "INSTALL",
+        "README.md",  "LICENCE.md",
+        "AUTHORS.md", "SECURITY.md",
+    },
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,10 +9,11 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},
     .paths = .{
-        "build.zig",  "build.zig.zon",
-        "src/",       "doc/",
-        "HACKING",    "INSTALL",
-        "README.md",  "LICENCE.md",
-        "AUTHORS.md", "SECURITY.md",
+        "build.zig",   "build.zig.zon",
+        "src/",        "doc/",
+        "deps/",       "HACKING",
+        "INSTALL",     "README.md",
+        "LICENCE.md",  "AUTHORS.md",
+        "SECURITY.md",
     },
 }

--- a/doc/html/README.txt
+++ b/doc/html/README.txt
@@ -991,6 +991,7 @@ The distribution should contain the files listed below.
   BUILD.bazel             ) files used by the Bazel
   MODULE.bazel            )   build system
   build.zig               file used by zig's build system
+  build.zig.zon           file used by zig's package manager
 
 (G) Auxiliary files for building PCRE2 under OpenVMS
 

--- a/maint/UpdateAlways
+++ b/maint/UpdateAlways
@@ -240,6 +240,7 @@ txt_files=(
   RunTest
   SECURITY.md
   build.zig
+  build.zig.zon
   configure.ac
   libpcre2-8.pc.in
   libpcre2-16.pc.in

--- a/maint/UpdateRelease.py
+++ b/maint/UpdateRelease.py
@@ -3,10 +3,12 @@
 # Script to update all the hardcoded release numbers in the source tree.
 #  - Documentation manpages.
 #  - Bazel MODULE file.
+#  - Zig package manifest.
 
 # This script should be run in the main PCRE2 directory.
 
 import glob
+import re
 
 from UpdateCommon import update_file, CURRENT_RELEASE
 
@@ -27,3 +29,9 @@ for filename in glob.glob('doc/*.3'):
 # MODULE.bazel
 print('Updating MODULE.bazel')
 update_file('MODULE.bazel', r'(?m)^    version = ".*?"', '    version = "%s"' % CURRENT_RELEASE)
+
+# build.zig.zon
+# Zig requires a semver MAJOR.MINOR.PATCH[-prerelease], so insert .0 as patch.
+print('Updating build.zig.zon')
+ZIG_VERSION = re.sub(r'^(\d+\.\d+)(.*)$', r'\1.0\2', CURRENT_RELEASE)
+update_file('build.zig.zon', r'(?m)^    \.version = ".*?"', '    .version = "%s"' % ZIG_VERSION)

--- a/maint/manifest-tarball
+++ b/maint/manifest-tarball
@@ -22,6 +22,7 @@ drwxr-xr-x tarball-dir/pcre2-SNAPSHOT
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/aclocal.m4
 -rwxr-xr-x tarball-dir/pcre2-SNAPSHOT/ar-lib
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/build.zig
+-rw-r--r-- tarball-dir/pcre2-SNAPSHOT/build.zig.zon
 drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/cmake
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/cmake/COPYING-CMAKE-SCRIPTS
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/cmake/FindEditline.cmake


### PR DESCRIPTION
Modern versions of zig (at least 0.15 and above) support a small package manager. This PR adds a manifest to the root directory and updates the build so that the manifest is included in the release archives.

I also took the liberty of updating the zig installation in CI to a reusable action from one of the zig core team members. This will prevent compiler version desynchronization and allow you to add builds to master versions if you wish. Let me know if this is unacceptable -- I'll return the snap or offer installation in ziglang.org with a small bash script (but with worse caching).

P.S. Thanks for supporting Zig here, it really made my job easier.