### PR TITLE
alpha: Add JIT support

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -642,6 +642,11 @@ jobs:
           # cross compilers do not depend on the target's libc headers, and it
           # cannot always be derived from the triple.
           #
+          # Alpha's libc package is libc6.1-dev-alpha-cross, because Alpha uses
+          # libc6.1 rather than libc6, but it provides the libc6-dev-alpha-cross
+          # name built from the "libc" field. Only gcc-14 is packaged for it.
+          - { name: alpha,       triple: alpha-linux-gnu,             qemu: alpha,       libc: alpha,      container: "ubuntu:26.04", gcc_suffix: "-14" }
+          #
           # Ubuntu armhf defaults to Thumb-2, so ARM mode needs asking for.
           - { name: arm,         triple: arm-linux-gnueabihf,         qemu: arm,         libc: armhf,      container: "ubuntu:26.04", cflags: -marm }
           - { name: arm-thumb2,  triple: arm-linux-gnueabihf,         qemu: arm,         libc: armhf,      container: "ubuntu:26.04", cflags: -mthumb }
@@ -675,7 +680,7 @@ jobs:
         run: |
           apt-get -qq update
           apt-get -qq install -y git autoconf automake libtool make \
-                                 gcc-${{ matrix.config.triple }} \
+                                 gcc${{ matrix.config.gcc_suffix }}-${{ matrix.config.triple }} \
                                  libc6-dev-${{ matrix.config.libc }}-cross \
                                  qemu-user
 
@@ -703,7 +708,7 @@ jobs:
           ./configure \
             --build=`./config.guess` \
             --host=${{ matrix.config.triple }} \
-            CC=${{ matrix.config.triple }}-gcc \
+            CC=${{ matrix.config.triple }}-gcc${{ matrix.config.gcc_suffix }} \
             CFLAGS="${{ matrix.config.cflags }} $CFLAGS_GCC_STYLE" \
             --disable-shared \
             --enable-jit \

--- a/Makefile.am
+++ b/Makefile.am
@@ -530,6 +530,7 @@ EXTRA_DIST += \
   deps/sljit/sljit_src/sljitConfigInternal.h \
   deps/sljit/sljit_src/sljitLir.c \
   deps/sljit/sljit_src/sljitLir.h \
+  deps/sljit/sljit_src/sljitNativeALPHA_64.c \
   deps/sljit/sljit_src/sljitNativeARM_32.c \
   deps/sljit/sljit_src/sljitNativeARM_64.c \
   deps/sljit/sljit_src/sljitNativeARM_T2_32.c \

--- a/doc/html/pcre2jit.html
+++ b/doc/html/pcre2jit.html
@@ -54,6 +54,7 @@ platforms:
 <pre>
   ARM 32-bit (v7, and Thumb2)
   ARM 64-bit
+  DEC Alpha 64-bit
   IBM s390x 64 bit
   Intel x86 32-bit and 64-bit
   LoongArch 64 bit

--- a/doc/pcre2jit.3
+++ b/doc/pcre2jit.3
@@ -29,6 +29,7 @@ platforms:
 .sp
   ARM 32-bit (v7, and Thumb2)
   ARM 64-bit
+  DEC Alpha 64-bit
   IBM s390x 64 bit
   Intel x86 32-bit and 64-bit
   LoongArch 64 bit

--- a/maint/manifest-tarball
+++ b/maint/manifest-tarball
@@ -58,6 +58,7 @@ drwxr-xr-x tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/allocator_src
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/sljitConfigInternal.h
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/sljitLir.c
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/sljitLir.h
+-rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/sljitNativeALPHA_64.c
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/sljitNativeARM_32.c
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/sljitNativeARM_64.c
 -rw-r--r-- tarball-dir/pcre2-SNAPSHOT/deps/sljit/sljit_src/sljitNativeARM_T2_32.c

--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -607,6 +607,15 @@ typedef struct compare_context {
 #define ARGUMENTS     SLJIT_S4
 #define RETURN_ADDR   SLJIT_R4
 
+/* Number of scratch registers the generated code may use. The Alpha CMPBGE
+   scanning loops keep up to five replicated character constants live across a
+   loop, so they use scratch registers above RETURN_ADDR and must declare them. */
+#if (defined SLJIT_CONFIG_ALPHA && SLJIT_CONFIG_ALPHA)
+#define SCRATCH_REGISTERS 10
+#else
+#define SCRATCH_REGISTERS 5
+#endif
+
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
 #define HAS_VIRTUAL_REGISTERS 1
 #else
@@ -13789,7 +13798,7 @@ common->compiler = compiler;
 
 /* Main pcre2_jit_exec entry. */
 SLJIT_ASSERT((private_data_size & (sizeof(sljit_sw) - 1)) == 0);
-sljit_emit_enter(compiler, 0, SLJIT_ARGS1(W, W), 5 | SLJIT_ENTER_VECTOR(SLJIT_NUMBER_OF_SCRATCH_VECTOR_REGISTERS), 5, private_data_size);
+sljit_emit_enter(compiler, 0, SLJIT_ARGS1(W, W), SCRATCH_REGISTERS | SLJIT_ENTER_VECTOR(SLJIT_NUMBER_OF_SCRATCH_VECTOR_REGISTERS), 5, private_data_size);
 
 /* Register init. */
 reset_ovector(common, (re->top_bracket + 1) * 2);

--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -609,7 +609,9 @@ typedef struct compare_context {
 
 /* Number of scratch registers the generated code may use. The Alpha CMPBGE
    scanning loops keep up to five replicated character constants live across a
-   loop, so they use scratch registers above RETURN_ADDR and must declare them. */
+   loop, so they use scratch registers above RETURN_ADDR and must declare them.
+   Registers above SLJIT_NUMBER_OF_TEMPORARY_REGISTERS are callee-saved, so
+   every JIT function pays to spill them: keep this as small as it can be. */
 #if (defined SLJIT_CONFIG_ALPHA && SLJIT_CONFIG_ALPHA)
 #define SCRATCH_REGISTERS 10
 #else
@@ -6977,6 +6979,16 @@ if (common->match_end_ptr != 0)
   OP2U(SLJIT_SUB | SLJIT_SET_GREATER, STR_END, 0, TMP1, 0);
   SELECT(SLJIT_GREATER, STR_END, TMP1, 0, STR_END);
   }
+
+#ifdef JIT_HAS_FAST_FORWARD_START_BITS_SIMD
+if (JIT_HAS_FAST_FORWARD_START_BITS_SIMD && common->mode == PCRE2_JIT_COMPLETE
+    && fast_forward_start_bits_simd(common, start_bits))
+  {
+  if (common->match_end_ptr != 0)
+    OP1(SLJIT_MOV, STR_END, 0, RETURN_ADDR, 0);
+  return;
+  }
+#endif
 
 start = LABEL();
 

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -2668,6 +2668,63 @@ partial_quit[0] = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0);
 if (common->mode == PCRE2_JIT_COMPLETE)
   add_jump(compiler, &common->failed_match, partial_quit[0]);
 
