### PR TITLE
Test the remaining JIT backends under QEMU

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,6 +23,7 @@ on:
         - chaffinch
         - fruitbat
         - ptarmigan
+        - coelacanth
         - zebrilus
         - bee
   push:
@@ -625,6 +626,106 @@ jobs:
             cd build
             ninja
             ctest -j3 --output-on-failure && (cat ./Testing/Temporary/LastTest.log || true)
+
+  coelacanth:
+    # Tests with: cross-compilation and qemu-user, for the JIT backends that no
+    # other job covers. A coelacanth is a fish that was thought to be extinct.
+    name: QEMU ${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.config.container }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # "libc" is the Debian architecture name. It is needed because the
+          # cross compilers do not depend on the target's libc headers, and it
+          # cannot always be derived from the triple.
+          #
+          # Ubuntu armhf defaults to Thumb-2, so ARM mode needs asking for.
+          - { name: arm,         triple: arm-linux-gnueabihf,         qemu: arm,         libc: armhf,      container: "ubuntu:26.04", cflags: -marm }
+          - { name: arm-thumb2,  triple: arm-linux-gnueabihf,         qemu: arm,         libc: armhf,      container: "ubuntu:26.04", cflags: -mthumb }
+          - { name: loongarch64, triple: loongarch64-linux-gnu,       qemu: loongarch64, libc: loong64,    container: "ubuntu:26.04" }
+          # PowerPC big-endian; ptarmigan covers ppc64le, which is a different
+          # ABI to ppc64.
+          - { name: powerpc,     triple: powerpc-linux-gnu,           qemu: ppc,         libc: powerpc,    container: "ubuntu:26.04" }
+          - { name: powerpc64,   triple: powerpc64-linux-gnu,         qemu: ppc64,       libc: ppc64,      container: "ubuntu:26.04" }
+          # These cross compilers come from Debian, which currently has no
+          # maintainer for the MIPS cross toolchain packages, so they have not
+          # been rebuilt for the release that Ubuntu 26.04 is based on. Hence
+          # the older container. (Ubuntu itself never targeted MIPS.)
+          - { name: mips,        triple: mips-linux-gnu,              qemu: mips,        libc: mips,       container: "ubuntu:24.04" }
+          - { name: mipsel,      triple: mipsel-linux-gnu,            qemu: mipsel,      libc: mipsel,     container: "ubuntu:24.04" }
+          - { name: mips64,      triple: mips64-linux-gnuabi64,       qemu: mips64,      libc: mips64,     container: "ubuntu:24.04" }
+          - { name: mips64el,    triple: mips64el-linux-gnuabi64,     qemu: mips64el,    libc: mips64el,   container: "ubuntu:24.04" }
+          # MIPS release 6 is a different instruction set to the earlier
+          # releases, and SLJIT_MIPS_REV >= 6 selects different code. There is
+          # no separate qemu-user binary for it; the emulated CPU has to be
+          # named instead, because the defaults predate release 6.
+          - { name: mips32r6el,  triple: mipsisa32r6el-linux-gnu,     qemu: mipsel,      libc: mipsr6el,   container: "ubuntu:24.04", qemu_cpu: mips32r6-generic }
+          - { name: mips64r6el,  triple: mipsisa64r6el-linux-gnuabi64, qemu: mips64el,   libc: mips64r6el, container: "ubuntu:24.04", qemu_cpu: I6400 }
+    if: |
+      (github.event_name == 'workflow_dispatch' && (inputs.job_id == 'all' || inputs.job_id == 'coelacanth')) ||
+      github.event_name == 'push'
+    env:
+      # Where qemu-user looks for the target's shared libraries.
+      QEMU_LD_PREFIX: /usr/${{ matrix.config.triple }}
+    steps:
+      - name: Setup
+        run: |
+          apt-get -qq update
+          apt-get -qq install -y git autoconf automake libtool make \
+                                 gcc-${{ matrix.config.triple }} \
+                                 libc6-dev-${{ matrix.config.libc }}-cross \
+                                 qemu-user
+
+          # Not set unconditionally: an empty QEMU_CPU makes qemu fail to find
+          # a CPU definition.
+          if [ -n "${{ matrix.config.qemu_cpu }}" ]; then
+            echo "QEMU_CPU=${{ matrix.config.qemu_cpu }}" >> "$GITHUB_ENV"
+          fi
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+
+      - name: Prepare
+        run: ./autogen.sh
+
+      - name: Configure
+        # Shared libraries are disabled so that the test programs are real
+        # executables rather than libtool wrapper scripts, which qemu-user
+        # cannot run.
+        run: |
+          ./configure \
+            --build=`./config.guess` \
+            --host=${{ matrix.config.triple }} \
+            CC=${{ matrix.config.triple }}-gcc \
+            CFLAGS="${{ matrix.config.cflags }} $CFLAGS_GCC_STYLE" \
+            --disable-shared \
+            --enable-jit \
+            --enable-pcre2-16 \
+            --enable-pcre2-32 \
+            --enable-debug \
+            --enable-Werror
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Test (main test script)
+        run: ./RunTest -sim qemu-${{ matrix.config.qemu }}
+
+      - name: Test (JIT test program)
+        run: qemu-${{ matrix.config.qemu }} ./pcre2_jit_test
+
+      - name: Test (pcre2posix program)
+        run: qemu-${{ matrix.config.qemu }} ./pcre2posix_test -v
+
+      # RunGrepTest is skipped as it does not have a "-sim" flag yet.
 
   zebrilus:
     # Tests with: Zig compiler. A "zebrilus" is known as a "zigzag heron".


