### PR TITLE
Use all available CPUs in CI instead of a fixed -j3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,10 +131,10 @@ jobs:
         run: cmake $CMAKE_FLAGS -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DPCRE2_SUPPORT_LIBZ=ON -DPCRE2_SUPPORT_LIBBZ2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
 
       - name: Build
-        run: cd build && make -j3
+        run: cd build && make -j$(sysctl -n hw.ncpu)
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -j$(sysctl -n hw.ncpu) --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         run: ./configure CFLAGS="$CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-pcre2grep-libz --enable-pcre2grep-libbz2 --enable-Werror
 
       - name: Build
-        run: make -j3
+        run: make -j$(nproc)
 
       - name: Test (main test script)
         run: ./RunTest
@@ -97,7 +97,7 @@ jobs:
         run: ./configure CFLAGS="$CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-pcre2grep-libz --enable-pcre2grep-libbz2 --enable-Werror
 
       - name: Build
-        run: make -j3
+        run: make -j$(nproc)
 
       - name: Test (main test script)
         run: ./RunTest
@@ -581,7 +581,7 @@ jobs:
         run: ./configure
 
       - name: Distcheck
-        run: make distcheck -j3
+        run: make distcheck -j$(nproc)
 
       - name: Manifest
         run: |
@@ -632,7 +632,7 @@ jobs:
         run: CC="clang -fprofile-instr-generate -fcoverage-mapping" cmake $CMAKE_FLAGS -DCMAKE_BUILD_TYPE=Debug -DPCRE2_DEBUG=OFF -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DPCRE2_SUPPORT_LIBZ=ON -DPCRE2_SUPPORT_LIBBZ2=ON -DPCRE2_SUPPORT_LIBEDIT=ON -DPCRE2_SUPPORT_LIBREADLINE=OFF -B build
 
       - name: Build
-        run: cd build && make -j3
+        run: cd build && make -j$(nproc)
 
       - name: Test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,6 +452,8 @@ jobs:
             PATH=/opt/developerstudio12.6/bin:"$PATH"
             export PATH
 
+            NPROC=`getconf NPROCESSORS_ONLN`
+
             cp -rp . ../build-autoconf-32
             cp -rp . ../build-autoconf-64
             cp -rp . ../build-cmake-64
@@ -484,7 +486,7 @@ jobs:
             CC="cc -m64" cmake $CMAKE_FLAGS -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_SOLARIS_CC" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
             cd build
             make
-            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+            ctest -j$NPROC --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
             cmake --install . --prefix install-dir
             ../maint/RunManifestTest install-dir ../maint/manifest-cmakeinstall-solaris
             ../maint/RunSymbolTest install-dir/lib/ ../maint/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,6 +319,8 @@ jobs:
           run: |
             set -e
 
+            NPROC=`sysctl -n hw.ncpu`
+
             cp -rp . ../build-autoconf
             cp -rp . ../build-cmake
 
@@ -326,7 +328,7 @@ jobs:
             cd ../build-autoconf
 
             ./configure CFLAGS="$CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-Werror