+#if PCRE2_CODE_UNIT_WIDTH == 8
+if (compare_type == vector_compare_match1)
+  {
+  /* Use memchr() for exact single-character scanning. glibc's Alpha memchr
+     uses CMPBGE with prefetching and software pipelining. */
+
+  /* The call clobbers every scratch register, so TMP3 must be preserved: the
+     callers keep the unclamped STR_END there while match_end_ptr is set. */
+  OP1(SLJIT_MOV, SLJIT_MEM1(SLJIT_SP), LOCAL0, TMP3, 0);
+
+#if defined SUPPORT_UNICODE
+  restart = LABEL();
+#endif
+
+  /* STR_PTR is SLJIT_R1, which is also the second argument register, so the
+     length and the start pointer must be read before it is overwritten. */
+  OP2(SLJIT_SUB, SLJIT_R2, 0, STR_END, 0, STR_PTR, 0);
+  OP1(SLJIT_MOV, SLJIT_R0, 0, STR_PTR, 0);
+  OP1(SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, char1);
+  sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS3(W, W, 32, W),
+    SLJIT_IMM, SLJIT_FUNC_ADDR(memchr));
+  OP1(SLJIT_MOV, TMP3, 0, SLJIT_MEM1(SLJIT_SP), LOCAL0);
+
+  if (common->mode == PCRE2_JIT_COMPLETE)
+    {
+    add_jump(compiler, &common->failed_match,
+      CMP(SLJIT_EQUAL, SLJIT_RETURN_REG, 0, SLJIT_IMM, 0));
+    OP1(SLJIT_MOV, STR_PTR, 0, SLJIT_RETURN_REG, 0);
+
+#if defined SUPPORT_UNICODE
+    if (common->utf && offset > 0)
+      {
+      OP1(MOV_UCHAR, TMP1, 0, SLJIT_MEM1(STR_PTR), IN_UCHARS(-offset));
+      quit = jump_if_utf_char_start(compiler, TMP1);
+      OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(1));
+      add_jump(compiler, &common->failed_match,
+        CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+      JUMPTO(SLJIT_JUMP, restart);
+      JUMPHERE(quit);
+      }
+#endif
+    }
+  else
+    {
+    /* Partial mode: found → STR_PTR = result, not found → STR_PTR = STR_END. */
+    quit = CMP(SLJIT_EQUAL, SLJIT_RETURN_REG, 0, SLJIT_IMM, 0);
+    OP1(SLJIT_MOV, STR_PTR, 0, SLJIT_RETURN_REG, 0);
+    partial_quit[1] = JUMP(SLJIT_JUMP);
+    JUMPHERE(quit);
+    JUMPHERE(partial_quit[0]);
+    OP1(SLJIT_MOV, STR_PTR, 0, STR_END, 0);
+    JUMPHERE(partial_quit[1]);
+    }
+  return;
+  }
+#endif
+
 /* Load replicated character constants into dedicated registers. */
 OP1(SLJIT_MOV, SLJIT_R5, 0, SLJIT_IMM, replicate_char_alpha(char1 | bit));
 
@@ -2786,6 +2843,25 @@ if (char1 != char2)
   }
 
 add_jump(compiler, &not_found, CMP(SLJIT_GREATER_EQUAL, TMP1, 0, STR_END, 0));
+
+#if PCRE2_CODE_UNIT_WIDTH == 8
+if (compare_type == vector_compare_match1)
+  {
+  /* Use memchr() to check if the required character exists.
+     Save STR_PTR across the icall since it clobbers all scratch registers. */
+  OP1(SLJIT_MOV, SLJIT_MEM1(SLJIT_SP), LOCAL0, STR_PTR, 0);
+  OP1(SLJIT_MOV, SLJIT_R0, 0, TMP1, 0);
+  OP1(SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, char1);
+  OP2(SLJIT_SUB, SLJIT_R2, 0, STR_END, 0, TMP1, 0);
+  sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS3(W, W, 32, W),
+    SLJIT_IMM, SLJIT_FUNC_ADDR(memchr));
+  OP1(SLJIT_MOV, STR_PTR, 0, SLJIT_MEM1(SLJIT_SP), LOCAL0);
+  add_jump(compiler, &not_found,
+    CMP(SLJIT_EQUAL, SLJIT_RETURN_REG, 0, SLJIT_IMM, 0));
+  return not_found;
+  }
+#endif
+
 OP1(SLJIT_MOV, TMP2, 0, TMP1, 0);
 OP1(SLJIT_MOV, TMP3, 0, STR_PTR, 0);
 

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -2646,6 +2646,7 @@ struct sljit_label *restart;
 #endif
 struct sljit_jump *quit;
 struct sljit_jump *partial_quit[2];
+struct sljit_jump *no_prefetch;
 vector_compare_type compare_type = vector_compare_match1;
 sljit_u32 bit = 0;
 
@@ -2699,6 +2700,9 @@ quit = CMP(SLJIT_NOT_ZERO, TMP1, 0, SLJIT_IMM, 0);
 
 OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
 
+/* Prefetch threshold: only prefetch when more than 192 bytes remain. */
+OP2(SLJIT_SUB, TMP2, 0, STR_END, 0, SLJIT_IMM, 192);
+
 /* Main loop (aligned). */
 start = LABEL();
 
@@ -2707,6 +2711,10 @@ OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, 8);
 partial_quit[1] = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0);
 if (common->mode == PCRE2_JIT_COMPLETE)
   add_jump(compiler, &common->failed_match, partial_quit[1]);
