### PR TITLE
Add pcre2_get_subject

### DIFF
--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -772,7 +772,9 @@ PCRE2_EXP_DECL PCRE2_SIZE *PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL PCRE2_SIZE PCRE2_CALL_CONVENTION \
   pcre2_get_startchar(pcre2_match_data *); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
-  pcre2_next_match(pcre2_match_data *, PCRE2_SIZE *, uint32_t *);
+  pcre2_next_match(pcre2_match_data *, PCRE2_SIZE *, uint32_t *); \
+PCRE2_EXP_DECL PCRE2_SPTR PCRE2_CALL_CONVENTION \
+  pcre2_get_subject(pcre2_match_data *);
 
 
 /* Convenience functions for handling matched substrings. */
@@ -937,6 +939,7 @@ pcre2_compile are called by application code. */
 #define pcre2_get_ovector_pointer             PCRE2_SUFFIX(pcre2_get_ovector_pointer_)
 #define pcre2_get_ovector_count               PCRE2_SUFFIX(pcre2_get_ovector_count_)
 #define pcre2_get_startchar                   PCRE2_SUFFIX(pcre2_get_startchar_)
+#define pcre2_get_subject                     PCRE2_SUFFIX(pcre2_get_subject_)
 #define pcre2_jit_compile                     PCRE2_SUFFIX(pcre2_jit_compile_)
 #define pcre2_jit_match                       PCRE2_SUFFIX(pcre2_jit_match_)
 #define pcre2_jit_free_unused_memory          PCRE2_SUFFIX(pcre2_jit_free_unused_memory_)

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -772,7 +772,9 @@ PCRE2_EXP_DECL PCRE2_SIZE *PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL PCRE2_SIZE PCRE2_CALL_CONVENTION \
   pcre2_get_startchar(pcre2_match_data *); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
-  pcre2_next_match(pcre2_match_data *, PCRE2_SIZE *, uint32_t *);
+  pcre2_next_match(pcre2_match_data *, PCRE2_SIZE *, uint32_t *); \
+PCRE2_EXP_DECL PCRE2_SPTR PCRE2_CALL_CONVENTION \
+  pcre2_get_subject(pcre2_match_data *);
 
 
 /* Convenience functions for handling matched substrings. */
@@ -937,6 +939,7 @@ pcre2_compile are called by application code. */
 #define pcre2_get_ovector_pointer             PCRE2_SUFFIX(pcre2_get_ovector_pointer_)
 #define pcre2_get_ovector_count               PCRE2_SUFFIX(pcre2_get_ovector_count_)
 #define pcre2_get_startchar                   PCRE2_SUFFIX(pcre2_get_startchar_)
+#define pcre2_get_subject                     PCRE2_SUFFIX(pcre2_get_subject_)
 #define pcre2_jit_compile                     PCRE2_SUFFIX(pcre2_jit_compile_)
 #define pcre2_jit_match                       PCRE2_SUFFIX(pcre2_jit_match_)
 #define pcre2_jit_free_unused_memory          PCRE2_SUFFIX(pcre2_jit_free_unused_memory_)

--- a/src/pcre2_match_data.c
+++ b/src/pcre2_match_data.c
@@ -181,4 +181,16 @@ pcre2_get_match_data_heapframes_size(pcre2_match_data *match_data)
 return match_data->heapframes_size;
 }
 
+
+
+/*************************************************
+*             Get subject                        *
+*************************************************/
+
+PCRE2_EXP_DEFN PCRE2_SPTR PCRE2_CALL_CONVENTION
+pcre2_get_subject(pcre2_match_data *match_data)
+{
+return match_data->subject;
+}
+
 /* End of pcre2_match_data.c */

--- a/src/pcre2test_inc.h
+++ b/src/pcre2test_inc.h
@@ -5996,8 +5996,14 @@ test_match_data = pcre2_match_data_create_from_pattern(test_compiled_code,
 ASSERT(test_match_data != NULL, "pcre2_match_data_create_from_pattern()");
 
 rc = pcre2_match(test_compiled_code, pattern, PCRE2_ZERO_TERMINATED, 0,
+  0, test_match_data, NULL);
+ASSERT(rc == 1, "pcre2_match()");
+ASSERT(pcre2_get_subject(test_match_data) == pattern, "pcre2_get_subject()");
+
+rc = pcre2_match(test_compiled_code, pattern, PCRE2_ZERO_TERMINATED, 0,
   PCRE2_COPY_MATCHED_SUBJECT, test_match_data, NULL);
 ASSERT(rc == 1, "pcre2_match()");
+ASSERT(memcmp(pattern, pcre2_get_subject(test_match_data), pcre2_strlen(pattern) * sizeof(PCRE2_UCHAR)) == 0, "pcre2_get_subject()");
 
 pcre2_match_data_free(test_match_data);
 test_match_data = NULL;


### PR DESCRIPTION
Add `pcre2_get_subject` to access the copied subject when `PCRE2_COPY_MATCHED_SUBJECT` is used or the original subject. Currently it is not possible to access the copied subject when `PCRE2_COPY_MATCHED_SUBJECT` is used, making the use of `pcre2_get_ovector_pointer` and `pcre2_get_ovector_count` infeasible without creating yet another copy of the original subject.

I was not exactly sure how to go about updating the documentation or whether it would be preferred to use `pcre2_get_match_data_subject`.