### PR TITLE
Check for the subject end before the first start-bits load

### DIFF
--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -589,15 +589,12 @@ if (common->match_end_ptr != 0)
   SELECT(SLJIT_LESS, STR_END, TMP1, 0, STR_END);
   }
 
-/* At offset zero the block the first load reads from is known to hold at least
-   one code unit of the subject, so the load cannot cross into an unmapped page
-   and the end of the subject is checked only once a candidate is found. That no
-   longer holds once STR_PTR is moved forward. */
 if (offset > 0)
-  {
   OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(offset));
-  add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
-  }
+
+/* STR_PTR may equal STR_END, and the block the first load reads could then be
+   in an unmapped page. */
+add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
 
 /* Load the constants of every range, two registers apiece from VR3 upwards,
    of which a single character needs only the first. */

--- a/src/pcre2_jit_simd_inc.h
+++ b/src/pcre2_jit_simd_inc.h
@@ -3584,15 +3584,12 @@ if (common->match_end_ptr != 0)
   SELECT(SLJIT_LESS, STR_END, TMP1, 0, STR_END);
   }
 
-/* At offset zero the quadword the first load reads from is known to hold at
-   least one code unit of the subject, so the load cannot cross into an
-   unmapped page and the end of the subject is checked only once a candidate is
-   found. That no longer holds once STR_PTR is moved forward. */
 if (offset > 0)
-  {
   OP2(SLJIT_ADD, STR_PTR, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(offset));
-  add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
-  }
+
+/* STR_PTR may equal STR_END, and the quadword the first load reads could then
+   be in an unmapped page. */
+add_jump(compiler, &common->failed_match, CMP(SLJIT_GREATER_EQUAL, STR_PTR, 0, STR_END, 0));
 
 #if defined SUPPORT_UNICODE
 restart = LABEL();


### PR DESCRIPTION
The Alpha and x86-64 start-bits scans checked STR_PTR against STR_END before
their first load only when the offset was nonzero. mainloop_entry() can
advance STR_PTR to STR_END before calling the scan, and if STR_END is on a
page boundary the aligned load then reads the next page. Check the end of the
subject unconditionally.

Tested on Alpha under qemu-alpha with the subject placed right before an
unmapped page: patterns such as `[a-c](?=\d)` against `zzzzzzza` fault
without the fix and return no match with it. `pcre2_jit_test` and `RunTest`
pass on Alpha, and ctest passes on x86-64.

Fixes #984