+
+no_prefetch = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, TMP2, 0);
+OP_SRC(SLJIT_PREFETCH_L1, SLJIT_MEM1(STR_PTR), 192);
+JUMPHERE(no_prefetch);
 
 OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), 0);
 fast_forward_char_pair_alpha_compare(compiler, compare_type, TMP1, TMP1, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
@@ -2760,6 +2768,7 @@ static jump_list *fast_requested_char_simd(compiler_common *common, PCRE2_UCHAR 
 DEFINE_COMPILER;
 struct sljit_label *start;
 struct sljit_jump *quit;
+struct sljit_jump *no_prefetch;
 jump_list *not_found = NULL;
 vector_compare_type compare_type = vector_compare_match1;
 sljit_u32 bit = 0;
@@ -2804,12 +2813,19 @@ quit = CMP(SLJIT_NOT_ZERO, TMP1, 0, SLJIT_IMM, 0);
 
 OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
 
+/* Prefetch threshold: only prefetch when more than 192 bytes remain. */
+OP2(SLJIT_SUB, TMP2, 0, STR_END, 0, SLJIT_IMM, 192);
+
 /* Main loop. */
 start = LABEL();
 
 OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, 8);
 
 add_jump(compiler, &not_found, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+no_prefetch = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, TMP2, 0);
+OP_SRC(SLJIT_PREFETCH_L1, SLJIT_MEM1(STR_PTR), 192);
+JUMPHERE(no_prefetch);
 
 OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), 0);
 fast_forward_char_pair_alpha_compare(compiler, compare_type, TMP1, TMP1, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
@@ -2847,6 +2863,7 @@ struct sljit_label *start;
 struct sljit_label *restart;
 #endif
 struct sljit_jump *jump[2];
+struct sljit_jump *no_prefetch;
 
 SLJIT_ASSERT(common->mode == PCRE2_JIT_COMPLETE && offs1 > offs2);
 SLJIT_ASSERT(diff <= (unsigned)IN_UCHARS(max_fast_forward_char_pair_offset()));
@@ -2954,11 +2971,18 @@ jump[0] = CMP(SLJIT_NOT_ZERO, TMP1, 0, SLJIT_IMM, 0);
 
 OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
 
+/* Prefetch threshold: only prefetch when more than 192 bytes remain. */
+OP2(SLJIT_SUB, TMP2, 0, STR_END, 0, SLJIT_IMM, 192);
+
 /* Main loop. */
 start = LABEL();
 
 OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, 8);
 add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+no_prefetch = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, TMP2, 0);
+OP_SRC(SLJIT_PREFETCH_L1, SLJIT_MEM1(STR_PTR), 192);
+JUMPHERE(no_prefetch);
 
 /* Load data1 and construct unaligned data2. */
 OP1(SLJIT_MOV, SLJIT_R9, 0, SLJIT_MEM1(STR_PTR), 0);

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -44,7 +44,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #if ((defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86) \
      || (defined SLJIT_CONFIG_ARM_64 && SLJIT_CONFIG_ARM_64) \
      || (defined SLJIT_CONFIG_S390X && SLJIT_CONFIG_S390X) \
-     || (defined SLJIT_CONFIG_LOONGARCH_64 && SLJIT_CONFIG_LOONGARCH_64))
+     || (defined SLJIT_CONFIG_LOONGARCH_64 && SLJIT_CONFIG_LOONGARCH_64) \
+     || (defined SLJIT_CONFIG_ALPHA && SLJIT_CONFIG_ALPHA))
 
 typedef enum {
   vector_compare_match1,
@@ -71,7 +72,20 @@ return 3;
 #error "Unsupported unit width"
 #endif
 }
-#else /* !SLJIT_CONFIG_X86 */
+#elif (defined SLJIT_CONFIG_ALPHA && SLJIT_CONFIG_ALPHA)
+static SLJIT_INLINE sljit_s32 max_fast_forward_char_pair_offset(void)
+{
+#if PCRE2_CODE_UNIT_WIDTH == 8
+return 7;
+#elif PCRE2_CODE_UNIT_WIDTH == 16
+return 3;
+#elif PCRE2_CODE_UNIT_WIDTH == 32
+return 1;
+#else
+#error "Unsupported unit width"
+#endif
+}
+#else /* !SLJIT_CONFIG_X86, !SLJIT_CONFIG_ALPHA */
 static SLJIT_INLINE sljit_s32 max_fast_forward_char_pair_offset(void)
 {
 #if PCRE2_CODE_UNIT_WIDTH == 8
@@ -101,7 +115,7 @@ return CMP(SLJIT_NOT_EQUAL, reg, 0, SLJIT_IMM, 0xdc00);
 }
 #endif
 
-#endif /* SLJIT_CONFIG_X86 || SLJIT_CONFIG_ARM_64 || SLJIT_CONFIG_S390X || SLJIT_CONFIG_LOONGARCH_64 */
+#endif /* SLJIT_CONFIG_X86 || SLJIT_CONFIG_ARM_64 || SLJIT_CONFIG_S390X || SLJIT_CONFIG_LOONGARCH_64 || SLJIT_CONFIG_ALPHA */
 
 #if (defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86)
 
@@ -2502,5 +2516,498 @@ if (common->match_end_ptr != 0)
 }
 
 #endif /* SLJIT_CONFIG_LOONGARCH_64 */
