### PR TITLE
Fix the JIT prefix scan of negated classes at 16 and 32 bits

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -5881,7 +5881,7 @@ fast_forward_char_data *chars_end = chars + MAX_N_CHARS;
 PCRE2_SPTR cc_stack[SCAN_PREFIX_STACK_END];
 fast_forward_char_data *chars_stack[SCAN_PREFIX_STACK_END];
 sljit_u8 next_alternative_stack[SCAN_PREFIX_STACK_END];
-BOOL last, any, class, caseless;
+BOOL last, any, class, caseless, accept_above;
 int stack_ptr, step_count, repeat, len, len_save;
 sljit_u32 chr; /* Any unicode character. */
 sljit_u8 *bytes, *bytes_end, byte;
@@ -6206,6 +6206,14 @@ while (TRUE)
   if (class)
     {
     bytes = (sljit_u8*) (cc + 1);
+    /* The bitmap covers the first 256 code units. Whatever it says about 255,
+    a negated class accepts every code unit above them and a positive class
+    none, and the 8-bit library has none to accept. */
+#if PCRE2_CODE_UNIT_WIDTH != 8
+    accept_above = (*cc == OP_NCLASS);
+#else
+    accept_above = FALSE;
+#endif
     cc += 1 + 32 / sizeof(PCRE2_UCHAR);
 
     SLJIT_ASSERT(last == TRUE && repeat == 1);
@@ -6255,7 +6263,7 @@ while (TRUE)
 
     do
       {
-      if (bytes[31] & 0x80)
+      if (accept_above)
         chars->count = 255;
       else if (chars->count != 255)
         {

--- a/testdata/testinput11
+++ b/testdata/testinput11
@@ -499,6 +499,30 @@
 \= Expect no match
     \x{80000002}
 
+# A negated class accepts every code unit above 255, even when its bitmap
+# leaves out 255 itself.
+
+/[^\x00-\x40\x42-\xff]/
+    A
+    \x{100}
+\= Expect no match
+    \xff
+
+/.{2}[^\x00-\x40\x42-\xff]/
+    xyA
+    xy\x{100}
+\= Expect no match
+    xy\xff
+
+# A positive class accepts no code unit above 255, even when its bitmap
+# includes 255 itself.
+
+/[A\xff]/
+    \x{100}\xff
+    \x{100}A
+\= Expect no match
+    \x{100}\x{1ff}
+
 # --------------
 
 # End of testinput11

--- a/testdata/testoutput11-16
+++ b/testdata/testoutput11-16
@@ -876,6 +876,39 @@ Failed: error 134 at offset 15: character code point value in \x{} or \o{} is to
 \= Expect no match
     \x{80000002}
 
+# A negated class accepts every code unit above 255, even when its bitmap
+# leaves out 255 itself.
+
+/[^\x00-\x40\x42-\xff]/
+    A
+ 0: A
+    \x{100}
+ 0: \x{100}
+\= Expect no match
+    \xff
+No match
+
+/.{2}[^\x00-\x40\x42-\xff]/
+    xyA
+ 0: xyA
+    xy\x{100}
+ 0: xy\x{100}
+\= Expect no match
+    xy\xff
+No match
+
+# A positive class accepts no code unit above 255, even when its bitmap
+# includes 255 itself.
+
+/[A\xff]/
+    \x{100}\xff
+ 0: \xff
+    \x{100}A
+ 0: A
+\= Expect no match
+    \x{100}\x{1ff}
+No match
+
 # --------------
 
 # End of testinput11

--- a/testdata/testoutput11-32
+++ b/testdata/testoutput11-32
@@ -1009,6 +1009,39 @@ No match
     \x{80000002}
 No match
 
+# A negated class accepts every code unit above 255, even when its bitmap
+# leaves out 255 itself.
+
+/[^\x00-\x40\x42-\xff]/
+    A
+ 0: A
+    \x{100}
+ 0: \x{100}
+\= Expect no match
+    \xff
+No match
+
+/.{2}[^\x00-\x40\x42-\xff]/
+    xyA
+ 0: xyA
+    xy\x{100}
+ 0: xy\x{100}
+\= Expect no match
+    xy\xff
+No match
+
+# A positive class accepts no code unit above 255, even when its bitmap
+# includes 255 itself.
+
+/[A\xff]/
+    \x{100}\xff
+ 0: \xff
+    \x{100}A
+ 0: A
+\= Expect no match
+    \x{100}\x{1ff}
+No match
+
 # --------------
 
 # End of testinput11


### PR DESCRIPTION
In the 16-bit and 32-bit libraries a negated class accepts every code unit above 255, whatever its bitmap says about 255 itself. `scan_prefix()` only took the class to accept those code units when bit 255 was set, so a negated class which leaves out `\xff`, such as `[^\x00-\x40\x42-\xff]`, was taken to accept `A` alone. The JIT then fast-forwarded to the next `A` and missed a `\x{100}` before it, which the interpreter matches:

```
$ pcre2test -16 -jit
/[^\x00-\x40\x42-\xff]/
\x{100}
No match
```

This treats a negated class as accepting everything above the bitmap at those widths, as `pcre2_study()` already does when it builds the start bitmap. 10.47 is affected as well, so it may be worth a backport.

I found this while extending #941 to 16 and 32 bits, and the next revision of that PR builds on this change. The new tests in testinput11 fail under the JIT without the fix. RunTest and pcre2_jit_test pass at all three widths.
