### PR TITLE
fix stale byte in negated glob class with glob_no_wild_separator

### DIFF
--- a/src/pcre2_convert.c
+++ b/src/pcre2_convert.c
@@ -679,9 +679,10 @@ if (*pattern == CHAR_EXCLAMATION_MARK
       len++;
       }
     out->out_str[len] = (uint8_t) separator;
+    len++;
     }
 
-  convert_glob_write_str(out, len + 1);
+  convert_glob_write_str(out, len);
   }
 else
   convert_glob_write(out, CHAR_LEFT_SQUARE_BRACKET);

--- a/testdata/testinput24
+++ b/testdata/testinput24
@@ -330,6 +330,12 @@
 
 /??a??/
 
+/[!a]/
+
+/[^xy]/
+
+/a*[!b]/
+
 #pattern convert=unset
 #pattern convert=glob,convert_glob_escape=0
 

--- a/testdata/testoutput24
+++ b/testdata/testoutput24
@@ -512,6 +512,15 @@ No match
 /??a??/
 (?s)\A..a..\z
 
+/[!a]/
+(?s)\A[^a]\z
+
+/[^xy]/
+(?s)\A[^xy]\z
+
+/a*[!b]/
+(?s)\Aa(*COMMIT).*?[^b]\z
+
 #pattern convert=unset
 #pattern convert=glob,convert_glob_escape=0
 


### PR DESCRIPTION
Converting a negated glob class with PCRE2_CONVERT_GLOB_NO_WILD_SEPARATOR emits one extra character:
- convert_glob_parse_range writes "[^" plus the wildcard separator into the shared out_str scratch, then always emits a count of len + 1
- the no-wildcard-separator flag skips the separator store, so that count now includes a leftover byte from an earlier write into out_str
- [!a] converts to [^sa] (the "s" survives from "(?s)"), and a*[!b] to [^Cb] (from "(*COMMIT)")

Count only the units actually written. Added glob_no_wild_separator negated-class cases to test 24; they fail before the change and pass after.