### PR TITLE
Give the Alpha and x86 start-bits scans one interface

### DIFF
--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -7129,16 +7129,6 @@ if (common->match_end_ptr != 0)
   SELECT(SLJIT_GREATER, STR_END, TMP1, 0, STR_END);
   }
 
-#ifdef JIT_HAS_FAST_FORWARD_START_BITS_SIMD
-if (JIT_HAS_FAST_FORWARD_START_BITS_SIMD && common->mode == PCRE2_JIT_COMPLETE
-    && fast_forward_start_bits_simd(common, start_bits))
-  {
-  if (common->match_end_ptr != 0)
-    OP1(SLJIT_MOV, STR_END, 0, RETURN_ADDR, 0);
-  return;
-  }
-#endif
-
 start = LABEL();
 
 partial_quit = CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0);

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -3484,12 +3484,18 @@ OP2(SLJIT_AND, dst, 0, dst, 0, TMP1, 0);
 }
 
 /* Scan for the first code unit whose start bit is set, eight bytes at a time.
-   Returns FALSE without emitting anything if the bitmap does not reduce to few
-   enough ranges, in which case the caller emits its own scan. */
-static BOOL fast_forward_start_bits_simd(compiler_common *common, const sljit_u8 *start_bits)
+   The bitmap describes the code unit at offset from the start of the match, and
+   STR_PTR is left pointing at that start. Returns FALSE without emitting
+   anything if the bitmap does not reduce to few enough ranges, in which case
+   the caller emits its own scan. */
+static BOOL fast_forward_start_bits_simd(compiler_common *common, const sljit_u8 *start_bits, sljit_s32 offset,
+  BOOL bit_255_above)
 {
 DEFINE_COMPILER;
 struct sljit_label *start;
+#if defined SUPPORT_UNICODE
+struct sljit_label *restart;
+#endif
 struct sljit_jump *quit;
 struct sljit_jump *no_prefetch;
 sljit_u32 low[ALPHA_START_BITS_MAX_CONSTS];
@@ -3501,6 +3507,11 @@ int count = 0;
 int consts = 0;
 int next = 5;
 int i, k;
+
+/* At 8 bits there is nothing above code unit 255 for bit 255 to stand for. */
+SLJIT_UNUSED_ARG(bit_255_above);
+
+SLJIT_ASSERT(common->mode == PCRE2_JIT_COMPLETE && offset >= 0);
 
 /* Split the bitmap into inclusive ranges, costing the constants as we go. */
 i = 0;
@@ -3535,8 +3546,7 @@ if (count == 0 || (count == 1 && low[0] == 0 && high[0] == 255))
   return FALSE;
 
 /* Assign a scratch register to each constant, then one for the accumulated
-   mask and one for the per-range mask. RETURN_ADDR is not available: the
-   caller keeps the unclamped STR_END there while match_end_ptr is set. */
+   mask and one for the per-range mask. */
 for (k = 0; k < count; k++)
   {
   low_reg[k] = 0;
@@ -3563,6 +3573,30 @@ for (k = 0; k < count; k++)
   if (high_reg[k] != 0)
     OP1(SLJIT_MOV, high_reg[k], 0, SLJIT_IMM, replicate_char_alpha((PCRE2_UCHAR)(high[k] + 1)));
   }
+
+if (common->match_end_ptr != 0)
+  {
+  OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(SLJIT_SP), common->match_end_ptr);
+  OP1(SLJIT_MOV, TMP3, 0, STR_END, 0);
+  OP2(SLJIT_ADD, TMP1, 0, TMP1, 0, SLJIT_IMM, IN_UCHARS(offset + 1));
+
+  OP2U(SLJIT_SUB | SLJIT_SET_LESS, TMP1, 0, STR_END, 0);
+  SELECT(SLJIT_LESS, STR_END, TMP1, 0, STR_END);
+  }
+
+/* At offset zero the quadword the first load reads from is known to hold at
+   least one code unit of the subject, so the load cannot cross into an
+   unmapped page and the end of the subject is checked only once a candidate is
+   found. That no longer holds once STR_PTR is moved forward. */
+if (offset > 0)
+  {
+  OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(offset));
+  add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+  }
+
+#if defined SUPPORT_UNICODE
+restart = LABEL();
+#endif
 
 /* Align STR_PTR down to an 8-byte boundary; keep the misalignment in TMP2. */
 OP1(SLJIT_MOV, TMP2, 0, STR_PTR, 0);