+
+#if (defined SLJIT_CONFIG_ALPHA && SLJIT_CONFIG_ALPHA)
+
+/* Alpha CMPBGE-based pseudo-SIMD: 8-byte-at-a-time character scanning in GPRs.
+   Works on all Alpha CPUs; no CIX extension required. */
+
+/* Replicate a code unit to fill all positions in a 64-bit register.
+   Computed at JIT compile time and emitted as an immediate load. */
+static SLJIT_INLINE sljit_sw replicate_char_alpha(PCRE2_UCHAR c)
+{
+sljit_uw r = c;
+#if PCRE2_CODE_UNIT_WIDTH == 8
+r |= r << 8;
+r |= r << 16;
+r |= r << 32;
+#elif PCRE2_CODE_UNIT_WIDTH == 16
+r |= r << 16;
+r |= r << 32;
+#else /* 32 */
+r |= r << 32;
+#endif
+return (sljit_sw)r;
+}
+
+/* Emit CMPBGE Ra, Rb, Rc: for each byte i, bit i of Rc is set if
+   byte i of Ra >= byte i of Rb. Uses hardware register indices. */
+static SLJIT_INLINE void emit_alpha_cmpbge(struct sljit_compiler *compiler,
+  sljit_s32 ra_ind, sljit_s32 rb_ind, sljit_s32 rc_ind)
+{
+sljit_ins ins = CMPBGE | ((sljit_ins)ra_ind << 21) | ((sljit_ins)rb_ind << 16) | (sljit_ins)rc_ind;
+sljit_emit_op_custom(compiler, &ins, sizeof(ins));
+}
+
+/* Compare helper: produces CMPBGE byte-match mask in dst (a GPR).
+   For match1:  mask = cmpbge(0, data ^ cmp1)
+   For match1i: mask = cmpbge(0, (data | cmp2) ^ cmp1)
+   For match2:  mask = cmpbge(0, data ^ cmp1) | cmpbge(0, data ^ cmp2)
+
+   data may alias dst for match1/match1i.
+   For match2, data must NOT alias tmp (tmp is clobbered). */
+static void fast_forward_char_pair_alpha_compare(struct sljit_compiler *compiler,
+  vector_compare_type compare_type, sljit_s32 dst, sljit_s32 data,
+  sljit_s32 cmp1, sljit_s32 cmp2, sljit_s32 tmp)
+{
+sljit_s32 dst_ind = sljit_get_register_index(SLJIT_GP_REGISTER, dst);
+sljit_s32 tmp_ind;
+
+if (compare_type != vector_compare_match2)
+  {
+  if (compare_type == vector_compare_match1i)
+    {
+    OP2(SLJIT_OR, dst, 0, data, 0, cmp2, 0);
+    OP2(SLJIT_XOR, dst, 0, dst, 0, cmp1, 0);
+    }
+  else
+    OP2(SLJIT_XOR, dst, 0, data, 0, cmp1, 0);
+
+  /* CMPBGE $31, dst, dst — bits set where XOR byte is zero (match). */
+  emit_alpha_cmpbge(compiler, 31, dst_ind, dst_ind);
+  return;
+  }
+
+/* match2: compare against both chars, OR the masks. */
+tmp_ind = sljit_get_register_index(SLJIT_GP_REGISTER, tmp);
+
+OP2(SLJIT_XOR, tmp, 0, data, 0, cmp2, 0);
+emit_alpha_cmpbge(compiler, 31, tmp_ind, tmp_ind);
+
+OP2(SLJIT_XOR, dst, 0, data, 0, cmp1, 0);
+emit_alpha_cmpbge(compiler, 31, dst_ind, dst_ind);
+
+OP2(SLJIT_OR, dst, 0, dst, 0, tmp, 0);
+}
+
+#if PCRE2_CODE_UNIT_WIDTH != 8
+/* For 16/32-bit code units, CMPBGE produces per-byte bits but we need
+   per-code-unit matching. Compact the mask so only positions where ALL
+   bytes of a code unit matched remain set. */
+static SLJIT_INLINE void compact_cmpbge_mask(struct sljit_compiler *compiler,
+  sljit_s32 mask, sljit_s32 tmp)
+{
+#if PCRE2_CODE_UNIT_WIDTH == 16
+OP2(SLJIT_LSHR, tmp, 0, mask, 0, SLJIT_IMM, 1);
+OP2(SLJIT_AND, mask, 0, mask, 0, tmp, 0);
+OP2(SLJIT_AND, mask, 0, mask, 0, SLJIT_IMM, 0x55);
+#else /* 32 */
+OP2(SLJIT_LSHR, tmp, 0, mask, 0, SLJIT_IMM, 1);
+OP2(SLJIT_AND, mask, 0, mask, 0, tmp, 0);
+OP2(SLJIT_LSHR, tmp, 0, mask, 0, SLJIT_IMM, 2);
+OP2(SLJIT_AND, mask, 0, mask, 0, tmp, 0);
+OP2(SLJIT_AND, mask, 0, mask, 0, SLJIT_IMM, 0x11);
+#endif
+}
+#endif
+
+/* Find the position of the lowest set bit in an 8-bit CMPBGE mask held in
+   TMP1; replace TMP1 with that bit index (0-7). TMP2 and RETURN_ADDR are
+   clobbered. Uses base-ISA NEGQ+AND to isolate the bit, then a binary search
+   via three AND+SELECT pairs — identical to glibc's Alpha strchr approach. */
+static SLJIT_INLINE void emit_alpha_ctz8(struct sljit_compiler *compiler)
+{
+OP2(SLJIT_SUB, TMP2, 0, SLJIT_IMM, 0, TMP1, 0);       /* TMP2 = -TMP1          */
+OP2(SLJIT_AND, TMP1, 0, TMP1, 0, TMP2, 0);              /* TMP1 = lowest set bit */
+
+OP1(SLJIT_MOV, TMP2, 0, SLJIT_IMM, 0);
+OP2U(SLJIT_AND | SLJIT_SET_Z, TMP1, 0, SLJIT_IMM, 0xf0);
+SELECT(SLJIT_NOT_ZERO, TMP2, SLJIT_IMM, 4, TMP2);       /* TMP2 = 4 or 0         */
+
+OP1(SLJIT_MOV, RETURN_ADDR, 0, SLJIT_IMM, 0);
+OP2U(SLJIT_AND | SLJIT_SET_Z, TMP1, 0, SLJIT_IMM, 0xcc);
+SELECT(SLJIT_NOT_ZERO, RETURN_ADDR, SLJIT_IMM, 2, RETURN_ADDR);  /* RA = 2 or 0  */
+OP2(SLJIT_ADD, TMP2, 0, TMP2, 0, RETURN_ADDR, 0);
+
+OP1(SLJIT_MOV, RETURN_ADDR, 0, SLJIT_IMM, 0);
+OP2U(SLJIT_AND | SLJIT_SET_Z, TMP1, 0, SLJIT_IMM, 0xaa);
+SELECT(SLJIT_NOT_ZERO, RETURN_ADDR, SLJIT_IMM, 1, RETURN_ADDR);  /* RA = 1 or 0  */
+OP2(SLJIT_ADD, TMP1, 0, TMP2, 0, RETURN_ADDR, 0);
+}
+
+#define JIT_HAS_FAST_FORWARD_CHAR_SIMD 1
+
+static void fast_forward_char_simd(compiler_common *common, PCRE2_UCHAR char1, PCRE2_UCHAR char2, sljit_s32 offset)
+{
+DEFINE_COMPILER;
+struct sljit_label *start;
+#if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
+struct sljit_label *restart;
+#endif
+struct sljit_jump *quit;
+struct sljit_jump *partial_quit[2];
+vector_compare_type compare_type = vector_compare_match1;
+sljit_u32 bit = 0;
+
+SLJIT_UNUSED_ARG(offset);
+
+if (char1 != char2)
+  {
+  bit = char1 ^ char2;
+  compare_type = vector_compare_match1i;
+
+  if (!is_powerof2(bit))
+    {
+    bit = 0;
+    compare_type = vector_compare_match2;
+    }
+  }
+
+partial_quit[0] = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0);
+if (common->mode == PCRE2_JIT_COMPLETE)
+  add_jump(compiler, &common->failed_match, partial_quit[0]);
+
+/* Load replicated character constants into dedicated registers. */
+OP1(SLJIT_MOV, SLJIT_R5, 0, SLJIT_IMM, replicate_char_alpha(char1 | bit));
+
+if (char1 != char2)
+  OP1(SLJIT_MOV, SLJIT_R6, 0, SLJIT_IMM, replicate_char_alpha(bit != 0 ? bit : char2));
+
+OP1(SLJIT_MOV, TMP2, 0, STR_PTR, 0);
+
+#if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
+restart = LABEL();
+#endif
+
+/* Align STR_PTR down to 8-byte boundary; save misalignment in TMP2. */
+OP2(SLJIT_AND, TMP2, 0, TMP2, 0, SLJIT_IMM, 0x7);
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+/* Load 8 aligned bytes, compare, produce CMPBGE mask. */
+OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), 0);
+fast_forward_char_pair_alpha_compare(compiler, compare_type, TMP1, TMP1, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
+
+#if PCRE2_CODE_UNIT_WIDTH != 8
+compact_cmpbge_mask(compiler, TMP1, RETURN_ADDR);
+#endif
+
+/* Restore STR_PTR, shift mask to ignore bytes before original position. */
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+OP2(SLJIT_LSHR, TMP1, 0, TMP1, 0, TMP2, 0);
+
+quit = CMP(SLJIT_NOT_ZERO, TMP1, 0, SLJIT_IMM, 0);
+
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+/* Main loop (aligned). */
+start = LABEL();
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, 8);
+
+partial_quit[1] = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0);
+if (common->mode == PCRE2_JIT_COMPLETE)
+  add_jump(compiler, &common->failed_match, partial_quit[1]);
+
+OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), 0);
+fast_forward_char_pair_alpha_compare(compiler, compare_type, TMP1, TMP1, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
+
+#if PCRE2_CODE_UNIT_WIDTH != 8
+compact_cmpbge_mask(compiler, TMP1, RETURN_ADDR);
+#endif
+
+CMPTO(SLJIT_ZERO, TMP1, 0, SLJIT_IMM, 0, start);
+
+JUMPHERE(quit);
+
+/* Find position of first match. */
+emit_alpha_ctz8(compiler);
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP1, 0);
+
+if (common->mode != PCRE2_JIT_COMPLETE)
+  {
+  JUMPHERE(partial_quit[0]);
+  JUMPHERE(partial_quit[1]);
+  OP2U(SLJIT_SUB | SLJIT_SET_GREATER, STR_PTR, 0, STR_END, 0);
+  SELECT(SLJIT_GREATER, STR_PTR, STR_END, 0, STR_PTR);
+  }
+else
+  add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+#if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
+if (common->utf && offset > 0)
+  {
+  SLJIT_ASSERT(common->mode == PCRE2_JIT_COMPLETE);
+
+  OP1(MOV_UCHAR, TMP1, 0, SLJIT_MEM1(STR_PTR), IN_UCHARS(-offset));
+
+  quit = jump_if_utf_char_start(compiler, TMP1);
+
+  OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(1));
+  add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+  OP1(SLJIT_MOV, TMP2, 0, STR_PTR, 0);
+  JUMPTO(SLJIT_JUMP, restart);
+
+  JUMPHERE(quit);
+  }
+#endif
+}
+
+#define JIT_HAS_FAST_REQUESTED_CHAR_SIMD 1
+
+static jump_list *fast_requested_char_simd(compiler_common *common, PCRE2_UCHAR char1, PCRE2_UCHAR char2)
+{
+DEFINE_COMPILER;
+struct sljit_label *start;
+struct sljit_jump *quit;
+jump_list *not_found = NULL;
+vector_compare_type compare_type = vector_compare_match1;
+sljit_u32 bit = 0;
+
+if (char1 != char2)
+  {
+  bit = char1 ^ char2;
+  compare_type = vector_compare_match1i;
+
+  if (!is_powerof2(bit))
+    {
+    bit = 0;
+    compare_type = vector_compare_match2;
+    }
+  }
+
+add_jump(compiler, &not_found, CMP(SLJIT_GREATER_EQUAL, TMP1, 0, STR_END, 0));
+OP1(SLJIT_MOV, TMP2, 0, TMP1, 0);
+OP1(SLJIT_MOV, TMP3, 0, STR_PTR, 0);
+
+/* Load replicated character constants. */
+OP1(SLJIT_MOV, SLJIT_R5, 0, SLJIT_IMM, replicate_char_alpha(char1 | bit));
+
+if (char1 != char2)
+  OP1(SLJIT_MOV, SLJIT_R6, 0, SLJIT_IMM, replicate_char_alpha(bit != 0 ? bit : char2));
+
+OP1(SLJIT_MOV, STR_PTR, 0, TMP2, 0);
+OP2(SLJIT_AND, TMP2, 0, TMP2, 0, SLJIT_IMM, 0x7);
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), 0);
+fast_forward_char_pair_alpha_compare(compiler, compare_type, TMP1, TMP1, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
+
+#if PCRE2_CODE_UNIT_WIDTH != 8
+compact_cmpbge_mask(compiler, TMP1, RETURN_ADDR);
+#endif
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+OP2(SLJIT_LSHR, TMP1, 0, TMP1, 0, TMP2, 0);
+
+quit = CMP(SLJIT_NOT_ZERO, TMP1, 0, SLJIT_IMM, 0);
+
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+/* Main loop. */
+start = LABEL();
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, 8);
+
+add_jump(compiler, &not_found, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), 0);
+fast_forward_char_pair_alpha_compare(compiler, compare_type, TMP1, TMP1, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
+
+#if PCRE2_CODE_UNIT_WIDTH != 8
+compact_cmpbge_mask(compiler, TMP1, RETURN_ADDR);
+#endif
+
+CMPTO(SLJIT_ZERO, TMP1, 0, SLJIT_IMM, 0, start);
+
+JUMPHERE(quit);
+
+emit_alpha_ctz8(compiler);
+
+OP2(SLJIT_ADD, TMP1, 0, TMP1, 0, STR_PTR, 0);
+add_jump(compiler, &not_found, CMP(SLJIT_GREATER_EQUAL, TMP1, 0, STR_END, 0));
+
+OP1(SLJIT_MOV, STR_PTR, 0, TMP3, 0);
+return not_found;
+}
+
+#define JIT_HAS_FAST_FORWARD_CHAR_PAIR_SIMD 1
+
+static void fast_forward_char_pair_simd(compiler_common *common, sljit_s32 offs1,
+  PCRE2_UCHAR char1a, PCRE2_UCHAR char1b, sljit_s32 offs2, PCRE2_UCHAR char2a, PCRE2_UCHAR char2b)
+{
+DEFINE_COMPILER;
+vector_compare_type compare1_type = vector_compare_match1;
+vector_compare_type compare2_type = vector_compare_match1;
+sljit_u32 bit1 = 0;
+sljit_u32 bit2 = 0;
+sljit_u32 diff = IN_UCHARS(offs1 - offs2);
+struct sljit_label *start;
+#if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
+struct sljit_label *restart;
+#endif
+struct sljit_jump *jump[2];
+
+SLJIT_ASSERT(common->mode == PCRE2_JIT_COMPLETE && offs1 > offs2);
+SLJIT_ASSERT(diff <= (unsigned)IN_UCHARS(max_fast_forward_char_pair_offset()));
+
+/* Initialize. */
+if (common->match_end_ptr != 0)
+  {
+  OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(SLJIT_SP), common->match_end_ptr);
+  OP2(SLJIT_ADD, TMP1, 0, TMP1, 0, SLJIT_IMM, IN_UCHARS(offs1 + 1));
+  OP1(SLJIT_MOV, TMP3, 0, STR_END, 0);
+
+  OP2U(SLJIT_SUB | SLJIT_SET_LESS, TMP1, 0, STR_END, 0);
+  SELECT(SLJIT_LESS, STR_END, TMP1, 0, STR_END);
+  }
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(offs1));
+add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+/* Set up replicated character constants. */
+if (char1a == char1b)
+  OP1(SLJIT_MOV, SLJIT_R5, 0, SLJIT_IMM, replicate_char_alpha(char1a));
+else
+  {
+  bit1 = char1a ^ char1b;
+  if (is_powerof2(bit1))
+    {
+    compare1_type = vector_compare_match1i;
+    OP1(SLJIT_MOV, SLJIT_R5, 0, SLJIT_IMM, replicate_char_alpha(char1a | bit1));
+    OP1(SLJIT_MOV, SLJIT_R6, 0, SLJIT_IMM, replicate_char_alpha(bit1));
+    }
+  else
+    {
+    compare1_type = vector_compare_match2;
+    bit1 = 0;
+    OP1(SLJIT_MOV, SLJIT_R5, 0, SLJIT_IMM, replicate_char_alpha(char1a));
+    OP1(SLJIT_MOV, SLJIT_R6, 0, SLJIT_IMM, replicate_char_alpha(char1b));
+    }
+  }
+
+if (char2a == char2b)
+  OP1(SLJIT_MOV, SLJIT_R7, 0, SLJIT_IMM, replicate_char_alpha(char2a));
+else
+  {
+  bit2 = char2a ^ char2b;
+  if (is_powerof2(bit2))
+    {
+    compare2_type = vector_compare_match1i;
+    OP1(SLJIT_MOV, SLJIT_R7, 0, SLJIT_IMM, replicate_char_alpha(char2a | bit2));
+    OP1(SLJIT_MOV, SLJIT_R8, 0, SLJIT_IMM, replicate_char_alpha(bit2));
+    }
+  else
+    {
+    compare2_type = vector_compare_match2;
+    bit2 = 0;
+    OP1(SLJIT_MOV, SLJIT_R7, 0, SLJIT_IMM, replicate_char_alpha(char2a));
+    OP1(SLJIT_MOV, SLJIT_R8, 0, SLJIT_IMM, replicate_char_alpha(char2b));
+    }
+  }
+
+#if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
+restart = LABEL();
+#endif
+
+OP2(SLJIT_SUB, TMP1, 0, STR_PTR, 0, SLJIT_IMM, diff);
+OP1(SLJIT_MOV, TMP2, 0, STR_PTR, 0);
+OP2(SLJIT_AND, TMP2, 0, TMP2, 0, SLJIT_IMM, 0x7);
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+/* Load data1 (for char1 comparison). */
+OP1(SLJIT_MOV, SLJIT_R9, 0, SLJIT_MEM1(STR_PTR), 0);
+
+/* Construct data2 (for char2 comparison). If the second load address
+   falls before our aligned load, synthesize data2 by shifting data1
+   left, filling the low bytes with zeros (they will be masked off by
+   the alignment shift and never produce false matches). */
+jump[0] = CMP(SLJIT_GREATER_EQUAL, TMP1, 0, STR_PTR, 0);
+
+OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), -8);
+OP2(SLJIT_LSHR, TMP1, 0, TMP1, 0, SLJIT_IMM, (8 - diff) * 8);
+OP2(SLJIT_SHL, RETURN_ADDR, 0, SLJIT_R9, 0, SLJIT_IMM, diff * 8);
+OP2(SLJIT_OR, TMP1, 0, TMP1, 0, RETURN_ADDR, 0);
+jump[1] = JUMP(SLJIT_JUMP);
+
+JUMPHERE(jump[0]);
+
+OP2(SLJIT_SHL, TMP1, 0, SLJIT_R9, 0, SLJIT_IMM, diff * 8);
+
+JUMPHERE(jump[1]);
+
+/* Compare both data words. */
+fast_forward_char_pair_alpha_compare(compiler, compare2_type, TMP1, TMP1, SLJIT_R7, SLJIT_R8, RETURN_ADDR);
+fast_forward_char_pair_alpha_compare(compiler, compare1_type, SLJIT_R9, SLJIT_R9, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
+
+OP2(SLJIT_AND, TMP1, 0, TMP1, 0, SLJIT_R9, 0);
+
+#if PCRE2_CODE_UNIT_WIDTH != 8
+compact_cmpbge_mask(compiler, TMP1, RETURN_ADDR);
+#endif
+
+/* Ignore matches before the original STR_PTR. */
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+OP2(SLJIT_LSHR, TMP1, 0, TMP1, 0, TMP2, 0);
+
+jump[0] = CMP(SLJIT_NOT_ZERO, TMP1, 0, SLJIT_IMM, 0);
+
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+/* Main loop. */
+start = LABEL();
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, 8);
+add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+/* Load data1 and construct unaligned data2. */
+OP1(SLJIT_MOV, SLJIT_R9, 0, SLJIT_MEM1(STR_PTR), 0);
+OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), -8);
+OP2(SLJIT_LSHR, TMP1, 0, TMP1, 0, SLJIT_IMM, (8 - diff) * 8);
+OP2(SLJIT_SHL, RETURN_ADDR, 0, SLJIT_R9, 0, SLJIT_IMM, diff * 8);
+OP2(SLJIT_OR, TMP1, 0, TMP1, 0, RETURN_ADDR, 0);
+
+fast_forward_char_pair_alpha_compare(compiler, compare1_type, SLJIT_R9, SLJIT_R9, SLJIT_R5, SLJIT_R6, RETURN_ADDR);
+fast_forward_char_pair_alpha_compare(compiler, compare2_type, TMP1, TMP1, SLJIT_R7, SLJIT_R8, RETURN_ADDR);
+
+OP2(SLJIT_AND, TMP1, 0, TMP1, 0, SLJIT_R9, 0);
+
+#if PCRE2_CODE_UNIT_WIDTH != 8
+compact_cmpbge_mask(compiler, TMP1, RETURN_ADDR);
+#endif
+
+CMPTO(SLJIT_ZERO, TMP1, 0, SLJIT_IMM, 0, start);
+
+JUMPHERE(jump[0]);
+
+emit_alpha_ctz8(compiler);
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP1, 0);
+
+add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+#if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
+if (common->utf)
+  {
+  OP1(MOV_UCHAR, TMP1, 0, SLJIT_MEM1(STR_PTR), IN_UCHARS(-offs1));
+
+  jump[0] = jump_if_utf_char_start(compiler, TMP1);
+
+  OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(1));
+  CMPTO(SLJIT_LESS, STR_PTR, 0, STR_END, 0, restart);
+
+  add_jump(compiler, &common->failed_match, JUMP(SLJIT_JUMP));
+
+  JUMPHERE(jump[0]);
+  }
+#endif
+
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(offs1));
+
+if (common->match_end_ptr != 0)
+  OP1(SLJIT_MOV, STR_END, 0, TMP3, 0);
+}
+
+#endif /* SLJIT_CONFIG_ALPHA */
 
 #endif /* !SUPPORT_VALGRIND */

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -3108,6 +3108,209 @@ if (common->match_end_ptr != 0)
   OP1(SLJIT_MOV, STR_END, 0, TMP3, 0);
 }
 
