### PR TITLE
Partially revert a Windows behavioural change in pcre2grep

### DIFF
--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -3549,7 +3549,7 @@ if (
   }
 
 #ifdef WIN32
-else if (iswild(pathname))
+if (iswild(pathname))
   {
   char buffer[1024];
   char *nextfile;


### PR DESCRIPTION
In 1876ea1c431295187231ed128622c19d2f8c7e31, I made what I thought was a conservative tidy-up.

Unfortunately, it broke one of the MinGW builds (the ordinary Windows builds that I tested were fine). I will need to investigate in future - but for now, I am simply reverting.