### PR DESCRIPTION
PCRE2 has hand-written code for every architecture SLJIT supports, but CI only exercises some of it. The existing `ptarmigan` job covers s390x, ppc64le, armv7, aarch64 and riscv64. This adds a job covering the backends that nothing currently touches:

| Target | Backend |
|---|---|
| arm (`-marm`) | `sljitNativeARM_32.c` |
| arm (`-mthumb`) | `sljitNativeARM_T2_32.c` |
| powerpc | `sljitNativePPC_32.c` |
| powerpc64 (big-endian) | `sljitNativePPC_64.c` |
| mips, mipsel | `sljitNativeMIPS_32.c` |
| mips64, mips64el | `sljitNativeMIPS_64.c` |
| mips32r6el, mips64r6el | as above, `SLJIT_MIPS_REV >= 6` paths |
| loongarch64 | `sljitNativeLOONGARCH_64.c` |

Two of these are easy to overlook. Ubuntu's armhf compiler defaults to Thumb-2, so `armv7` in `ptarmigan` never exercises the ARM-mode backend. And ppc64le is ELFv2 while ppc64 big-endian is ELFv1, with function descriptors and a different call sequence, so the two are not interchangeable.

## Why a new job rather than more rows in ptarmigan

`ptarmigan` uses `run-on-arch-action`, which boots a container of the target architecture. That action supports only armv6, armv7, aarch64, riscv64, s390x and ppc64le, so none of the targets above can be added to it. (It also emulates with QEMU, so this is not a change in kind, just in mechanism.)

Cross-compiling and emulating only the test programs is also faster than emulating a whole toolchain.

`RunTest` already accepts a `-sim` prefix for exactly this, so no test scripts change. Shared libraries are disabled so the test programs are real executables rather than libtool wrapper scripts, which `qemu-user` cannot run.

## Cost

Eleven jobs. Measured locally on a fast desktop, each is about 2.5 minutes of compute: the cross-build runs at native speed, `RunTest` costs ~10x native under emulation (15-21s) and `pcre2_jit_test` ~20-29x (82-113s). Allowing for a slower runner plus container pull, apt and autogen, expect 6-10 minutes per job. The timeout is set to 20 minutes.

Gated to `push` and `workflow_dispatch` only, matching `ptarmigan`, so pull requests are unaffected.

## Testing

Cross-built and run under qemu-user locally for arm, loongarch64, powerpc, powerpc64 and mips64. `RunTest` and `pcre2_jit_test` pass on all five, including both big-endian PowerPC targets.

Not verified locally: the 32-bit MIPS targets, the little-endian MIPS variants and the release 6 rows, for want of toolchains, and the Thumb-2 row. Package availability for all rows was checked against the Ubuntu archive indices rather than by building, so the first CI run may need fixups.

## Notes

Two implementation details that I should note:

- The cross compilers do not depend on the target's libc headers, so `libc6-dev-<arch>-cross` is installed explicitly. That needs the Debian architecture name, which is not always derivable from the triple (`mipsisa32r6el-linux-gnu` needs `libc6-dev-mipsr6el-cross`).
- MIPS release 6 has no separate `qemu-user` binary, so `QEMU_CPU` names the emulated CPU instead. The defaults predate release 6.

The MIPS cross compilers are no longer built for Ubuntu 26.04, so those rows use a 24.04 container.