+#if PCRE2_CODE_UNIT_WIDTH == 8
+
+#define JIT_HAS_FAST_FORWARD_START_BITS_SIMD 1
+
+/* Number of replicated constants the start-bits scanning loop can keep live in
+   scratch registers. A range costs two of them, one per bound; a single
+   character costs one; and a range that reaches 0 or 255 costs one, because
+   that bound needs no test. Bitmaps that need more fall back to the
+   byte-at-a-time bitmap scan.
+
+   Three is what fits alongside the accumulated mask and the per-range mask
+   without raising SCRATCH_REGISTERS, and raising it is not free: the registers
+   above RETURN_ADDR are callee-saved, so widening the budget would add a spill
+   and a reload to the prologue of every JIT function, whether it scans a
+   character class or not. */
+#define ALPHA_START_BITS_MAX_CONSTS 3
+
+/* Emit the CMPBGE match mask for one range into dst, reloading the data word
+   into TMP1 first. Bits 0-7 of dst end up set for the bytes of the word that
+   fall inside [low, high]. TMP1 is clobbered. */
+static void emit_alpha_class_range(struct sljit_compiler *compiler,
+  sljit_s32 dst, sljit_u32 low, sljit_u32 high, sljit_s32 low_reg, sljit_s32 high_reg)
+{
+sljit_s32 dst_ind = sljit_get_register_index(SLJIT_GP_REGISTER, dst);
+sljit_s32 tmp1_ind = sljit_get_register_index(SLJIT_GP_REGISTER, TMP1);
+
+OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(STR_PTR), 0);
+
+if (low == high)
+  {
+  /* Single character: bits set where the XOR leaves a zero byte. */
+  OP2(SLJIT_XOR, TMP1, 0, TMP1, 0, low_reg, 0);
+  emit_alpha_cmpbge(compiler, 31, tmp1_ind, dst_ind);
+  return;
+  }
+
+if (high == 255)
+  {
+  /* No upper bound to test. */
+  emit_alpha_cmpbge(compiler, tmp1_ind, sljit_get_register_index(SLJIT_GP_REGISTER, low_reg), dst_ind);
+  return;
+  }
+
+if (low == 0)
+  {
+  /* No lower bound to test; complement "greater than high" within 8 bits. */
+  emit_alpha_cmpbge(compiler, tmp1_ind, sljit_get_register_index(SLJIT_GP_REGISTER, high_reg), dst_ind);
+  OP2(SLJIT_XOR, dst, 0, dst, 0, SLJIT_IMM, 0xff);
+  return;
+  }
+
+/* Both bounds: (byte >= low) & ~(byte >= high + 1). */
+emit_alpha_cmpbge(compiler, tmp1_ind, sljit_get_register_index(SLJIT_GP_REGISTER, low_reg), dst_ind);
+emit_alpha_cmpbge(compiler, tmp1_ind, sljit_get_register_index(SLJIT_GP_REGISTER, high_reg), tmp1_ind);
+OP2(SLJIT_XOR, TMP1, 0, TMP1, 0, SLJIT_IMM, 0xff);
+OP2(SLJIT_AND, dst, 0, dst, 0, TMP1, 0);
+}
+
+/* Scan for the first code unit whose start bit is set, eight bytes at a time.
+   Returns FALSE without emitting anything if the bitmap does not reduce to few
+   enough ranges, in which case the caller emits its own scan. */
+static BOOL fast_forward_start_bits_simd(compiler_common *common, const sljit_u8 *start_bits)
+{
+DEFINE_COMPILER;
+struct sljit_label *start;
+struct sljit_jump *quit;
+struct sljit_jump *no_prefetch;
+sljit_u32 low[ALPHA_START_BITS_MAX_CONSTS];
+sljit_u32 high[ALPHA_START_BITS_MAX_CONSTS];
+sljit_s32 low_reg[ALPHA_START_BITS_MAX_CONSTS];
+sljit_s32 high_reg[ALPHA_START_BITS_MAX_CONSTS];
+sljit_s32 acc, mask_reg;
+int count = 0;
+int consts = 0;
+int next = 5;
+int i, k;
+
+/* Split the bitmap into inclusive ranges, costing the constants as we go. */
+i = 0;
+while (i < 256)
+  {
+  if ((start_bits[i >> 3] & (1 << (i & 0x7))) == 0)
+    {
+    i++;
+    continue;
+    }
+
+  if (count >= ALPHA_START_BITS_MAX_CONSTS)
+    return FALSE;
+
+  low[count] = (sljit_u32)i;
+  while (i < 256 && (start_bits[i >> 3] & (1 << (i & 0x7))) != 0)
+    i++;
+  high[count] = (sljit_u32)(i - 1);
+
+  if (low[count] == high[count] || low[count] == 0 || high[count] == 255)
+    consts += 1;
+  else
+    consts += 2;
+
+  if (consts > ALPHA_START_BITS_MAX_CONSTS)
+    return FALSE;
+  count++;
+  }
+
+/* Nothing to match, or everything matches: leave both to the scalar path. */
+if (count == 0 || (count == 1 && low[0] == 0 && high[0] == 255))
+  return FALSE;
+
+/* Assign a scratch register to each constant, then one for the accumulated
+   mask and one for the per-range mask. RETURN_ADDR is not available: the
+   caller keeps the unclamped STR_END there while match_end_ptr is set. */
+for (k = 0; k < count; k++)
+  {
+  low_reg[k] = 0;
+  high_reg[k] = 0;
+
+  if (low[k] == high[k])
+    low_reg[k] = SLJIT_R(next++);
+  else
+    {
+    if (low[k] != 0)
+      low_reg[k] = SLJIT_R(next++);
+    if (high[k] != 255)
+      high_reg[k] = SLJIT_R(next++);
+    }
+  }
+
+acc = SLJIT_R(next);
+mask_reg = (count > 1) ? SLJIT_R(next + 1) : acc;
+
+for (k = 0; k < count; k++)
+  {
+  if (low_reg[k] != 0)
+    OP1(SLJIT_MOV, low_reg[k], 0, SLJIT_IMM, replicate_char_alpha((PCRE2_UCHAR)low[k]));
+  if (high_reg[k] != 0)
+    OP1(SLJIT_MOV, high_reg[k], 0, SLJIT_IMM, replicate_char_alpha((PCRE2_UCHAR)(high[k] + 1)));
+  }
+
+/* Align STR_PTR down to an 8-byte boundary; keep the misalignment in TMP2. */
+OP1(SLJIT_MOV, TMP2, 0, STR_PTR, 0);
+OP2(SLJIT_AND, TMP2, 0, TMP2, 0, SLJIT_IMM, 0x7);
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+emit_alpha_class_range(compiler, acc, low[0], high[0], low_reg[0], high_reg[0]);
+for (k = 1; k < count; k++)
+  {
+  emit_alpha_class_range(compiler, mask_reg, low[k], high[k], low_reg[k], high_reg[k]);
+  OP2(SLJIT_OR, acc, 0, acc, 0, mask_reg, 0);
+  }
+
+/* Restore STR_PTR and drop the bits for bytes before the starting position. */
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+OP2(SLJIT_LSHR, acc, 0, acc, 0, TMP2, 0);
+
+quit = CMP(SLJIT_NOT_ZERO, acc, 0, SLJIT_IMM, 0);
+
+OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, TMP2, 0);
+
+/* Prefetch threshold: only prefetch while more than 192 bytes remain. */
+OP2(SLJIT_SUB, TMP2, 0, STR_END, 0, SLJIT_IMM, 192);
+
+start = LABEL();
+
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, 8);
+
+add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+no_prefetch = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, TMP2, 0);
+OP_SRC(SLJIT_PREFETCH_L1, SLJIT_MEM1(STR_PTR), 192);
+JUMPHERE(no_prefetch);
+
+emit_alpha_class_range(compiler, acc, low[0], high[0], low_reg[0], high_reg[0]);
+for (k = 1; k < count; k++)
+  {
+  emit_alpha_class_range(compiler, mask_reg, low[k], high[k], low_reg[k], high_reg[k]);
+  OP2(SLJIT_OR, acc, 0, acc, 0, mask_reg, 0);
+  }
+
+CMPTO(SLJIT_ZERO, acc, 0, SLJIT_IMM, 0, start);
+
+JUMPHERE(quit);
+
+/* Both paths arrive with the mask in acc and STR_PTR at the byte that bit 0
+   of the mask describes. The constants are dead from here on, so R5 is free to
+   borrow: emit_alpha_ctz8() clobbers RETURN_ADDR, which is where the caller
+   keeps the unclamped STR_END while match_end_ptr is set. */
+if (common->match_end_ptr != 0)
+  OP1(SLJIT_MOV, SLJIT_R5, 0, RETURN_ADDR, 0);
+
+OP1(SLJIT_MOV, TMP1, 0, acc, 0);
+emit_alpha_ctz8(compiler);
+OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP1, 0);
+
+if (common->match_end_ptr != 0)
+  OP1(SLJIT_MOV, RETURN_ADDR, 0, SLJIT_R5, 0);
+
+add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+return TRUE;
+}
+
+#endif /* PCRE2_CODE_UNIT_WIDTH == 8 */
+
 #endif /* SLJIT_CONFIG_ALPHA */
 
 #endif /* !SUPPORT_VALGRIND */


