### PR TITLE
Fix: Fetch SLJIT through the zig package manager for JIT builds

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -634,14 +634,14 @@ jobs:
       (github.event_name == 'workflow_dispatch' && (inputs.job_id == 'all' || inputs.job_id == 'zebrilus')) ||
       github.event_name == 'push'
     steps:
-      # The zig version from minimum_zig_version in build.zig.zon will be installed.
-      - name: Install zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: true
+          submodules: false
+
+      # The zig version from minimum_zig_version in build.zig.zon will be installed.
+      - name: Install zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
 
       - name: Build
         run: zig build -Dsupport_jit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -37,6 +37,10 @@ jobs:
            startsWith(github.ref, 'refs/tags/pcre2-'))
         run: maint/UpdateDates.py
 
+      # The zig version from minimum_zig_version in build.zig.zon will be installed.
+      - name: Install zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+
       - name: UpdateAlways
         run: maint/UpdateAlways
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,16 +30,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
+      # The zig version from minimum_zig_version in build.zig.zon will be installed.
+      - name: Install zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+
       - name: UpdateDates
         if: |
           github.event_name != 'pull_request' &&
           (startsWith(github.ref, 'refs/heads/release/') ||
            startsWith(github.ref, 'refs/tags/pcre2-'))
         run: maint/UpdateDates.py
-
-      # The zig version from minimum_zig_version in build.zig.zon will be installed.
-      - name: Install zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
 
       - name: UpdateAlways
         run: maint/UpdateAlways

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,24 @@ pub fn build(b: *std.Build) !void {
     const codeUnitWidth = b.option(CodeUnitWidth, "code-unit-width", "Sets the code unit width") orelse .@"8";
     const jit = b.option(bool, "support_jit", "Enable/disable JIT compiler support") orelse false;
 
+    const jit_source = if (jit) blk: {
+        const sljit = b.lazyDependency("sljit", .{}) orelse
+            return error.MissingDependency;
+
+        const files = b.addWriteFiles();
+
+        _ = files.addCopyDirectory(
+            sljit.path("sljit_src"),
+            "deps/sljit/sljit_src",
+            .{},
+        );
+
+        break :blk files.addCopyFile(
+            b.path("src/pcre2_jit_compile.c"),
+            "src/pcre2_jit_compile.c",
+        );
+    } else b.path("src/pcre2_jit_compile.c");
+
     const pcre2_h_dir = b.addWriteFiles();
     const pcre2_h = pcre2_h_dir.addCopyFile(b.path("src/pcre2.h.generic"), "pcre2.h");
     b.addNamedLazyPath("pcre2.h", pcre2_h);
@@ -118,7 +136,6 @@ pub fn build(b: *std.Build) !void {
             "src/pcre2_error.c",
             "src/pcre2_extuni.c",
             "src/pcre2_find_bracket.c",
-            "src/pcre2_jit_compile.c",
             "src/pcre2_maketables.c",
             "src/pcre2_match.c",
             "src/pcre2_match_data.c",
@@ -137,6 +154,11 @@ pub fn build(b: *std.Build) !void {
             "src/pcre2_valid_utf.c",
             "src/pcre2_xclass.c",
         },
+        .flags = cflags,
+    });
+
+    lib_mod.addCSourceFile(.{
+        .file = jit_source,
         .flags = cflags,
     });
 