-            make -j3
+            make -j$NPROC
             (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
             make install "DESTDIR=`pwd`/install-dir"
@@ -338,8 +340,8 @@ jobs:
 
             cmake $CMAKE_FLAGS -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
             cd build
-            make -j3
-            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+            make -j$NPROC
+            ctest -j$NPROC --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
             cmake --install . --prefix install-dir
             ../maint/RunManifestTest install-dir ../maint/manifest-cmakeinstall-freebsd
             ../maint/RunSymbolTest install-dir/lib/ ../maint/
@@ -373,6 +375,7 @@ jobs:
 
             export MALLOC_OPTIONS="USRJGFC>>"
             EXTRA_CFLAGS="-DSLJIT_WX_EXECUTABLE_ALLOCATOR"
+            NPROC=`sysctl -n hw.ncpu`
 
             cp -rp . ../build-autoconf
             cp -rp . ../build-cmake
@@ -381,7 +384,7 @@ jobs:
             cd ../build-autoconf
 
             ./configure CFLAGS="$CFLAGS_GCC_STYLE $EXTRA_CFLAGS" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-Werror
-            make -j3
+            make -j$NPROC
             (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
 
             make install "DESTDIR=`pwd`/install-dir"
@@ -395,8 +398,8 @@ jobs:
 
             cmake $CMAKE_FLAGS -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE $EXTRA_CFLAGS" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
             cd build
-            make -j3
-            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+            make -j$NPROC
+            ctest -j$NPROC --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
             cmake --install . --prefix install-dir
             # ../maint/RunManifestTest install-dir ../maint/manifest-cmakeinstall-openbsd
             # ../maint/RunSymbolTest install-dir/lib/ ../maint/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Test
-        run: cd build && ctest -C Release -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -C Release -j $env:NUMBER_OF_PROCESSORS --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -555,7 +555,7 @@ jobs:
             cmake $CMAKE_FLAGS -G Ninja -DPCRE2_EBCDIC=ON -DPCRE2_SUPPORT_UNICODE=OFF -DCMAKE_C_COMPILER=ibm-clang -DCMAKE_C_FLAGS="-m64 $CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
             cd build;
             ninja;
-            ctest -j3 --output-on-failure; && (cat ./Testing/Temporary/LastTest.log || true)
+            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
             '
 
   distcheck:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,7 +64,7 @@ jobs:
         run: ./configure CC='gcc -fsanitize=undefined,address -fsanitize-undefined-trap-on-error' CFLAGS="-O0 $CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --enable-Werror --enable-pcre2test-libedit --with-link-size=4
 
       - name: Build
-        run: make -j3
+        run: make -j$(nproc)
 
       - name: Test
         run: (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
@@ -91,7 +91,7 @@ jobs:
         run: ./configure CC='clang -fsanitize=undefined,address,integer -fno-sanitize-recover=undefined,integer -fno-sanitize=unsigned-integer-overflow,unsigned-shift-base,function' CFLAGS="${{ matrix.opt }} $CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --enable-Werror --with-link-size=3
 
       - name: Build
-        run: make -j3
+        run: make -j$(nproc)
 
       - name: Test
         run: |
@@ -147,10 +147,10 @@ jobs:
           cmake $CMAKE_FLAGS -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DPCRE2_SUPPORT_LIBEDIT=ON -DPCRE2_SUPPORT_LIBREADLINE=OFF -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE" -DCMAKE_POLICY_VERSION_MINIMUM=$CMAKE_VER -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
 
       - name: Build
-        run: cd build && make -j3
+        run: cd build && make -j$(nproc)
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -j$(nproc) --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |
@@ -229,7 +229,7 @@ jobs:
         run: ./configure CFLAGS="-Os $CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --enable-Werror
 
       - name: Build
-        run: make -j3
+        run: make -j$(nproc)
 
       - name: Test
         run: (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
@@ -266,7 +266,7 @@ jobs:
         run: ./configure CFLAGS="-O0 $CFLAGS_GCC_STYLE" --enable-jit --enable-pcre2-16 --enable-pcre2-32 --enable-debug --enable-Werror
 
       - name: Build
-        run: make -j3
+        run: make -j$(nproc)
 
       - name: Test
         run: (make check; rc=$?; for i in test-suite.log Run*Test.log pcre2*_test.log; do echo "== $i =="; cat $i; done; exit $rc)
@@ -301,10 +301,10 @@ jobs:
         run: cmake $CMAKE_FLAGS -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build
 
       - name: Build
-        run: cd build && make -j3
+        run: cd build && make -j$(nproc)
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -j$(nproc) --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |
@@ -397,7 +397,7 @@ jobs:
         run: ninja -C build
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -j$(nproc) --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
       - name: Install
         run: |
@@ -506,10 +506,10 @@ jobs:
         run: cmake $CMAKE_FLAGS -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE $CFLAGS_UNITY" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Release -B build
 
       - name: Build
-        run: cd build && make -j3
+        run: cd build && make -j$(nproc)
 
       - name: Test
-        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -j$(nproc) --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   fruitbat:
     # Tests with: MSYS2 unix-on-Windows environment
@@ -554,7 +554,7 @@ jobs:
 
       - name: Test
         shell: msys2 {0}
-        run: cd build && ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -j$(nproc) --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   ptarmigan:
     # Tests with various unusual processor architectures
@@ -624,7 +624,7 @@ jobs:
             cmake $CMAKE_FLAGS -G Ninja -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2_16=ON -DPCRE2_BUILD_PCRE2_32=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DPCRE2_DEBUG=ON -DCMAKE_C_FLAGS="$CFLAGS_GCC_STYLE" -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build
             cd build
             ninja
-            ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+            ctest -j$(nproc) --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   zebrilus:
     # Tests with: Zig compiler. A "zebrilus" is known as a "zigzag heron".

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -424,7 +424,7 @@ jobs:
         run: cmake --build build --config RelWithDebInfo
 
       - name: Test
-        run: cd build && ctest -C RelWithDebInfo -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -C RelWithDebInfo -j $env:NUMBER_OF_PROCESSORS --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   pterodactyl:
     # Tests with: MSVC 64-bit, Debug, shared libraries
@@ -444,7 +444,7 @@ jobs:
         run: cmake --build build --config Debug
 
       - name: Test
-        run: cd build && ctest -C Debug -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+        run: cd build && ctest -C Debug -j $env:NUMBER_OF_PROCESSORS --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
 
   bigbird:
     # Job to execute ManyConfigTests


### PR DESCRIPTION
Every CI job hard-codes `-j3` for `make` and `ctest`. GitHub's hosted Linux runners currently have four CPUs, and larger or self-hosted runners have more, so this leaves capacity unused.

There is no portable way to ask for the CPU count, so each platform gets the spelling it supports:

| Platform | Expression |
|---|---|
| Linux hosts, containers, MSYS2, run-on-arch | `$(nproc)` |
| macOS | `$(sysctl -n hw.ncpu)` |
| FreeBSD, OpenBSD | `NPROC=`sysctl -n hw.ncpu`` once per VM script |
| Solaris | `NPROC=`getconf NPROCESSORS_ONLN`` |
| Windows (PowerShell) | `-j $env:NUMBER_OF_PROCESSORS` |

On the BSDs and Solaris the count is computed once at the top of the VM script and reused, rather than repeating the command at each call site.

One commit per platform, so the unusual ones can be reviewed or dropped individually.

No functional change: the same jobs run the same builds and tests.

Two things deliberately left alone:

- The z/OS `ctest -j3`. I don't know whether `nproc` exists in the zopen environment, and that line has a pre-existing syntax error (`--output-on-failure; &&`) which I've included a patch to fix
- The Solaris compilation steps, which were already serial and stay that way. Only its `ctest` changes.
