### PR TITLE
pcre2test: fix off-by-one heap write in pattern expand buffer

### DIFF
--- a/src/pcre2test_inc.h
+++ b/src/pcre2test_inc.h
@@ -2289,7 +2289,7 @@ else if ((pat_patctl.control & CTL_EXPAND) != 0)
     expanding buffers always keeps buffer and pbuffer8 in step as far as their
     size goes. */
 
-    while (pt + count * length > pbuffer8 + pbuffer8_size)
+    while (pt + count * length >= pbuffer8 + pbuffer8_size)
       {
       size_t pc_offset = pc - buffer;
       size_t pp_offset = pp - buffer;

--- a/testdata/testinput8
+++ b/testdata/testinput8
@@ -186,4 +186,9 @@
 
 /\[()]{65535}/expand
 
+# This expansion fills pbuffer8 to exactly its default size, checking that the
+# growth loop leaves room for the terminating zero written after it.
+
+/\[a]{50000}/expand
+
 # End of testinput8

--- a/testdata/testoutput8-16-2
+++ b/testdata/testoutput8-16-2
@@ -1022,4 +1022,10 @@ Failed: error 114 at offset 509: missing closing parenthesis
 /\[()]{65535}/expand
 Failed: error 120 at offset 0: regular expression is too large
 
+# This expansion fills pbuffer8 to exactly its default size, checking that the
+# growth loop leaves room for the terminating zero written after it.
+
+/\[a]{50000}/expand
+Failed: error 120 at offset 0: regular expression is too large
+
 # End of testinput8

--- a/testdata/testoutput8-16-4
+++ b/testdata/testoutput8-16-4
@@ -1019,4 +1019,9 @@ Failed: error 114 at offset 509: missing closing parenthesis
 
 /\[()]{65535}/expand
 
+# This expansion fills pbuffer8 to exactly its default size, checking that the
+# growth loop leaves room for the terminating zero written after it.
+
+/\[a]{50000}/expand
+
 # End of testinput8

--- a/testdata/testoutput8-32-4
+++ b/testdata/testoutput8-32-4
@@ -1019,4 +1019,9 @@ Failed: error 114 at offset 509: missing closing parenthesis
 
 /\[()]{65535}/expand
 
+# This expansion fills pbuffer8 to exactly its default size, checking that the
+# growth loop leaves room for the terminating zero written after it.
+
+/\[a]{50000}/expand
+
 # End of testinput8

--- a/testdata/testoutput8-8-2
+++ b/testdata/testoutput8-8-2
@@ -1022,4 +1022,10 @@ Failed: error 114 at offset 509: missing closing parenthesis
 /\[()]{65535}/expand
 Failed: error 120 at offset 0: regular expression is too large
 
+# This expansion fills pbuffer8 to exactly its default size, checking that the
+# growth loop leaves room for the terminating zero written after it.
+
+/\[a]{50000}/expand
+Failed: error 120 at offset 0: regular expression is too large
+
 # End of testinput8

--- a/testdata/testoutput8-8-3
+++ b/testdata/testoutput8-8-3
@@ -1019,4 +1019,9 @@ Failed: error 114 at offset 509: missing closing parenthesis
 
 /\[()]{65535}/expand
 
+# This expansion fills pbuffer8 to exactly its default size, checking that the
+# growth loop leaves room for the terminating zero written after it.
+
+/\[a]{50000}/expand
+
 # End of testinput8

--- a/testdata/testoutput8-8-4
+++ b/testdata/testoutput8-8-4
@@ -1019,4 +1019,9 @@ Failed: error 114 at offset 509: missing closing parenthesis
 
 /\[()]{65535}/expand
 
+# This expansion fills pbuffer8 to exactly its default size, checking that the
+# growth loop leaves room for the terminating zero written after it.
+
+/\[a]{50000}/expand
+
 # End of testinput8


### PR DESCRIPTION
The expand pattern modifier can fill pbuffer8 to its exact size and then write the terminating zero one byte past the end:
- the growth loop at pcre2test_inc.h:2292 stops once count*length fits exactly, leaving no room for the trailing NUL stored just after at :2310
- `/\[a]{50000}/expand` (50000 is the default pbuffer8 size) overflows the buffer by one byte; ASAN reports a heap-buffer-overflow WRITE of size 1 in process_pattern
- the subject-side `\[...]{n}` replicator lower in the same file already reserves the byte with `>=`