### PR DESCRIPTION
Add JIT compiler support for DEC Alpha (AXP) 64-bit, in four commits:

Base
  - Document and package the backend: add sljit Alpha sources to EXTRA_DIST, update the JIT-supported-platforms list. The deps/sljit submodule bump is deferred until the sljit backend is merged upstream.

CMPBGE scanning:
  - Implement `fast_forward_char_simd`, `fast_requested_char_simd`, and `fast_forward_char_pair_simd` using the Alpha `CMPBGE` instruction for 8-byte-at-a-time character scanning, analogous to the SIMD paths on other architectures. The first-match step uses a base-ISA binary search (NEGQ+AND to isolate the lowest set bit, then three AND+SELECT pairs), identical to glibc's Alpha strchr.

memchr:
  - For exact single-character 8-bit scanning, call glibc's `memchr()` instead of the inline CMPBGE loop. glibc's Alpha memchr uses CMPBGE with 3-cache-line prefetching, alignment, and software pipelining that the JIT cannot easily replicate.

Prefetching:
  - Emit `PREFETCH_L1` (LDL R31) 192 bytes ahead in all three CMPBGE scanning loops. Guarded against short haystacks. Unconditional prefetch caused a ~15% regression on inputs shorter than 192 bytes.

Validated on a real HP AlphaServer ES47 (1 GHz EV7): `pcre2_jit_test passes` all tests in 8/16/32-bit modes; RunTest passes with and without JIT.

The last two commits could be dropped from this PR and considered separately, if desired.

Requires https://github.com/zherczeg/sljit/pull/364