### PR TITLE
keep check_escape error offset within the pattern for \x{ and \o{

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -2020,7 +2020,7 @@ else
     else
       {
       *errorcodeptr = ERR64;
-      goto ESCAPE_FAILED_FORWARD;
+      if (ptr < ptrend) goto ESCAPE_FAILED_FORWARD;
       }
     break;
 
@@ -2107,7 +2107,7 @@ else
         else
           {
           *errorcodeptr = ERR67;
-          goto ESCAPE_FAILED_FORWARD;
+          if (ptr < ptrend) goto ESCAPE_FAILED_FORWARD;
           }
         }   /* End of \x{} processing */
 
@@ -2224,10 +2224,7 @@ return escape;
 /* Some errors need to indicate the next character. */
 
 ESCAPE_FAILED_FORWARD:
-/* Point past the offending character, but not past the end of the pattern. The
-\x{ and \o{ scanners can reach here with ptr at ptrend, and the reported error
-offset must stay within the pattern. */
-if (ptr < ptrend) ptr++;
+ptr++;
 #ifdef SUPPORT_UNICODE
 if (utf) FORWARDCHARTEST(ptr, ptrend);
 #endif

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -2224,7 +2224,10 @@ return escape;
 /* Some errors need to indicate the next character. */
 
 ESCAPE_FAILED_FORWARD:
-ptr++;
+/* Point past the offending character, but not past the end of the pattern. The
+\x{ and \o{ scanners can reach here with ptr at ptrend, and the reported error
+offset must stay within the pattern. */
+if (ptr < ptrend) ptr++;
 #ifdef SUPPORT_UNICODE
 if (utf) FORWARDCHARTEST(ptr, ptrend);
 #endif

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -3987,6 +3987,10 @@
 
 /^A\x{/
 
+/\x{2/
+
+/\o{7/
+
 /[ab]++/B,no_auto_possess
 
 /[^ab]*+/B,no_auto_possess
@@ -8350,12 +8354,5 @@ a)"xI
 \= Expect to fail with PCRE2_ERROR_PARTIALSUBS
     abc\=ps,substitute_replacement_only,replace=>$_<
     abc\=ps,substitute_replacement_only,replace=>$'<
-
-# An unterminated \x{ or \o{ escape at the end of the pattern must report an
-# error offset that lies within the pattern.
-
-/\x{2/
-
-/\o{7/
 
 # End of testinput2

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -8351,4 +8351,11 @@ a)"xI
     abc\=ps,substitute_replacement_only,replace=>$_<
     abc\=ps,substitute_replacement_only,replace=>$'<
 
+# An unterminated \x{ or \o{ escape at the end of the pattern must report an
+# error offset that lies within the pattern.
+
+/\x{2/
+
+/\o{7/
+
 # End of testinput2

--- a/testdata/testinput5
+++ b/testdata/testinput5
@@ -3616,4 +3616,9 @@
     \x{e1}
     \x{c1}
 
+# An unterminated \N{U+ escape at the end of the pattern must
+# report an error offset that lies within the pattern.
+
+/(*UTF)\N{U+2/
+
 # End of testinput5

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13630,6 +13630,14 @@ Failed: error 167 at offset 8: non-hex character in \x{} (closing brace missing?
 Failed: error 178 at offset 5: digits missing after \x or in \x{} or \o{} or \N{U+}
         here: ^A\x{ |<--|
 
+/\x{2/
+Failed: error 167 at offset 4: non-hex character in \x{} (closing brace missing?)
+        here: \x{2 |<--|
+
+/\o{7/
+Failed: error 164 at offset 4: non-octal character in \o{} (closing brace missing?)
+        here: \o{7 |<--|
+
 /[ab]++/B,no_auto_possess
 ------------------------------------------------------------------
         Bra
@@ -23711,17 +23719,6 @@ Failed: error -76 at offset 3 in replacement: replacement $' or $_ not supported
     abc\=ps,substitute_replacement_only,replace=>$'<
 Failed: error -76 at offset 3 in replacement: replacement $' or $_ not supported with partial match
         here: >$' |<--| <
-
-# An unterminated \x{ or \o{ escape at the end of the pattern must report an
-# error offset that lies within the pattern.
-
-/\x{2/
-Failed: error 167 at offset 4: non-hex character in \x{} (closing brace missing?)
-        here: \x{2 |<--|
-
-/\o{7/
-Failed: error 164 at offset 4: non-octal character in \o{} (closing brace missing?)
-        here: \o{7 |<--|
 
 # End of testinput2
 Error -80: PCRE2_ERROR_BADDATA (unknown error number)

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -23712,6 +23712,17 @@ Failed: error -76 at offset 3 in replacement: replacement $' or $_ not supported
 Failed: error -76 at offset 3 in replacement: replacement $' or $_ not supported with partial match
         here: >$' |<--| <
 
+# An unterminated \x{ or \o{ escape at the end of the pattern must report an
+# error offset that lies within the pattern.
+
+/\x{2/
+Failed: error 167 at offset 4: non-hex character in \x{} (closing brace missing?)
+        here: \x{2 |<--|
+
+/\o{7/
+Failed: error 164 at offset 4: non-octal character in \o{} (closing brace missing?)
+        here: \o{7 |<--|
+
 # End of testinput2
 Error -80: PCRE2_ERROR_BADDATA (unknown error number)
 Error -62: bad serialized data

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -8335,4 +8335,11 @@ Failed: error 150 at offset 5: invalid range in character class
     \x{c1}
  0: \x{c1}
 
+# An unterminated \N{U+ escape at the end of the pattern must
+# report an error offset that lies within the pattern.
+
+/(*UTF)\N{U+2/
+Failed: error 167 at offset 12: non-hex character in \x{} (closing brace missing?)
+        here: ...UTF)\N{U+2 |<--|
+
 # End of testinput5


### PR DESCRIPTION
An unterminated \x{ or \o{ escape at the end of a pattern makes check_escape report an error offset past the end of the pattern:
- ESCAPE_FAILED_FORWARD increments ptr unconditionally, but the \x{ and \o{ scanners reach it with ptr already at ptrend
- pcre2_compile then returns erroroffset = patlen + 1 (offset 5 for the 4-unit pattern \x{2), out of range for the caller
- with --enable-debug this trips PCRE2_ASSERT(ptr <= pattern + patlen); the \c paths sharing this label only arrive with ptr < ptrend, so they stay correct
Guarded the increment against ptrend and added a regression to test 2.
