### PR TITLE
Remove the conditional z/OS indentation in pcre2grep

### DIFF
--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -3457,14 +3457,17 @@ if (zos_type == __ZOS_PDS || zos_type == __ZOS_PDSE)
 
 /* Handle a z/OS directory using common code. */
 
-else if (zos_type == __ZOS_HFS)
- {
 #endif  /* NATIVE_ZOS */
 
 
 /* Handle directories: common code for all OS */
 
-if (isdirectory(pathname))
+if (
+#if defined NATIVE_ZOS
+    zos_type == __ZOS_HFS &&
+#endif
+    isdirectory(pathname)
+  )
   {
   if (dee_action == dee_SKIP ||
       !test_incexc(lastcomp, include_dir_patterns, exclude_dir_patterns))
@@ -3542,7 +3545,7 @@ if (isdirectory(pathname))
   }
 
 #ifdef WIN32
-if (iswild(pathname))
+else if (iswild(pathname))
   {
   char buffer[1024];
   char *nextfile;
@@ -3581,10 +3584,6 @@ if (iswild(pathname))
   closedirectory(dir);
   return rc;
   }
-#endif
-
-#if defined NATIVE_ZOS
- }
 #endif
 
 /* If the file is not a directory, check for a regular file, and if it is not,


### PR DESCRIPTION
The z/OS block in pcre2grep alters the indentation level with an ifdef, which I find ugly.

The fallthrough behaviour looks slightly incorrect too. There is a small behavioural adjustment with this.

I have also changed Windows to an "else if" in the same chain of ifs. I believe this has no effect in practice, since directories and wildcards are mutually exclusive conditions.