@@ -3609,20 +3643,35 @@ CMPTO(SLJIT_ZERO, acc, 0, SLJIT_IMM, 0, start);
 JUMPHERE(quit);
 
 /* Both paths arrive with the mask in acc and STR_PTR at the byte that bit 0
-   of the mask describes. The constants are dead from here on, so R5 is free to
-   borrow: emit_alpha_ctz8() clobbers RETURN_ADDR, which is where the caller
-   keeps the unclamped STR_END while match_end_ptr is set. */
-if (common->match_end_ptr != 0)
-  OP1(SLJIT_MOV, SLJIT_R5, 0, RETURN_ADDR, 0);
-
+   of the mask describes. */
 OP1(SLJIT_MOV, TMP1, 0, acc, 0);
 emit_alpha_ctz8(compiler);
 OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, TMP1, 0);
 
-if (common->match_end_ptr != 0)
-  OP1(SLJIT_MOV, RETURN_ADDR, 0, SLJIT_R5, 0);
-
 add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
+
+#if defined SUPPORT_UNICODE
+if (common->utf && offset > 0)
+  {
+  OP1(MOV_UCHAR, TMP1, 0, SLJIT_MEM1(STR_PTR), IN_UCHARS(-offset));
+
+  quit = jump_if_utf_char_start(compiler, TMP1);
+
+  OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(1));
+  CMPTO(SLJIT_LESS, STR_PTR, 0, STR_END, 0, restart);
+
+  add_jump(compiler, &common->failed_match, JUMP(SLJIT_JUMP));
+
+  JUMPHERE(quit);
+  }
+#endif
+
+if (offset > 0)
+  OP2(SLJIT_SUB, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(offset));
+
+if (common->match_end_ptr != 0)
+  OP1(SLJIT_MOV, STR_END, 0, TMP3, 0);
+
 return TRUE;
 }
 


### PR DESCRIPTION
Fixes the x86 build failure reported in https://github.com/PCRE2Project/pcre2/pull/941#issuecomment-5647107448.

#921 and #941 each added a `fast_forward_start_bits_simd()` behind `JIT_HAS_FAST_FORWARD_START_BITS_SIMD`, with a signature and a call site of its own: two arguments for the Alpha CMPBGE scan, four for the x86-64 vector scan. The two never touched the same lines, so git merged both cleanly and CI did not re-run either once the other had landed. With both in, `fast_forward_start_bits()` holds two call sites and the Alpha one passes two arguments to the function x86-64 declares with four:

```
pcre2_jit_compile.c:7134:8: error: too few arguments to function 'fast_forward_start_bits_simd'; expected 4, have 2
```

This keeps the x86-64 interface, the more capable of the two. The Alpha scan takes the offset of the bitmap within the match and the flag for whether bit 255 stands for the code units above it, clamps STR_END against `match_end_ptr` itself instead of leaving that to the caller, and restarts on a candidate that is not a UTF character boundary. Its second call site then has nothing left to do, and the borrow of R5 to preserve RETURN_ADDR across `emit_alpha_ctz8()` goes away with it.

Testing:

- x86-64: `pcre2_jit_test` and `RunTest` pass at all three code unit widths.
- Alpha under qemu: same, with and without JIT.
- A differential run of ~1500 generated character class patterns, JIT against the interpreter, at both offset zero and an offset, covering `firstline` and `use_offset_limit` (the two options that set `match_end_ptr`): identical output on both architectures.
- Built clean with `-Wall -Wextra` for both architectures, with JIT on and off.

One thing I left alone, since it wants a measurement rather than a guess: the x86-64 scan declines a class covering more than `X86_START_BITS_MAX_COVERED` code units, on the grounds that a dense class usually stops the loop at once while the scan has already tested a whole block. The Alpha scan has no equivalent cap, only its three constant budget, so now that it reaches the offset call site it vectorizes classes x86-64 turns down, `.{3}[a-zA-Z]` among them. The argument for a cap is weaker at eight bytes than at sixteen, but it is not absent. I would rather add `ALPHA_START_BITS_MAX_COVERED` once I have numbers from real hardware than pick a threshold here.