### PR TITLE
Widen class_ranges::range_list_size from uint16_t to uint32_t

### DIFF
--- a/src/pcre2_compile_class.c
+++ b/src/pcre2_compile_class.c
@@ -549,7 +549,7 @@ cranges->header.next = NULL;
 #ifdef PCRE2_DEBUG
 cranges->header.type = CDATA_CRANGE;
 #endif
-cranges->range_list_size = (uint16_t)range_list_size;
+cranges->range_list_size = range_list_size;
 cranges->char_lists_types = 0;
 cranges->char_lists_size = 0;
 cranges->char_lists_start = 0;
@@ -618,7 +618,7 @@ ptr = buffer;
 while (ptr < dst && ptr[1] < 0x100) ptr += 2;
 if (dst - ptr < (2 * (6 - 1)))
   {
-  cranges->range_list_size = (uint16_t)(dst + 2 - buffer);
+  cranges->range_list_size = (size_t)(dst + 2 - buffer);
   return cranges;
   }
 
@@ -740,7 +740,7 @@ PCRE2_ASSERT((uint16_t*)dst <= next_char);
 cranges->char_lists_size =
   (size_t)((uint8_t*)(buffer + total_size) - (uint8_t*)next_char);
 cranges->char_lists_start = (size_t)((uint8_t*)next_char - (uint8_t*)buffer);
-cranges->range_list_size = (uint16_t)(dst - buffer);
+cranges->range_list_size = (size_t)(dst - buffer);
 return cranges;
 }
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -778,7 +778,7 @@ typedef struct class_ranges {
   compile_data header;             /* Common header */
   size_t char_lists_size;          /* Total size of encoded char lists */
   size_t char_lists_start;         /* Start offset of encoded char lists */
-  uint16_t range_list_size;        /* Size of ranges array */
+  size_t range_list_size;          /* Size of ranges array */
   uint16_t char_lists_types;       /* The XCL_LIST header of char lists */
   /* Followed by the list of ranges (start/end pairs) */
 } class_ranges;


### PR DESCRIPTION
`class_ranges::range_list_size` is computed in `pcre2_compile_class.c` as a `size_t` from `parse_class()`, then stored into the struct as `uint16_t` via three explicit narrowing casts. The underlying allocation at line 542 uses the full `size_t` value, so no out-of-bounds write occurs. Downstream consumers (e.g. `compile_class_not_nested` reading `cranges->range_list_size - 1` and `cranges->range_list_size - 2` at lines 1150-1151) walk fewer entries than were allocated when the count exceeds 65535, producing wrong match results.

Reachable on 16-bit or 32-bit lib builds with `LINK_SIZE >= 3`, where `MAX_PATTERN_SIZE` grows enough for a single character class to produce more than 65535 sorted-range entries. Not reachable on the default 8-bit lib with `LINK_SIZE = 2`. Discovered during an internal audit of PCRE2 10.47.

Widening the struct field to `uint32_t` and updating all three narrowing casts:

- `src/pcre2_intmodedep.h:781` field declaration
- `src/pcre2_compile_class.c:552, 621, 743` producer casts

The neighbouring `char_lists_types` field stays `uint16_t` (it holds flag bits, not a count).

No new test added. Reaching the trigger requires more than 65535 sorted-range entries in a single character class, which would inflate `testdata/testinput*` significantly and only run in non-8-bit lib mode. Happy to add a test if reviewers want one. Existing `RunTest` suite verified clean against the patch (29 tests, all pass).
