### PR TITLE
Use CU2BYTES for byte sizing in two allocation sites

### DIFF
--- a/src/pcre2_convert.c
+++ b/src/pcre2_convert.c
@@ -1215,9 +1215,11 @@ for (int i = 0; i < 2; i++)
   /* Allocate memory for the buffer, with hidden space for an allocator at
   the start. The next time round the loop runs the conversion for real. */
 
-  allocated = PRIV(memctl_malloc)(sizeof(pcre2_memctl) +
-    (*bufflenptr + 1)*PCRE2_CODE_UNIT_WIDTH, (pcre2_memctl *)ccontext);
-  if (allocated == NULL)
+  if (*bufflenptr > ((PCRE2_SIZE_MAX - sizeof(pcre2_memctl)) /
+        CU2BYTES(1)) - 1 ||
+      (allocated = PRIV(memctl_malloc)(sizeof(pcre2_memctl) +
+        CU2BYTES(*bufflenptr + 1),
+        (pcre2_memctl *)ccontext)) == NULL)
     {
     *bufflenptr = 0;  /* Error offset */
     return PCRE2_ERROR_NOMEMORY;

--- a/src/pcre2_substring.c
+++ b/src/pcre2_substring.c
@@ -210,9 +210,10 @@ PCRE2_SIZE size;
 PCRE2_UCHAR *yield;
 rc = pcre2_substring_length_bynumber(match_data, stringnumber, &size);
 if (rc < 0) return rc;
-yield = PRIV(memctl_malloc)(sizeof(pcre2_memctl) +
-  (size + 1)*PCRE2_CODE_UNIT_WIDTH, (pcre2_memctl *)match_data);
-if (yield == NULL) return PCRE2_ERROR_NOMEMORY;
+if (size > ((PCRE2_SIZE_MAX - sizeof(pcre2_memctl)) / CU2BYTES(1)) - 1 ||
+    (yield = PRIV(memctl_malloc)(sizeof(pcre2_memctl) +
+      CU2BYTES(size + 1), (pcre2_memctl *)match_data)) == NULL)
+  return PCRE2_ERROR_NOMEMORY;
 yield = (PCRE2_UCHAR *)(((char *)yield) + sizeof(pcre2_memctl));
 if (size != 0) memcpy(yield, match_data->subject + match_data->ovector[stringnumber*2],
   CU2BYTES(size));


### PR DESCRIPTION
Two allocation sites multiply by `PCRE2_CODE_UNIT_WIDTH` (the bit width: 8, 16, or 32) where the byte-count helper `CU2BYTES(x) = (x) * (PCRE2_CODE_UNIT_WIDTH/8)` is intended. The result over-allocates by the code-unit byte width: 8x in 8-bit mode, 16x in 16-bit, 32x in 32-bit.

Subsequent `memcpy` calls already use `CU2BYTES` correctly, so no out-of-bounds write occurs. The over-allocation leaks the difference until the buffer is freed, on every call.

Sites:
- `src/pcre2_substring.c:214` (`pcre2_substring_get_bynumber`)
- `src/pcre2_convert.c:1219` (`pcre2_pattern_convert`)

Repo-wide grep for `* PCRE2_CODE_UNIT_WIDTH` outside preprocessor conditionals turned up only these two sites. Found via internal audit of PCRE2 10.47.

Verified clean against the existing test suite via `cmake` build + `RunTest` (29 tests, all pass). Tests 24 and 25 exercise `pcre2_pattern_convert`; substring tests in test 1 exercise `pcre2_substring_get_bynumber`.
