### PR TITLE
doc: say that PCRE2_DFA_RESTART does not remove the need to retain data

### DIFF
--- a/doc/html/pcre2partial.html
+++ b/doc/html/pcre2partial.html
@@ -389,15 +389,18 @@ followed by "no match" when PCRE2_DFA_RESTART is used on the second buffer, you
 can then try a new match starting at offset <i>n+1</i> in the first buffer.
 </p>
 <p>
-Note that PCRE2_DFA_RESTART does not remove the need to keep earlier subject
-data. A lookbehind assertion still refers to characters that PCRE2 no longer
-holds, so the amount that must be retained is bounded in the same way as for
-<b>pcre2_match()</b>, described above; see PCRE2_INFO_MAXLOOKBEHIND. Together
-with the inability to retry at a new starting point, this makes the restart
-facility awkward for matching a stream. Retaining a bounded amount of earlier
-text and running a fresh match over it, as described for <b>pcre2_match()</b>
-above, achieves the same results as searching the whole subject at once, and is
-easier to reason about.
+Therefore, PCRE2_DFA_RESTART does not remove the need to keep earlier subject
+data. In order to perform a bumpalong and continue matching at the next
+character, all subject data from the current match start must be retained,
+together with enough preceding data to satisfy the requirements of lookbehind
+assertions (remembering as above that PCRE2_INFO_MAXLOOKBEHIND only describes
+the buffer requirement of a single lookbehind, and nested lookbehinds can read
+back further from the match start). This makes streaming match processing
+using PCRE2_DFA_RESTART challenging, and the application cannot easily set a
+bound on the number of chunks to buffer. For multi-segment searching that is
+intended to produce the same result as searching the whole subject, it is
+usually simpler to avoid PCRE2_DFA_RESTART and run a fresh match, using either
+matching function, over the retained text.
 </p>
 <h2><a name="SEC7" href="#TOC1">AUTHOR</a></h2>
 <p>

--- a/doc/html/pcre2partial.html
+++ b/doc/html/pcre2partial.html
@@ -388,6 +388,17 @@ two buffers. If a partial match at offset <i>n</i> in the first buffer is
 followed by "no match" when PCRE2_DFA_RESTART is used on the second buffer, you
 can then try a new match starting at offset <i>n+1</i> in the first buffer.
 </p>
+<p>
+Note that PCRE2_DFA_RESTART does not remove the need to keep earlier subject
+data. A lookbehind assertion still refers to characters that PCRE2 no longer
+holds, so the amount that must be retained is bounded in the same way as for
+<b>pcre2_match()</b>, described above; see PCRE2_INFO_MAXLOOKBEHIND. Together
+with the inability to retry at a new starting point, this makes the restart
+facility awkward for matching a stream. Retaining a bounded amount of earlier
+text and running a fresh match over it, as described for <b>pcre2_match()</b>
+above, achieves the same results as searching the whole subject at once, and is
+easier to reason about.
+</p>
 <h2><a name="SEC7" href="#TOC1">AUTHOR</a></h2>
 <p>
 Philip Hazel

--- a/doc/pcre2.txt
+++ b/doc/pcre2.txt
@@ -6921,6 +6921,20 @@ MULTI-SEGMENT MATCHING WITH pcre2_dfa_match()
        on the second buffer, you can then try a new match starting  at  offset
        n+1 in the first buffer.
 
+       Therefore,  PCRE2_DFA_RESTART  does not remove the need to keep earlier
+       subject data. In order to perform a bumpalong and continue matching  at
+       the  next character, all subject data from the current match start must
+       be retained, together with enough preceding data  to  satisfy  the  re-
+       quirements   of   lookbehind  assertions  (remembering  as  above  that
+       PCRE2_INFO_MAXLOOKBEHIND only describes the  buffer  requirement  of  a
+       single  lookbehind,  and  nested lookbehinds can read back further from
+       the  match  start).  This  makes  streaming  match   processing   using
+       PCRE2_DFA_RESTART  challenging, and the application cannot easily set a
+       bound on the number of chunks to buffer.  For  multi-segment  searching
+       that is intended to produce the same result as searching the whole sub-
+       ject,  it is usually simpler to avoid PCRE2_DFA_RESTART and run a fresh
+       match, using either matching function, over the retained text.
+
 
 AUTHOR
 

