### PR TITLE
pcre2test: correctly set history prompt with readline()

### DIFF
--- a/doc/html/pcre2test.html
+++ b/doc/html/pcre2test.html
@@ -214,9 +214,11 @@ If an unknown option is given, an error message is output; the exit code is 0.
 </p>
 <p>
 <b>--colo[u]r[=&#60;always,auto,never&#62;]</b>
-By default, the output is coloured if the output file is a terminal (<b>auto</b>).
-Force or suppress output of ANSI colour escapes with <b>always</b> and <b>never</b>
-respectively.
+With <b>auto</b>, the output is coloured if the output is to a terminal. Force or
+suppress output of ANSI colour escapes with <b>always</b> (or no specifier
+provided) and <b>never</b> respectively. If no colour option is provided, the
+default is <b>auto</b>, unless the NO_COLOR environment variable is defined and
+non-empty.
 </p>
 <p>
 <b>-d</b>

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -180,9 +180,10 @@ information. It returns one of the following values:
 If an unknown option is given, an error message is output; the exit code is 0.
 .TP 10
 \fB--colo[u]r[=<always,auto,never>]\fP
-By default, the output is coloured if the output file is a terminal (\fBauto\fP).
-Force or suppress output of ANSI colour escapes with \fBalways\fP and \fBnever\fP
-respectively.
+By default, the output is coloured if the output is a terminal (\fBauto\fP)
+and there is no NO_COLOR variable defined in the environment.
+Force or suppress output of ANSI colour escapes with \fBalways\fP and
+\fBnever\fP respectively.
 .TP 10
 \fB-d\fP
 Behave as if each pattern has the \fBdebug\fP modifier; the internal

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -180,10 +180,11 @@ information. It returns one of the following values:
 If an unknown option is given, an error message is output; the exit code is 0.
 .TP 10
 \fB--colo[u]r[=<always,auto,never>]\fP
-By default, the output is coloured if the output is a terminal (\fBauto\fP)
-and there is no NO_COLOR variable defined in the environment.
-Force or suppress output of ANSI colour escapes with \fBalways\fP and
-\fBnever\fP respectively.
+With \fBauto\fP, the output is coloured if the output is to a terminal. Force or
+suppress output of ANSI colour escapes with \fBalways\fP (or no specifier
+provided) and \fBnever\fP respectively. If no colour option is provided, the
+default is \fBauto\fP, unless the NO_COLOR environment variable is defined and
+non-empty.
 .TP 10
 \fB-d\fP
 Behave as if each pattern has the \fBdebug\fP modifier; the internal

--- a/doc/pcre2test.txt
+++ b/doc/pcre2test.txt
@@ -173,9 +173,11 @@ COMMAND LINE OPTIONS
                  the exit code is 0.
 
        --colo[u]r[=<always,auto,never>]
-                 By default, the output is coloured if the output  file  is  a
-                 terminal (auto).  Force or suppress output of ANSI colour es-
-                 capes with always and never respectively.
+                 With auto, the output is coloured if the output is to a  ter-
+                 minal.  Force  or suppress output of ANSI colour escapes with
+                 always (or no specifier provided) and never respectively.  If
+                 no colour option is provided, the default is auto, unless the
+                 NO_COLOR environment variable is defined and non-empty.
 
        -d        Behave  as if each pattern has the debug modifier; the inter-
                  nal form and information about the compiled pattern is output

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -2027,8 +2027,13 @@ for (;;)
     int snprintf_rc;
     char *s;
     if (should_print_colour(clr_prompt, stdout) &&
-        (snprintf_rc = snprintf(promptbuf, sizeof(promptbuf), "\x1b[%dm%s\x1b[0m", clr_prompt, prompt)) > 0 &&
-        snprintf_rc < (int)sizeof(promptbuf))
+        (snprintf_rc = snprintf(promptbuf, sizeof(promptbuf),
+                                "%c\x1b[%dm%c%s%c\x1b[0m%c",
+                                RL_PROMPT_START_IGNORE, clr_prompt,
+                                RL_PROMPT_END_IGNORE, prompt,
+                                RL_PROMPT_START_IGNORE,
+                                RL_PROMPT_END_IGNORE)) > 0 &&
+                       snprintf_rc < (int)sizeof(promptbuf))
       s = readline(promptbuf);
     else
       s = readline(prompt);
