### PR TITLE
pcre2test: honor no_jit when used with jitfast

### DIFF
--- a/doc/html/pcre2test.html
+++ b/doc/html/pcre2test.html
@@ -863,7 +863,7 @@ when it can never be used.
 The <b>framesize</b> modifier shows the size, in bytes, of each storage frame
 used by <b>pcre2_match()</b> for handling backtracking. The size depends on the
 number of capturing parentheses in the pattern. A vector of these frames is
-used at matching time; its overall size is shown when the <b>heaframes_size</b>
+used at matching time; its overall size is shown when the <b>heapframes_size</b>
 subject modifier is set.
 </p>
 <p>

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -811,7 +811,7 @@ when it can never be used.
 The \fBframesize\fP modifier shows the size, in bytes, of each storage frame
 used by \fBpcre2_match()\fP for handling backtracking. The size depends on the
 number of capturing parentheses in the pattern. A vector of these frames is
-used at matching time; its overall size is shown when the \fBheaframes_size\fP
+used at matching time; its overall size is shown when the \fBheapframes_size\fP
 subject modifier is set.
 .P
 The \fBcallout_info\fP modifier requests information about all the callouts in

--- a/doc/pcre2test.txt
+++ b/doc/pcre2test.txt
@@ -787,7 +787,7 @@ PATTERN MODIFIERS
        used by pcre2_match() for handling backtracking. The  size  depends  on
        the  number  of capturing parentheses in the pattern. A vector of these
        frames is used at matching time; its overall size  is  shown  when  the
-       heaframes_size subject modifier is set.
+       heapframes_size subject modifier is set.
 
        The  callout_info  modifier requests information about all the callouts
        in the pattern. A list of them is output at the end of any other infor-

--- a/src/pcre2test_inc.h
+++ b/src/pcre2test_inc.h
@@ -3165,7 +3165,8 @@ for (;;)
       dat_context, dfa_workspace, DFA_WS_DIMENSION);
     }
 
-  else if ((pat_patctl.control & CTL_JITFAST) != 0)
+  else if ((pat_patctl.control & CTL_JITFAST) != 0 &&
+           (dat_datctl.options & PCRE2_NO_JIT) == 0)
     capcount = pcre2_jit_match(compiled_code, pp, ulen, dat_datctl.offset,
       dat_datctl.options, match_data, dat_context);
 
@@ -4747,7 +4748,8 @@ if (dat_datctl.replacement[0] != MOD_STR_UNSET)
         dat_datctl.offset, dat_datctl.options, match_data,
         use_dat_context, dfa_workspace, DFA_WS_DIMENSION);
       }
-    else if ((pat_patctl.control & CTL_JITFAST) != 0)
+    else if ((pat_patctl.control & CTL_JITFAST) != 0 &&
+             (dat_datctl.options & PCRE2_NO_JIT) == 0)
       {
       (void)pcre2_jit_match(compiled_code, pp, arg_ulen, dat_datctl.offset,
         dat_datctl.options, match_data, use_dat_context);
@@ -4990,7 +4992,7 @@ for (gmatched = 0;; gmatched++)
   /* When matching is via pcre2_match(), we will detect the use of JIT via the
   stack callback function. */
 
-  jit_was_used = (pat_patctl.control & CTL_JITFAST) != 0;
+  jit_was_used = FALSE;
 
   /* Do timing if required. */
 
@@ -5021,7 +5023,8 @@ for (gmatched = 0;; gmatched++)
         }
       }
 
-    else if ((pat_patctl.control & CTL_JITFAST) != 0)
+    else if ((pat_patctl.control & CTL_JITFAST) != 0 &&
+             (dat_datctl.options & PCRE2_NO_JIT) == 0)
       {
       start_time = clock();
       for (i = 0; i < timeitm; i++)
@@ -5105,9 +5108,11 @@ for (gmatched = 0;; gmatched++)
       }
     else
       {
-      if ((pat_patctl.control & CTL_JITFAST) != 0)
-        capcount = pcre2_jit_match(compiled_code, pp, arg_ulen, dat_datctl.offset,
-          dat_datctl.options | g_notempty, match_data, use_dat_context);
+      if ((pat_patctl.control & CTL_JITFAST) != 0 &&
+          (dat_datctl.options & PCRE2_NO_JIT) == 0)
+        capcount = pcre2_jit_match(compiled_code, pp, arg_ulen,
+          dat_datctl.offset, dat_datctl.options | g_notempty, match_data,
+          use_dat_context);
       else
         capcount = pcre2_match(compiled_code, pp, arg_ulen, dat_datctl.offset,
           dat_datctl.options | g_notempty, match_data, use_dat_context);
@@ -5142,12 +5147,15 @@ for (gmatched = 0;; gmatched++)
           }
         else
           {
-          if ((pat_patctl.control & CTL_JITFAST) != 0)
-            capcount = pcre2_jit_match(compiled_code, pp, arg_ulen, dat_datctl.offset,
-              dat_datctl.options | g_notempty, match_data, use_dat_context);
+          if ((pat_patctl.control & CTL_JITFAST) != 0 &&
+              (dat_datctl.options & PCRE2_NO_JIT) == 0)
+            capcount = pcre2_jit_match(compiled_code, pp, arg_ulen,
+              dat_datctl.offset, dat_datctl.options | g_notempty, match_data,
+              use_dat_context);
           else
-            capcount = pcre2_match(compiled_code, pp, arg_ulen, dat_datctl.offset,
-              dat_datctl.options | g_notempty, match_data, use_dat_context);
+            capcount = pcre2_match(compiled_code, pp, arg_ulen,
+              dat_datctl.offset, dat_datctl.options | g_notempty, match_data,
+              use_dat_context);
           }
 
         mallocs_until_failure = INT_MAX;
