### PR TITLE
Fix setting STR_END in JIT

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -12520,6 +12520,8 @@ else if (SLJIT_UNLIKELY(opcode == OP_ASSERT_SCS))
   if (common->restore_end_ptr == 0)
     common->restore_end_ptr = private_data_ptr + sizeof(sljit_sw);
   }
+else if (SLJIT_UNLIKELY(opcode == OP_ASSERTBACK_NA) && PRIVATE_DATA(ccbegin + 1))
+  OP1(SLJIT_MOV, STR_END, 0, SLJIT_MEM1(SLJIT_SP), private_data_ptr);
 
 if (SLJIT_UNLIKELY(opcode == OP_ONCE))
   {

--- a/src/pcre2_jit_test.c
+++ b/src/pcre2_jit_test.c
@@ -657,6 +657,7 @@ static struct regression_test_case regression_test_cases[] = {
 	{ MU, A, 0, 0 | F_NOMATCH, "a(?!)b", "ab" },
 	{ MU, A, 0, 0, "(?(?<!|(|a)))", "a" },
 	{ MU, A, 0, 0, "(?=((?|(a)(.)|(b)(..)|(c)(...)))(?1(2,3))).x", "b12c123bx2c123" },
+	{ MU, A, 0, 3, "(?<*(.).{,2})\\1", "BABA" },
 
 	/* Not empty, ACCEPT, FAIL */
 	{ MU, A, PCRE2_NOTEMPTY, 0 | F_NOMATCH, "a*", "bcx" },


### PR DESCRIPTION
When OP_VREVERSE is present in a non-atomic LOOKBEHIND ASSERTION, the STR_END must be set before the backtracking path is executed.