@@ -3675,6 +3680,8 @@ locale_name[0] = 0;
 
 patctl_zero(&def_patctl);
 datctl_zero(&def_datctl);
+
+if (getenv("NO_COLOR") != NULL) colour_setting = COLOUR_NEVER;
 
 /* Scan command line options. */
 

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -2026,17 +2026,23 @@ for (;;)
     char promptbuf[80];
     int snprintf_rc;
     char *s;
-    if (should_print_colour(clr_prompt, stdout) &&
-        (snprintf_rc = snprintf(promptbuf, sizeof(promptbuf),
-                                "%c\x1b[%dm%c%s%c\x1b[0m%c",
-                                RL_PROMPT_START_IGNORE, clr_prompt,
-                                RL_PROMPT_END_IGNORE, prompt,
-                                RL_PROMPT_START_IGNORE,
-                                RL_PROMPT_END_IGNORE)) > 0 &&
-                       snprintf_rc < (int)sizeof(promptbuf))
-      s = readline(promptbuf);
+    if (should_print_colour(clr_prompt, stdout))
+      /* libedit cannot handle ANSI escapes as the final character of a prompt,
+      so we ensure a trailing space comes after the last escape. */
+      snprintf_rc = snprintf(promptbuf, sizeof(promptbuf),
+                             "%c\x1b[%dm%c%s%c\x1b[0m%c ",
+                             RL_PROMPT_START_IGNORE, clr_prompt,
+                             RL_PROMPT_END_IGNORE, prompt,
+                             RL_PROMPT_START_IGNORE,
+                             RL_PROMPT_END_IGNORE);
     else
-      s = readline(prompt);
+      snprintf_rc = snprintf(promptbuf, sizeof(promptbuf), "%s ", prompt);
+    if (snprintf_rc <= 0 || snprintf_rc >= (int)sizeof(promptbuf))
+      {
+      cfprintf(clr_test_error, outfile, "** Interactive prompt exceeds buffer space\n");
+      exit(1);
+      }
+    s = readline(promptbuf);
     if (s == NULL) return (here == start)? NULL : start;
     dlen = strlen(s);
     if (dlen > rlen - 2)
@@ -3681,7 +3687,8 @@ locale_name[0] = 0;
 patctl_zero(&def_patctl);
 datctl_zero(&def_datctl);
 
-if (getenv("NO_COLOR") != NULL) colour_setting = COLOUR_NEVER;
+if (getenv("NO_COLOR") != NULL && strlen(getenv("NO_COLOR")) > 0)
+  colour_setting = COLOUR_NEVER;
 
 /* Scan command line options. */
 
@@ -4072,7 +4079,7 @@ while (notdone)
   expectdata |= preg.re_pcre2_code != NULL;
 #endif
 
-  if (extend_inputline(infile, buffer, expectdata? "data> " : "  re> ") == NULL)
+  if (extend_inputline(infile, buffer, expectdata? "data>" : "  re>") == NULL)
     break;
 
   /* Pre-process input lines with #if...#endif. */

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -3663,6 +3663,7 @@ BOOL skipping_endif = FALSE;
 char *arg_subject = NULL;
 char *arg_pattern = NULL;
 char *arg_error = NULL;
+char *env_no_color = getenv("NO_COLOR");
 
 /* Get buffers from malloc() so that valgrind will check their misuse when
 debugging. They grow automatically when very long lines are read. The 16-
@@ -3687,7 +3688,7 @@ locale_name[0] = 0;
 patctl_zero(&def_patctl);
 datctl_zero(&def_datctl);
 
-if (getenv("NO_COLOR") != NULL && strlen(getenv("NO_COLOR")) > 0)
+if (env_no_color != NULL && strlen(env_no_color) > 0)
   colour_setting = COLOUR_NEVER;
 
 /* Scan command line options. */


### PR DESCRIPTION
when building pcre2test with either GNU readline or libedit, the prompt will break as shown in (press up, down, up in the second prompt, which now includes some of the previous line as the prompt):

```
PCRE2 version 10.47 2025-10-21 (8-bit)
  re> 12345678901234567
** Invalid pattern delimiter '1' (x31).
  re> 12345678912345678901234567
```