@@ -5207,12 +5215,20 @@ for (gmatched = 0;; gmatched++)
       return PR_ABEND;
       }
 
+    /* tracking JIT with jitverify needs a context, but in cases where one
+    wasn't available, can fallback to the match_data status */
+
+    if ((dat_datctl.control & CTL_NULLCONTEXT) != 0 &&
+        (pat_patctl.control & CTL_JITVERIFY) != 0)
+      jit_was_used = match_data->matchedby == PCRE2_MATCHEDBY_JIT;
+
     /* If PCRE2_COPY_MATCHED_SUBJECT was set, check that things are as they
     should be, but not for fast JIT, where it isn't supported. */
 
     if ((dat_datctl.options & PCRE2_COPY_MATCHED_SUBJECT) != 0)
       {
-      if ((pat_patctl.control & CTL_JITFAST) != 0)
+      if ((pat_patctl.control & CTL_JITFAST) != 0 &&
+          (dat_datctl.options & PCRE2_NO_JIT) == 0)
         {
         if ((match_data->flags & PCRE2_MD_COPIED_SUBJECT) != 0)
           cfprintf(clr_test_error, outfile,
@@ -6026,9 +6042,11 @@ if (pcre2_jit_compile(test_compiled_code, PCRE2_JIT_COMPLETE) == 0)
 
 #ifdef SUPPORT_JIT
 
-/* Check that fast JIT releases a copied subject when reusing match data. */
 if (test_compiled_with_jit)
   {
+
+/* Check that fast JIT releases a copied subject when reusing match data. */
+
   test_match_data = pcre2_match_data_create_from_pattern(test_compiled_code,
     test_gen_context);
   ASSERT(test_match_data != NULL, "pcre2_match_data_create_from_pattern(JIT)");
@@ -6043,6 +6061,22 @@ if (test_compiled_with_jit)
 
   pcre2_match_data_free(test_match_data);
   test_match_data = NULL;
+
+/* Check that fast JIT ignores PCRE2_NO_JIT */
+
+  test_match_data = pcre2_match_data_create(100000, test_gen_context);
+  ASSERT(test_match_data != NULL, "pcre2_match_data_create(100000)");
+  ASSERT(pcre2_get_ovector_count(test_match_data) == 65535,
+    "pcre2_get_ovector_count(UINT32_MAX) <= UINT16_MAX)");
+
+  rc = pcre2_jit_match(test_compiled_code, subject_abcz, 4, 0, PCRE2_NO_JIT,
+    test_match_data, NULL);
+  ASSERT(rc == 1 && (test_match_data->matchedby == PCRE2_MATCHEDBY_JIT),
+    "pcre2_jit_match(ignore PCRE2_NO_JIT");
+
+  pcre2_match_data_free(test_match_data);
+  test_match_data = NULL;
+
   }
 
 #endif

--- a/testdata/testinput17
+++ b/testdata/testinput17
@@ -295,12 +295,29 @@
 /abc/
     abc
     abc\=no_jit 
-    
+
+/(*NO_JIT)abc/
+    abc
+
 /abc/jitfast
     abc
-    abc\=copy_matched_subject
     abc\=no_jit 
-    
+
+/(*NO_JIT)abc/jitfast
+\= Expect error
+    abc
+
+# Do not leak a previously copied subject with jitfast (#920)
+
+/abc/jitfast
+    abc\=copy_matched_subject,no_jit
+    abc
+
+/abc/jitfast
+    abc\=copy_matched_subject
+    abc\=null_context
+    abc\=null_context,no_jit
+
 # ---- 
 
 /[aC]/mg,firstline,newline=lf

--- a/testdata/testoutput17
+++ b/testdata/testoutput17
@@ -539,15 +539,38 @@ Failed: error -47: match limit exceeded
  0: abc (JIT)
     abc\=no_jit 
  0: abc
-    
+
+/(*NO_JIT)abc/
+    abc
+ 0: abc
+
 /abc/jitfast
     abc
  0: abc (JIT)
+    abc\=no_jit 
+ 0: abc
+
+/(*NO_JIT)abc/jitfast
+\= Expect error
+    abc
+Failed: error -45: bad JIT option
+
+# Do not leak a previously copied subject with jitfast (#920)
+
+/abc/jitfast
+    abc\=copy_matched_subject,no_jit
+ 0: abc
+    abc
+ 0: abc (JIT)
+
+/abc/jitfast
     abc\=copy_matched_subject
  0: abc (JIT)
-    abc\=no_jit 
+    abc\=null_context
  0: abc (JIT)
-    
+    abc\=null_context,no_jit
+ 0: abc
+
 # ---- 
 
 /[aC]/mg,firstline,newline=lf


### PR DESCRIPTION
teach `pcre2test` to avoid calling `pcre2_jit_match()` directly if `no_jit` was requested, making the use of both options work as expected in recent tests, and improve those so they trigger correctly.