--- a/build.zig
+++ b/build.zig
@@ -14,25 +14,41 @@ pub fn build(b: *std.Build) !void {
     const linkage = b.option(std.builtin.LinkMode, "linkage", "whether to statically or dynamically link the library") orelse @as(std.builtin.LinkMode, if (rt.isGnuLibC()) .dynamic else .static);
     const sanitize_c = b.option(std.zig.SanitizeC, "sanitize_c", "whether to build with undefined behaviour sanitizer enabled") orelse .off;
     const codeUnitWidth = b.option(CodeUnitWidth, "code-unit-width", "Sets the code unit width") orelse .@"8";
-    const jit = b.option(bool, "support_jit", "Enable/disable JIT compiler support") orelse false;
+    const support_jit = b.option(bool, "support_jit", "Enable/disable JIT compiler support") orelse false;
 
-    const jit_source = if (jit) blk: {
+    const sljit_is_checked_out = if (!support_jit)
+        false
+    else if (b.build_root.handle.access(
+        b.graph.io,
+        "deps/sljit/sljit_src/sljitLir.c",
+        .{},
+    )) |_| true else |err| switch (err) {
+        error.FileNotFound => false,
+        else => return err,
+    };
+
+    // We don't know how the sljit dependency is being provided. Either it
+    // comes via a git submodule, or it may be fetched by zig itself.
+    const sljit_include_path = if (!support_jit)
+        null
+    else if (sljit_is_checked_out)
+        null
+    else blk: {
         const sljit = b.lazyDependency("sljit", .{}) orelse
-            return error.MissingDependency;
+            break :blk null;
 
         const files = b.addWriteFiles();
 
+        // Recreate the layout used by pcre2_jit_compile.c's relative include.
         _ = files.addCopyDirectory(
             sljit.path("sljit_src"),
             "deps/sljit/sljit_src",
             .{},
         );
+        _ = files.add("src/.empty", "");
 
-        break :blk files.addCopyFile(
-            b.path("src/pcre2_jit_compile.c"),
-            "src/pcre2_jit_compile.c",
-        );
-    } else b.path("src/pcre2_jit_compile.c");
+        break :blk files.getDirectory().path(b, "src");
+    };
 
     const pcre2_h_dir = b.addWriteFiles();
     const pcre2_h = pcre2_h_dir.addCopyFile(b.path("src/pcre2.h.generic"), "pcre2.h");
@@ -81,7 +97,7 @@ pub fn build(b: *std.Build) !void {
             .SUPPORT_PCRE2_16 = codeUnitWidth == .@"16",
             .SUPPORT_PCRE2_32 = codeUnitWidth == .@"32",
             .SUPPORT_UNICODE = true,
-            .SUPPORT_JIT = jit,
+            .SUPPORT_JIT = support_jit,
 
             // As for CMake builds, use visibilty attributes for both shared and static
             // builds. Internal symbols should be hidden even in static builds, because
@@ -117,6 +133,9 @@ pub fn build(b: *std.Build) !void {
     lib_mod.addConfigHeader(config_h);
     lib_mod.addIncludePath(pcre2_h_dir.getDirectory());
     lib_mod.addIncludePath(b.path("src"));
+    if (sljit_include_path) |include_path| {
+        lib_mod.addIncludePath(include_path);
+    }
 
     lib_mod.addCSourceFile(.{
         .file = b.addWriteFiles().addCopyFile(b.path("src/pcre2_chartables.c.dist"), "pcre2_chartables.c"),
@@ -136,6 +155,7 @@ pub fn build(b: *std.Build) !void {
             "src/pcre2_error.c",
             "src/pcre2_extuni.c",
             "src/pcre2_find_bracket.c",
+            "src/pcre2_jit_compile.c",
             "src/pcre2_maketables.c",
             "src/pcre2_match.c",
             "src/pcre2_match_data.c",
@@ -154,11 +174,6 @@ pub fn build(b: *std.Build) !void {
             "src/pcre2_valid_utf.c",
             "src/pcre2_xclass.c",
         },
-        .flags = cflags,
-    });
-
-    lib_mod.addCSourceFile(.{
-        .file = jit_source,
         .flags = cflags,
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,7 +7,12 @@
     .fingerprint = 0x914b3d63ebab9e21,
 
     .minimum_zig_version = "0.15.2",
-    .dependencies = .{},
+    .dependencies = .{
+        .sljit = .{
+            .url = "git+https://github.com/zherczeg/sljit.git#45f910b78c6605ebf5b53d3ec7cb00f2312fe417",
+            .hash = "N-V-__8AAIUFRABdZku3bW_1S5GOC4iaFh17LsRurEDR1lvv",
+        },
+    },
     .paths = .{
         "build.zig",   "build.zig.zon",
         "src/",        "doc/",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,11 +6,12 @@
     // DO change this if making a fork of PCRE2 which is used by any Zig clients.
     .fingerprint = 0x914b3d63ebab9e21,
 
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .sljit = .{
             .url = "git+https://github.com/zherczeg/sljit.git#45f910b78c6605ebf5b53d3ec7cb00f2312fe417",
             .hash = "N-V-__8AAIUFRABdZku3bW_1S5GOC4iaFh17LsRurEDR1lvv",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/maint/UpdateAlways
+++ b/maint/UpdateAlways
@@ -332,6 +332,15 @@ perl maint/CheckTxt "${txt_files[@]}"
 perl maint/CheckTxt -ascii "${c_files[@]}"
 perl maint/CheckTxt -crlf "${crlf_files[@]}"
 
+SLJIT_COMMIT=`git ls-tree HEAD deps/sljit | awk '{print $3}'`
+if [ -z "$SLJIT_COMMIT" ] ; then
+  echo "Warning: could not find deps/sljit in the tree; not updating build.zig.zon"
+elif ! grep -q "sljit.git#$SLJIT_COMMIT" build.zig.zon ; then
+  echo "Updating SLJIT pin in build.zig.zon to $SLJIT_COMMIT"
+  zig fetch --save=sljit "git+https://github.com/zherczeg/sljit.git#$SLJIT_COMMIT"
+  if [ $? != 0 ] ; then exit 1; fi
+fi
+
 # Verify the version number in the Bazel file
 if ! grep -E "version = \"$CURRENT_RELEASE\"" MODULE.bazel >/dev/null ; then
   echo "Version number in MODULE.bazel does not match current release"

--- a/maint/UpdateAlways
+++ b/maint/UpdateAlways
@@ -332,10 +332,14 @@ perl maint/CheckTxt "${txt_files[@]}"
 perl maint/CheckTxt -ascii "${c_files[@]}"
 perl maint/CheckTxt -crlf "${crlf_files[@]}"
 
-SLJIT_COMMIT=`git ls-tree HEAD deps/sljit | awk '{print $3}'`
+SLJIT_COMMIT=$(git rev-parse HEAD:deps/sljit 2>/dev/null)
 if [ -z "$SLJIT_COMMIT" ] ; then
   echo "Warning: could not find deps/sljit in the tree; not updating build.zig.zon"
-elif ! grep -q "sljit.git#$SLJIT_COMMIT" build.zig.zon ; then
+elif grep -q "sljit.git#$SLJIT_COMMIT" build.zig.zon ; then
+  echo "SLJIT pinned in build.zig.zon to $SLJIT_COMMIT"
+elif ! command -v zig >/dev/null 2>&1 ; then
+  echo "Warning: zig is not executable; not updating build.zig.zon"
+else
   echo "Updating SLJIT pin in build.zig.zon to $SLJIT_COMMIT"
   zig fetch --save=sljit "git+https://github.com/zherczeg/sljit.git#$SLJIT_COMMIT"
   if [ $? != 0 ] ; then exit 1; fi


### PR DESCRIPTION
Zig fetched git packages do not include submodule contents, which caused the following error while building pcre2 with JIT mode on:

<img width="1390" height="136" alt="image" src="https://github.com/user-attachments/assets/7ba3d104-26f0-4aa6-97df-7829e7ac4c05" />

So I made this tiny patch to fetch the pinned SLJIT revision through zig's package manager when JIT support is enabled and stage the fetched sources alongside `pcre2_jit_compile.c`. This works without modifying the C source or affecting non-JIT builds of pcre2.