--- a/doc/pcre2partial.3
+++ b/doc/pcre2partial.3
@@ -352,6 +352,16 @@ as described for \fBpcre2_match()\fP above. Another possibility is to work with
 two buffers. If a partial match at offset \fIn\fP in the first buffer is
 followed by "no match" when PCRE2_DFA_RESTART is used on the second buffer, you
 can then try a new match starting at offset \fIn+1\fP in the first buffer.
+.P
+Note that PCRE2_DFA_RESTART does not remove the need to keep earlier subject
+data. A lookbehind assertion still refers to characters that PCRE2 no longer
+holds, so the amount that must be retained is bounded in the same way as for
+\fBpcre2_match()\fP, described above; see PCRE2_INFO_MAXLOOKBEHIND. Together
+with the inability to retry at a new starting point, this makes the restart
+facility awkward for matching a stream. Retaining a bounded amount of earlier
+text and running a fresh match over it, as described for \fBpcre2_match()\fP
+above, achieves the same results as searching the whole subject at once, and is
+easier to reason about.
 .
 .
 .SH AUTHOR

--- a/doc/pcre2partial.3
+++ b/doc/pcre2partial.3
@@ -353,15 +353,18 @@ two buffers. If a partial match at offset \fIn\fP in the first buffer is
 followed by "no match" when PCRE2_DFA_RESTART is used on the second buffer, you
 can then try a new match starting at offset \fIn+1\fP in the first buffer.
 .P
-Note that PCRE2_DFA_RESTART does not remove the need to keep earlier subject
-data. A lookbehind assertion still refers to characters that PCRE2 no longer
-holds, so the amount that must be retained is bounded in the same way as for
-\fBpcre2_match()\fP, described above; see PCRE2_INFO_MAXLOOKBEHIND. Together
-with the inability to retry at a new starting point, this makes the restart
-facility awkward for matching a stream. Retaining a bounded amount of earlier
-text and running a fresh match over it, as described for \fBpcre2_match()\fP
-above, achieves the same results as searching the whole subject at once, and is
-easier to reason about.
+Therefore, PCRE2_DFA_RESTART does not remove the need to keep earlier subject
+data. In order to perform a bumpalong and continue matching at the next
+character, all subject data from the current match start must be retained,
+together with enough preceding data to satisfy the requirements of lookbehind
+assertions (remembering as above that PCRE2_INFO_MAXLOOKBEHIND only describes
+the buffer requirement of a single lookbehind, and nested lookbehinds can read
+back further from the match start). This makes streaming match processing
+using PCRE2_DFA_RESTART challenging, and the application cannot easily set a
+bound on the number of chunks to buffer. For multi-segment searching that is
+intended to produce the same result as searching the whole subject, it is
+usually simpler to avoid PCRE2_DFA_RESTART and run a fresh match, using either
+matching function, over the retained text.
 .
 .
 .SH AUTHOR


### PR DESCRIPTION
Follow-up to #867

the multi-segment section for `pcre2_dfa_match()` explains the `1234|3789` limitation, but it still reads as if restarting frees the caller from keeping earlier text. It does not: a lookbehind reaches back into the segment that was discarded, and the bound on how much to keep is the same `PCRE2_INFO_MAXLOOKBEHIND` that the `pcre2_match()` section above already describes

so the added paragraph says that, and points at retaining a bounded tail and running a fresh match as the approach that achieves the same results as searching the whole subject at once. Nothing new is claimed here, the wording follows what was concluded in #867

two files: `doc/pcre2partial.3`, and the generated `doc/html/pcre2partial.html` regenerated with `maint/132html` the way `maint/UpdateAlways` calls it. `maint/CheckMan` is clean on the page

if you would rather deprecate `PCRE2_DFA_RESTART` outright, say so and I will close this
